### PR TITLE
Sylvaneth units added

### DIFF
--- a/Order_-_9thBRB_Warscrolls.cat
+++ b/Order_-_9thBRB_Warscrolls.cat
@@ -1,89 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="1e0b-c068-a46a-8a22" revision="1" gameSystemId="13ba-994f-8c12-9f8d" gameSystemRevision="1" battleScribeVersion="1.15" name="Order - 9thBRB_Warscrolls" books="Wood Elves Warscroll, High Elves Warscroll, Dark Elves Warscroll, ..." authorName="Markus W. (taalas)" authorContact="" authorUrl="https://github.com/taalas" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="1e0b-c068-a46a-8a22" revision="2" gameSystemId="13ba-994f-8c12-9f8d" gameSystemRevision="1" battleScribeVersion="1.15" name="Order - 9thBRB_Warscrolls" books="Wood Elves Warscroll, High Elves Warscroll, Dark Elves Warscroll, ..." authorName="Markus W. (taalas)" authorContact="" authorUrl="https://github.com/taalas" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
-    <entry id="aa9f-52dc-e2ae-dc9e" name="Branchwraith" points="0.0" categoryId="bee2-43e8-42c4-b182" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="WEW" page="16">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="4fd2-4ea9-ad9e-20b7" profileTypeId="d42a-7ddd-953b-4d23" name="Branchwraith" hidden="false" book="WEW" page="16">
-          <characteristics>
-            <characteristic characteristicId="0ae7-a2b1-6b97-8f4d" name="Move" value="7&quot;"/>
-            <characteristic characteristicId="0054-981e-bc82-2ce2" name="Wounds" value="5"/>
-            <characteristic characteristicId="d875-64d5-4fad-c5c3" name="Save" value="5+"/>
-            <characteristic characteristicId="2b7b-be5f-5b04-1ec4" name="Bravery" value="8"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="154c-f246-beea-8a55" targetId="2b65-c372-dd60-53b0" linkType="profile">
-          <modifiers/>
-        </link>
-        <link id="f46e-93c1-313a-0134" targetId="a910-e80d-3729-4571" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="fda6-5455-9f86-809c" targetId="de4c-1699-27f5-7a68" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="e8c8-002d-6fe2-e7da" targetId="fe31-9297-be2c-966c" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="009b-13ea-a95e-c518" targetId="3a6c-677d-79f6-0651" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="0ad4-ebb5-2ef2-41a5" name="Dryads" points="0.0" categoryId="bee2-43e8-42c4-b182" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="WEW" page="16">
-      <entries>
-        <entry id="361d-f7f1-7cf5-29b6" name="Dryad" points="0.0" categoryId="(No Category)" type="unit" minSelections="5" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="WEW" page="16">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="bbf5-8ffe-ff23-52ed" profileTypeId="d42a-7ddd-953b-4d23" name="Dryad" hidden="false" book="WEW" page="16">
-              <characteristics>
-                <characteristic characteristicId="0ae7-a2b1-6b97-8f4d" name="Move" value="7&quot;"/>
-                <characteristic characteristicId="0054-981e-bc82-2ce2" name="Wounds" value="1"/>
-                <characteristic characteristicId="d875-64d5-4fad-c5c3" name="Save" value="5+"/>
-                <characteristic characteristicId="2b7b-be5f-5b04-1ec4" name="Bravery" value="6"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="0743-cd0a-3ed3-4829" targetId="48df-3711-d76e-4f01" linkType="profile">
-          <modifiers/>
-        </link>
-        <link id="0fcb-2559-be3c-4a10" targetId="de4c-1699-27f5-7a68" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="6e0c-9f70-d40d-6f21" targetId="2dda-973a-252b-c079" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="e58b-29a7-8b30-b64e" targetId="c02e-c8e6-3c34-188e" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="4cad-0ec6-4396-7275" targetId="158e-2f95-0739-010b" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="3dc1-83f2-d330-1e0f" targetId="f7a8-1d48-717f-8ee4" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="a28e-36e5-a049-5387" targetId="d850-57ce-2223-b4c7" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
     <entry id="81a3-f3fd-4858-f721" name="Eternal Guard" points="0.0" categoryId="bee2-43e8-42c4-b182" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="WEW" page="13">
       <entries>
         <entry id="6bf6-502b-4f92-0ce1" name="Eternal Guard" points="0.0" categoryId="(No Category)" type="model" minSelections="10" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="WEW" page="13">
@@ -421,6 +338,71 @@
         </link>
       </links>
     </entry>
+    <entry id="8017-8554-c260-020e" name="Tree Kin" points="0.0" categoryId="bee2-43e8-42c4-b182" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="WEW" page="17">
+      <entries>
+        <entry id="5310-8701-c4b1-62f0" name="Tree Kin" points="0.0" categoryId="(No Category)" type="model" minSelections="3" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="WEW" page="17">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="517b-ac59-3f81-c988" profileTypeId="d42a-7ddd-953b-4d23" name="Tree Kin" hidden="false" book="WEW" page="17">
+              <characteristics>
+                <characteristic characteristicId="0ae7-a2b1-6b97-8f4d" name="Move" value="6&quot;"/>
+                <characteristic characteristicId="0054-981e-bc82-2ce2" name="Wounds" value="4"/>
+                <characteristic characteristicId="d875-64d5-4fad-c5c3" name="Save" value="4+"/>
+                <characteristic characteristicId="2b7b-be5f-5b04-1ec4" name="Bravery" value="6"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+      </entries>
+      <entryGroups>
+        <entryGroup id="7c17-40a0-7bd3-60bf" name="Spell references" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="b640-00ec-5d7a-6e92" name="Regrowth" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="1c10-edab-e534-9ffa" targetId="5cde-ccd6-efeb-8537" linkType="rule">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules>
+        <rule id="766c-ee4c-73a7-9f76" name="Tree Kin Spells" hidden="false" book="WEW" page="17">
+          <description>Sylvaneth Wizards know the Regrowth spell in addition to any other spell they know whilst there are any Tree Kin on the battlefield.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links>
+        <link id="e663-38b9-268a-1420" targetId="5ea1-8555-1861-19aa" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="cb1b-2d65-a1ef-2f55" targetId="158e-2f95-0739-010b" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="9aa0-ffc3-aedc-98f4" targetId="f7a8-1d48-717f-8ee4" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="7e82-8782-0ca8-9c90" targetId="4df9-e8bf-9fb0-5cad" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
     <entry id="a3cb-73f3-3a5d-2f70" name="Warhawk Riders" points="0.0" categoryId="bee2-43e8-42c4-b182" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="WEW" page="14">
       <entries>
         <entry id="49c2-1e2b-0aec-2e9f" name="Warhawk Rider" points="0.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="WEW" page="14">
@@ -572,71 +554,6 @@
         </link>
       </links>
     </entry>
-    <entry id="8017-8554-c260-020e" name="Tree Kin" points="0.0" categoryId="bee2-43e8-42c4-b182" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="WEW" page="17">
-      <entries>
-        <entry id="5310-8701-c4b1-62f0" name="Tree Kin" points="0.0" categoryId="(No Category)" type="model" minSelections="3" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="WEW" page="17">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="517b-ac59-3f81-c988" profileTypeId="d42a-7ddd-953b-4d23" name="Tree Kin" hidden="false" book="WEW" page="17">
-              <characteristics>
-                <characteristic characteristicId="0ae7-a2b1-6b97-8f4d" name="Move" value="6&quot;"/>
-                <characteristic characteristicId="0054-981e-bc82-2ce2" name="Wounds" value="4"/>
-                <characteristic characteristicId="d875-64d5-4fad-c5c3" name="Save" value="4+"/>
-                <characteristic characteristicId="2b7b-be5f-5b04-1ec4" name="Bravery" value="6"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="7c17-40a0-7bd3-60bf" name="Spell references" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="b640-00ec-5d7a-6e92" name="Regrowth" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="1c10-edab-e534-9ffa" targetId="5cde-ccd6-efeb-8537" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links/>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules>
-        <rule id="766c-ee4c-73a7-9f76" name="Tree Kin Spells" hidden="false" book="WEW" page="17">
-          <description>Sylvaneth Wizards know the Regrowth spell in addition to any other spell they know whilst there are any Tree Kin on the battlefield.</description>
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links>
-        <link id="e663-38b9-268a-1420" targetId="5ea1-8555-1861-19aa" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="cb1b-2d65-a1ef-2f55" targetId="158e-2f95-0739-010b" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="9aa0-ffc3-aedc-98f4" targetId="f7a8-1d48-717f-8ee4" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="7e82-8782-0ca8-9c90" targetId="4df9-e8bf-9fb0-5cad" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
   </entries>
   <rules/>
   <links/>
@@ -649,6 +566,10 @@
     </rule>
     <rule id="1d1e-c4ce-3f80-b302" name="(Ability) Death from the Skies" hidden="false" book="WEW" page="15">
       <description>Makes 6 attacks rather than 4 if charged this turn.</description>
+      <modifiers/>
+    </rule>
+    <rule id="2dda-973a-252b-c079" name="(Ability) Enrapturing Song" hidden="false" book="WEW" page="16">
+      <description>In your own combat phase, you can enrapture one enemy unit that is within 3&quot; of this unit. Add 1 to the hit rolls for attacks made by this unit against the enraptured unit in that combat phase.</description>
       <modifiers/>
     </rule>
     <rule id="42cf-2dd1-7eb8-933e" name="(Ability) Fire on the Move" hidden="false" book="WEW" page="13">
@@ -667,8 +588,16 @@
       <description>Hand weapon inflicts D3 Damage on Monsters instead of 1.</description>
       <modifiers/>
     </rule>
+    <rule id="c02e-c8e6-3c34-188e" name="(Ability) Impenetrable Thicket" hidden="false" book="WEW" page="16">
+      <description>You can add 1 to the result of save rolls for this unit if it includes at least 12 models.</description>
+      <modifiers/>
+    </rule>
     <rule id="a101-cc3e-a4bf-1277" name="(Ability) Predator&apos;s Descent" hidden="false" book="WEW" page="14">
       <description>Add 1 to all wound rolls if unit charged this turn.</description>
+      <modifiers/>
+    </rule>
+    <rule id="5ea1-8555-1861-19aa" name="(Ability) Roused to War" hidden="false" book="WEW" page="17">
+      <description>You can re-roll hit rolls of 1 if this unit is within 18&quot; of a Sylvaneth Hero.</description>
       <modifiers/>
     </rule>
     <rule id="af40-a6b2-5955-67b9" name="(Ability) Soar Away" hidden="false" book="WEW" page="15">
@@ -686,6 +615,9 @@
     <rule id="e928-a366-0050-4451" name="(Keyword) Aelf" hidden="false">
       <modifiers/>
     </rule>
+    <rule id="d850-57ce-2223-b4c7" name="(Keyword) Dryads" hidden="false">
+      <modifiers/>
+    </rule>
     <rule id="49f5-37e5-3f3a-c292" name="(Keyword) Eternal Guard" hidden="false">
       <modifiers/>
     </rule>
@@ -699,6 +631,12 @@
       <modifiers/>
     </rule>
     <rule id="0d29-82f7-f90a-fad6" name="(Keyword) Sisters of the Thorn" hidden="false">
+      <modifiers/>
+    </rule>
+    <rule id="f7a8-1d48-717f-8ee4" name="(Keyword) Sylvaneth" hidden="false">
+      <modifiers/>
+    </rule>
+    <rule id="4df9-e8bf-9fb0-5cad" name="(Keyword) Tree Kin" hidden="false">
       <modifiers/>
     </rule>
     <rule id="ec02-d50f-468a-c7a8" name="(Keyword) Wanderer" hidden="false">
@@ -717,6 +655,10 @@
       <modifiers/>
     </rule>
     <rule id="3a6c-677d-79f6-0651" name="(Spell) Mystic Shield" hidden="false">
+      <modifiers/>
+    </rule>
+    <rule id="5cde-ccd6-efeb-8537" name="(Spell) Regrowth" hidden="false" book="WEW" page="17">
+      <description>Regrowth has a casting value of 5. If successfully cast, select a Tree Kin model within 18&quot;. That model heals D3 wounds.</description>
       <modifiers/>
     </rule>
     <rule id="a910-e80d-3729-4571" name="(Spell) Roused to Wrath" hidden="false" book="WEW" page="16">
@@ -741,31 +683,6 @@
     </rule>
     <rule id="8b02-d645-1278-82fd" name="Standard Bearer" hidden="false">
       <description>Add 1 to the Bravery of this unit. Add 2 if unit is in cover.</description>
-      <modifiers/>
-    </rule>
-    <rule id="2dda-973a-252b-c079" name="(Ability) Enrapturing Song" hidden="false" book="WEW" page="16">
-      <description>In your own combat phase, you can enrapture one enemy unit that is within 3&quot; of this unit. Add 1 to the hit rolls for attacks made by this unit against the enraptured unit in that combat phase.</description>
-      <modifiers/>
-    </rule>
-    <rule id="c02e-c8e6-3c34-188e" name="(Ability) Impenetrable Thicket" hidden="false" book="WEW" page="16">
-      <description>You can add 1 to the result of save rolls for this unit if it includes at least 12 models.</description>
-      <modifiers/>
-    </rule>
-    <rule id="f7a8-1d48-717f-8ee4" name="(Keyword) Sylvaneth" hidden="false">
-      <modifiers/>
-    </rule>
-    <rule id="d850-57ce-2223-b4c7" name="(Keyword) Dryads" hidden="false">
-      <modifiers/>
-    </rule>
-    <rule id="5ea1-8555-1861-19aa" name="(Ability) Roused to War" hidden="false" book="WEW" page="17">
-      <description>You can re-roll hit rolls of 1 if this unit is within 18&quot; of a Sylvaneth Hero.</description>
-      <modifiers/>
-    </rule>
-    <rule id="5cde-ccd6-efeb-8537" name="(Spell) Regrowth" hidden="false" book="WEW" page="17">
-      <description>Regrowth has a casting value of 5. If successfully cast, select a Tree Kin model within 18&quot;. That model heals D3 wounds.</description>
-      <modifiers/>
-    </rule>
-    <rule id="4df9-e8bf-9fb0-5cad" name="(Keyword) Tree Kin" hidden="false">
       <modifiers/>
     </rule>
   </sharedRules>

--- a/Order_-_9thBRB_Warscrolls.cat
+++ b/Order_-_9thBRB_Warscrolls.cat
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="1e0b-c068-a46a-8a22" revision="3" gameSystemId="13ba-994f-8c12-9f8d" gameSystemRevision="1" battleScribeVersion="1.15" name="Order - 9thBRB_Warscrolls" books="Wood Elves Warscroll, High Elves Warscroll, Dark Elves Warscroll, ..." authorName="Markus W. (taalas)" authorContact="" authorUrl="https://github.com/taalas" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="1e0b-c068-a46a-8a22" revision="1" gameSystemId="13ba-994f-8c12-9f8d" gameSystemRevision="1" battleScribeVersion="1.15" name="Order - 9thBRB_Warscrolls" books="Wood Elves Warscroll, High Elves Warscroll, Dark Elves Warscroll, ..." authorName="Markus W. (taalas)" authorContact="" authorUrl="https://github.com/taalas" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
-    <entry id="aa9f-52dc-e2ae-dc9e" name="Branchwraith" points="0.0" categoryId="c96d-1643-ed56-ba60" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="WEW" page="16">
+    <entry id="aa9f-52dc-e2ae-dc9e" name="Branchwraith" points="0.0" categoryId="bee2-43e8-42c4-b182" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="WEW" page="16">
       <entries/>
       <entryGroups/>
       <modifiers/>
@@ -35,7 +35,7 @@
         </link>
       </links>
     </entry>
-    <entry id="0ad4-ebb5-2ef2-41a5" name="Dryads" points="0.0" categoryId="c96d-1643-ed56-ba60" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="WEW" page="16">
+    <entry id="0ad4-ebb5-2ef2-41a5" name="Dryads" points="0.0" categoryId="bee2-43e8-42c4-b182" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="WEW" page="16">
       <entries>
         <entry id="361d-f7f1-7cf5-29b6" name="Dryad" points="0.0" categoryId="(No Category)" type="unit" minSelections="5" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="WEW" page="16">
           <entries/>
@@ -80,83 +80,6 @@
           <modifiers/>
         </link>
         <link id="a28e-36e5-a049-5387" targetId="d850-57ce-2223-b4c7" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="fd79-07a5-fb75-c79a" name="Durthu" points="0.0" categoryId="c96d-1643-ed56-ba60" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules>
-        <rule id="e701-6feb-2bca-c053" name="(Ability) Elder Wrath Sword" hidden="false">
-          <description>Durthu makes an extra D3 attacks with the Elder Wrath Sword if he is within 3&quot; of a Sylvaneth Wyldwood when he attacks in the combat phase.</description>
-          <modifiers/>
-        </rule>
-        <rule id="b90a-139c-ac8e-41bb" name="(Table) Durthu Damage Table" hidden="false">
-          <description>&lt;table&gt;
-&lt;tr&gt;&lt;th colspan=4&gt;DAMAGE TABLE&lt;/th&gt;&lt;/tr&gt;
-&lt;tr&gt;&lt;th&gt;Wounds Suffered&lt;/th&gt;&lt;th&gt;Lamentations of Despair&lt;/th&gt;&lt;th&gt;Eldar Wrath Sword&lt;/th&gt;&lt;th&gt;Massive Impaling Talons&lt;/th&gt;&lt;/tr&gt;
-&lt;tr&gt;&lt;th&gt;0-2&lt;/th&gt;&lt;td&gt;12&lt;/td&gt;&lt;td&gt;6&lt;/td&gt;&lt;td&gt;2+&lt;/td&gt;&lt;/tr&gt;
-&lt;tr&gt;&lt;th&gt;3-4&lt;/th&gt;&lt;td&gt;10&lt;/td&gt;&lt;td&gt;D6&lt;/td&gt;&lt;td&gt;2+&lt;/td&gt;&lt;/tr&gt;
-&lt;tr&gt;&lt;th&gt;5-7&lt;/th&gt;&lt;td&gt;8&lt;/td&gt;&lt;td&gt;D6&lt;/td&gt;&lt;td&gt;3+&lt;/td&gt;&lt;/tr&gt;
-&lt;tr&gt;&lt;th&gt;8-9&lt;/th&gt;&lt;td&gt;6&lt;/td&gt;&lt;td&gt;D6&lt;/td&gt;&lt;td&gt;3+&lt;/td&gt;&lt;/tr&gt;
-&lt;tr&gt;&lt;th&gt;10+&lt;/th&gt;&lt;td&gt;4&lt;/td&gt;&lt;td&gt;D3&lt;/td&gt;&lt;td&gt;4+&lt;/td&gt;&lt;/tr&gt;
-&lt;/table&gt;</description>
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles>
-        <profile id="49b3-bb11-f120-29a7" profileTypeId="d42a-7ddd-953b-4d23" name="Durthu" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="0ae7-a2b1-6b97-8f4d" name="Move" value="5&quot;"/>
-            <characteristic characteristicId="0054-981e-bc82-2ce2" name="Wounds" value="12"/>
-            <characteristic characteristicId="d875-64d5-4fad-c5c3" name="Save" value="3+"/>
-            <characteristic characteristicId="2b7b-be5f-5b04-1ec4" name="Bravery" value="9"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-        <profile id="7209-d867-d427-d11d" profileTypeId="69e7-9460-0985-44b0" name="Lamentations of Despair" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="420c-6e7d-0b96-4289" name="Range" value="10&quot;"/>
-            <characteristic characteristicId="229e-c54a-7785-0e0f" name="Attacks" value="*"/>
-            <characteristic characteristicId="bdcd-ebcf-f909-49d9" name="To Hit" value="3+"/>
-            <characteristic characteristicId="0088-422c-55f2-2361" name="To Wound" value="5+"/>
-            <characteristic characteristicId="1b60-6be0-3cd0-df54" name="Rend" value="-"/>
-            <characteristic characteristicId="dace-95f3-a99b-89b6" name="Damage" value="1"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="fd56-a117-4363-01eb" targetId="d837-dc4c-72f3-7185" linkType="profile">
-          <modifiers/>
-        </link>
-        <link id="50cb-8f73-4860-20c5" targetId="3e7a-ae02-747e-b6ab" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="553a-d6bd-2424-6800" targetId="76f9-3a16-ecbe-3671" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="d7b2-f868-76ad-d8ce" targetId="b487-bb62-707f-cc51" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="74e6-5bf2-ad68-34b4" targetId="271b-f3a7-5650-dad2" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="7083-41c8-22b0-9b1e" targetId="3faf-938a-c642-8397" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="d5f0-d691-23d3-ecb8" targetId="877a-71fe-45fc-50cc" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="2a68-4702-754a-98c2" targetId="158e-2f95-0739-010b" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="6607-74aa-1b7a-671a" targetId="f7a8-1d48-717f-8ee4" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="bc89-637e-435d-a0c7" targetId="f2e8-bf72-d131-8cc2" linkType="profile">
           <modifiers/>
         </link>
       </links>
@@ -498,218 +421,6 @@
         </link>
       </links>
     </entry>
-    <entry id="863b-dc9e-8de4-841a" name="Sylvaneth Treelord" points="0.0" categoryId="c96d-1643-ed56-ba60" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules>
-        <rule id="9247-9e43-c002-858a" name="(Table) Treelord Damage Table" hidden="false">
-          <description>&lt;table&gt;
-&lt;tr&gt;&lt;th colspan=4&gt;DAMAGE TABLE&lt;/th&gt;&lt;/tr&gt;
-&lt;tr&gt;&lt;th&gt;Wounds Suffered&lt;/th&gt;&lt;th&gt;Strangleroots&lt;/th&gt;&lt;th&gt;Sweeping Blows&lt;/th&gt;&lt;th&gt;Massive Impaling Talons&lt;/th&gt;&lt;/tr&gt;
-&lt;tr&gt;&lt;th&gt;0-2&lt;/th&gt;&lt;td&gt;2+&lt;/td&gt;&lt;td&gt;3&lt;/td&gt;&lt;td&gt;2+&lt;/td&gt;&lt;/tr&gt;
-&lt;tr&gt;&lt;th&gt;3-4&lt;/th&gt;&lt;td&gt;3+&lt;/td&gt;&lt;td&gt;2&lt;/td&gt;&lt;td&gt;2+&lt;/td&gt;&lt;/tr&gt;
-&lt;tr&gt;&lt;th&gt;5-7&lt;/th&gt;&lt;td&gt;4+&lt;/td&gt;&lt;td&gt;2&lt;/td&gt;&lt;td&gt;3+&lt;/td&gt;&lt;/tr&gt;
-&lt;tr&gt;&lt;th&gt;8-9&lt;/th&gt;&lt;td&gt;5+&lt;/td&gt;&lt;td&gt;1&lt;/td&gt;&lt;td&gt;3+&lt;/td&gt;&lt;/tr&gt;
-&lt;tr&gt;&lt;th&gt;10+&lt;/th&gt;&lt;td&gt;6+&lt;/td&gt;&lt;td&gt;1&lt;/td&gt;&lt;td&gt;4+&lt;/td&gt;&lt;/tr&gt;
-&lt;/table&gt;</description>
-          <modifiers/>
-        </rule>
-        <rule id="e5e0-179a-fb36-13a1" name="(Keyword) Treelord" hidden="false">
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles>
-        <profile id="3972-00ed-7722-1326" profileTypeId="69e7-9460-0985-44b0" name="Strangleroots" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="420c-6e7d-0b96-4289" name="Range" value="12&quot;"/>
-            <characteristic characteristicId="229e-c54a-7785-0e0f" name="Attacks" value="5"/>
-            <characteristic characteristicId="bdcd-ebcf-f909-49d9" name="To Hit" value="*"/>
-            <characteristic characteristicId="0088-422c-55f2-2361" name="To Wound" value="3+"/>
-            <characteristic characteristicId="1b60-6be0-3cd0-df54" name="Rend" value="-1"/>
-            <characteristic characteristicId="dace-95f3-a99b-89b6" name="Damage" value="1"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-        <profile id="4cc1-8110-7229-983e" profileTypeId="d42a-7ddd-953b-4d23" name="Sylvaneth Treelord" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="0ae7-a2b1-6b97-8f4d" name="Move" value="6&quot;"/>
-            <characteristic characteristicId="0054-981e-bc82-2ce2" name="Wounds" value="12"/>
-            <characteristic characteristicId="d875-64d5-4fad-c5c3" name="Save" value="3+"/>
-            <characteristic characteristicId="2b7b-be5f-5b04-1ec4" name="Bravery" value="6"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="e944-9668-4042-ad95" targetId="3e7a-ae02-747e-b6ab" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="a8e9-75f9-2051-d027" targetId="76f9-3a16-ecbe-3671" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="00e6-b4d5-5b1d-780b" targetId="b487-bb62-707f-cc51" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="12fd-2dbc-5a57-5c4c" targetId="877a-71fe-45fc-50cc" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="58ef-e133-ec91-ac51" targetId="158e-2f95-0739-010b" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="57e8-ac1b-0aac-5e36" targetId="f7a8-1d48-717f-8ee4" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="4e52-8534-ce5d-9b27" targetId="f2e8-bf72-d131-8cc2" linkType="profile">
-          <modifiers/>
-        </link>
-        <link id="1c11-ddeb-1f6e-3e46" targetId="a65f-a441-aa32-73d9" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="db3b-2809-7184-1744" name="Sylvaneth Treelord Ancient" points="0.0" categoryId="c96d-1643-ed56-ba60" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules>
-        <rule id="3d6c-48d2-509a-e9a9" name="(Table) Treelord Ancient Damage Table" hidden="false">
-          <description>&lt;table&gt;
-&lt;tr&gt;&lt;th colspan=4&gt;DAMAGE TABLE&lt;/th&gt;&lt;/tr&gt;
-&lt;tr&gt;&lt;th&gt;Wounds Suffered&lt;/th&gt;&lt;th&gt;Doom Tendril Staff&lt;/th&gt;&lt;th&gt;Sweeping Blows&lt;/th&gt;&lt;th&gt;Massive Impaling Talons&lt;/th&gt;&lt;/tr&gt;
-&lt;tr&gt;&lt;th&gt;0-2&lt;/th&gt;&lt;td&gt;2+&lt;/td&gt;&lt;td&gt;3&lt;/td&gt;&lt;td&gt;2+&lt;/td&gt;&lt;/tr&gt;
-&lt;tr&gt;&lt;th&gt;3-4&lt;/th&gt;&lt;td&gt;3+&lt;/td&gt;&lt;td&gt;2&lt;/td&gt;&lt;td&gt;2+&lt;/td&gt;&lt;/tr&gt;
-&lt;tr&gt;&lt;th&gt;5-7&lt;/th&gt;&lt;td&gt;4+&lt;/td&gt;&lt;td&gt;2&lt;/td&gt;&lt;td&gt;3+&lt;/td&gt;&lt;/tr&gt;
-&lt;tr&gt;&lt;th&gt;8-9&lt;/th&gt;&lt;td&gt;5+&lt;/td&gt;&lt;td&gt;1&lt;/td&gt;&lt;td&gt;3+&lt;/td&gt;&lt;/tr&gt;
-&lt;tr&gt;&lt;th&gt;10+&lt;/th&gt;&lt;td&gt;6+&lt;/td&gt;&lt;td&gt;1&lt;/td&gt;&lt;td&gt;4+&lt;/td&gt;&lt;/tr&gt;
-&lt;/table&gt;</description>
-          <modifiers/>
-        </rule>
-        <rule id="3fa8-e741-e7c5-cc05" name="(Spell) Awakening the Wood" hidden="false">
-          <description>Awakening the Wood has a casting value of 6. If successfully cast, pick a Sylvaneth Wyldwood that is within 24&quot; of the caster. Each enemy unit within 3&quot; of this Sylvaneth Wyldwood suffers D3 mortal wounds the trees come to life and attack with twisted branches and thorny boughs.</description>
-          <modifiers/>
-        </rule>
-        <rule id="50e9-f167-36ef-ea67" name="(Keyword) Treelord Ancient" hidden="false">
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles>
-        <profile id="99ad-ab02-69f5-a779" profileTypeId="69e7-9460-0985-44b0" name="Doom Tendril Staff" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="420c-6e7d-0b96-4289" name="Range" value="18&quot;"/>
-            <characteristic characteristicId="229e-c54a-7785-0e0f" name="Attacks" value="1"/>
-            <characteristic characteristicId="bdcd-ebcf-f909-49d9" name="To Hit" value="*"/>
-            <characteristic characteristicId="0088-422c-55f2-2361" name="To Wound" value="3+"/>
-            <characteristic characteristicId="1b60-6be0-3cd0-df54" name="Rend" value="-1"/>
-            <characteristic characteristicId="dace-95f3-a99b-89b6" name="Damage" value="D6"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-        <profile id="6145-36a4-d07f-695b" profileTypeId="d42a-7ddd-953b-4d23" name="Sylvaneth Treelord Ancient" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="0ae7-a2b1-6b97-8f4d" name="Move" value="5&quot;"/>
-            <characteristic characteristicId="0054-981e-bc82-2ce2" name="Wounds" value="12"/>
-            <characteristic characteristicId="d875-64d5-4fad-c5c3" name="Save" value="3+"/>
-            <characteristic characteristicId="2b7b-be5f-5b04-1ec4" name="Bravery" value="9"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="16ae-3bc0-968a-c3d1" targetId="3e7a-ae02-747e-b6ab" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="1e32-a3e2-aa35-70b5" targetId="76f9-3a16-ecbe-3671" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="11f3-df54-74b8-fbf5" targetId="b487-bb62-707f-cc51" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="e5b4-cbb5-ad4c-4dfa" targetId="877a-71fe-45fc-50cc" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="83ae-9327-2451-7208" targetId="158e-2f95-0739-010b" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="d0b3-730f-120c-0dbc" targetId="f7a8-1d48-717f-8ee4" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="0ea6-3978-4a15-0445" targetId="ca4f-d69a-f445-c7ce" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="5a35-7bd3-6315-2e2f" targetId="f2e8-bf72-d131-8cc2" linkType="profile">
-          <modifiers/>
-        </link>
-        <link id="9d9d-225b-4cd3-1e2c" targetId="a65f-a441-aa32-73d9" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="8017-8554-c260-020e" name="Tree Kin" points="0.0" categoryId="bee2-43e8-42c4-b182" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="WEW" page="17">
-      <entries>
-        <entry id="5310-8701-c4b1-62f0" name="Tree Kin" points="0.0" categoryId="(No Category)" type="model" minSelections="3" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="WEW" page="17">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="517b-ac59-3f81-c988" profileTypeId="d42a-7ddd-953b-4d23" name="Tree Kin" hidden="false" book="WEW" page="17">
-              <characteristics>
-                <characteristic characteristicId="0ae7-a2b1-6b97-8f4d" name="Move" value="6&quot;"/>
-                <characteristic characteristicId="0054-981e-bc82-2ce2" name="Wounds" value="4"/>
-                <characteristic characteristicId="d875-64d5-4fad-c5c3" name="Save" value="4+"/>
-                <characteristic characteristicId="2b7b-be5f-5b04-1ec4" name="Bravery" value="6"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="7c17-40a0-7bd3-60bf" name="Spell references" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="b640-00ec-5d7a-6e92" name="Regrowth" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="1c10-edab-e534-9ffa" targetId="5cde-ccd6-efeb-8537" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links/>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules>
-        <rule id="766c-ee4c-73a7-9f76" name="Tree Kin Spells" hidden="false" book="WEW" page="17">
-          <description>Sylvaneth Wizards know the Regrowth spell in addition to any other spell they know whilst there are any Tree Kin on the battlefield.</description>
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links>
-        <link id="e663-38b9-268a-1420" targetId="5ea1-8555-1861-19aa" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="cb1b-2d65-a1ef-2f55" targetId="158e-2f95-0739-010b" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="9aa0-ffc3-aedc-98f4" targetId="f7a8-1d48-717f-8ee4" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="7e82-8782-0ca8-9c90" targetId="4df9-e8bf-9fb0-5cad" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
     <entry id="a3cb-73f3-3a5d-2f70" name="Warhawk Riders" points="0.0" categoryId="bee2-43e8-42c4-b182" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="WEW" page="14">
       <entries>
         <entry id="49c2-1e2b-0aec-2e9f" name="Warhawk Rider" points="0.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="WEW" page="14">
@@ -861,6 +572,71 @@
         </link>
       </links>
     </entry>
+    <entry id="8017-8554-c260-020e" name="Tree Kin" points="0.0" categoryId="bee2-43e8-42c4-b182" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="WEW" page="17">
+      <entries>
+        <entry id="5310-8701-c4b1-62f0" name="Tree Kin" points="0.0" categoryId="(No Category)" type="model" minSelections="3" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="WEW" page="17">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="517b-ac59-3f81-c988" profileTypeId="d42a-7ddd-953b-4d23" name="Tree Kin" hidden="false" book="WEW" page="17">
+              <characteristics>
+                <characteristic characteristicId="0ae7-a2b1-6b97-8f4d" name="Move" value="6&quot;"/>
+                <characteristic characteristicId="0054-981e-bc82-2ce2" name="Wounds" value="4"/>
+                <characteristic characteristicId="d875-64d5-4fad-c5c3" name="Save" value="4+"/>
+                <characteristic characteristicId="2b7b-be5f-5b04-1ec4" name="Bravery" value="6"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+      </entries>
+      <entryGroups>
+        <entryGroup id="7c17-40a0-7bd3-60bf" name="Spell references" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="b640-00ec-5d7a-6e92" name="Regrowth" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="1c10-edab-e534-9ffa" targetId="5cde-ccd6-efeb-8537" linkType="rule">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules>
+        <rule id="766c-ee4c-73a7-9f76" name="Tree Kin Spells" hidden="false" book="WEW" page="17">
+          <description>Sylvaneth Wizards know the Regrowth spell in addition to any other spell they know whilst there are any Tree Kin on the battlefield.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links>
+        <link id="e663-38b9-268a-1420" targetId="5ea1-8555-1861-19aa" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="cb1b-2d65-a1ef-2f55" targetId="158e-2f95-0739-010b" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="9aa0-ffc3-aedc-98f4" targetId="f7a8-1d48-717f-8ee4" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="7e82-8782-0ca8-9c90" targetId="4df9-e8bf-9fb0-5cad" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
   </entries>
   <rules/>
   <links/>
@@ -875,10 +651,6 @@
       <description>Makes 6 attacks rather than 4 if charged this turn.</description>
       <modifiers/>
     </rule>
-    <rule id="2dda-973a-252b-c079" name="(Ability) Enrapturing Song" hidden="false" book="WEW" page="16">
-      <description>In your own combat phase, you can enrapture one enemy unit that is within 3&quot; of this unit. Add 1 to the hit rolls for attacks made by this unit against the enraptured unit in that combat phase.</description>
-      <modifiers/>
-    </rule>
     <rule id="42cf-2dd1-7eb8-933e" name="(Ability) Fire on the Move" hidden="false" book="WEW" page="13">
       <description>Can run and shoot in the same turn.</description>
       <modifiers/>
@@ -891,37 +663,16 @@
       <description>Can re-roll failed save rolls of 1. Re-roll failed saves of 1 or 2 when in cover.</description>
       <modifiers/>
     </rule>
-    <rule id="3e7a-ae02-747e-b6ab" name="(Ability) Groundshaking Stomp" hidden="false">
-      <description>At the start of the combat phase this model stomps the ground; roll a dice for each enemy unit within 3&quot; of this model. On a roll of 4 or more that unit is knocked of their feet by the impact and must subtract 1 from all hit rolls in that combat phase as they regain their footing.</description>
-      <modifiers/>
-    </rule>
     <rule id="1a97-665b-edf2-0aac" name="(Ability) Guardians of the Wildwood" hidden="false" book="WEW" page="14">
       <description>Hand weapon inflicts D3 Damage on Monsters instead of 1.</description>
-      <modifiers/>
-    </rule>
-    <rule id="76f9-3a16-ecbe-3671" name="(Ability) Impale" hidden="false">
-      <description>If this model’s Massive Impaling Talons inflict a wound on an enemy model, roll a dice and subtract 1 from the roll. If
-the result equals or exceeds the number of wounds the enemy model has remaining, it is slain.</description>
-      <modifiers/>
-    </rule>
-    <rule id="c02e-c8e6-3c34-188e" name="(Ability) Impenetrable Thicket" hidden="false" book="WEW" page="16">
-      <description>You can add 1 to the result of save rolls for this unit if it includes at least 12 models.</description>
       <modifiers/>
     </rule>
     <rule id="a101-cc3e-a4bf-1277" name="(Ability) Predator&apos;s Descent" hidden="false" book="WEW" page="14">
       <description>Add 1 to all wound rolls if unit charged this turn.</description>
       <modifiers/>
     </rule>
-    <rule id="5ea1-8555-1861-19aa" name="(Ability) Roused to War" hidden="false" book="WEW" page="17">
-      <description>You can re-roll hit rolls of 1 if this unit is within 18&quot; of a Sylvaneth Hero.</description>
-      <modifiers/>
-    </rule>
     <rule id="af40-a6b2-5955-67b9" name="(Ability) Soar Away" hidden="false" book="WEW" page="15">
       <description>At the end of the combat phase, this unit can retreat from close combat and soar away if there are any enemy models within 3&quot; of their unit. If it does, roll three dice; the total scored is how far you can move the unit when it retreats. The unit must end this movement more than 3&quot; from any enemy units – if it can’t move far enough then it does not retreat.</description>
-      <modifiers/>
-    </rule>
-    <rule id="b487-bb62-707f-cc51" name="(Ability) Spirit Paths" hidden="false">
-      <description>If this model is within 3&quot; of a Sylvaneth Wyldwood at the start of your movement phase, it can travel along the spirit paths. If he does so, remove this model from the battlefield, and then set it up within 3&quot; of a different Sylvaneth Wyldwood, more than 9&quot; from any enemy models. This is its move for the movement phase.</description>
       <modifiers/>
     </rule>
     <rule id="9d11-a009-ed4e-8c88" name="(Ability) Sweep Through Their Lines" hidden="false" book="WEW" page="14">
@@ -935,12 +686,6 @@ the result equals or exceeds the number of wounds the enemy model has remaining,
     <rule id="e928-a366-0050-4451" name="(Keyword) Aelf" hidden="false">
       <modifiers/>
     </rule>
-    <rule id="d850-57ce-2223-b4c7" name="(Keyword) Dryads" hidden="false">
-      <modifiers/>
-    </rule>
-    <rule id="271b-f3a7-5650-dad2" name="(Keyword) Durthu" hidden="false">
-      <modifiers/>
-    </rule>
     <rule id="49f5-37e5-3f3a-c292" name="(Keyword) Eternal Guard" hidden="false">
       <modifiers/>
     </rule>
@@ -950,22 +695,10 @@ the result equals or exceeds the number of wounds the enemy model has remaining,
     <rule id="4464-c8ed-eaef-f9c0" name="(Keyword) Great Eagles" hidden="false">
       <modifiers/>
     </rule>
-    <rule id="3faf-938a-c642-8397" name="(Keyword) Hero" hidden="false">
-      <modifiers/>
-    </rule>
-    <rule id="877a-71fe-45fc-50cc" name="(Keyword) Monster" hidden="false">
-      <modifiers/>
-    </rule>
     <rule id="158e-2f95-0739-010b" name="(Keyword) Order" hidden="false">
       <modifiers/>
     </rule>
     <rule id="0d29-82f7-f90a-fad6" name="(Keyword) Sisters of the Thorn" hidden="false">
-      <modifiers/>
-    </rule>
-    <rule id="f7a8-1d48-717f-8ee4" name="(Keyword) Sylvaneth" hidden="false">
-      <modifiers/>
-    </rule>
-    <rule id="4df9-e8bf-9fb0-5cad" name="(Keyword) Tree Kin" hidden="false">
       <modifiers/>
     </rule>
     <rule id="ec02-d50f-468a-c7a8" name="(Keyword) Wanderer" hidden="false">
@@ -984,10 +717,6 @@ the result equals or exceeds the number of wounds the enemy model has remaining,
       <modifiers/>
     </rule>
     <rule id="3a6c-677d-79f6-0651" name="(Spell) Mystic Shield" hidden="false">
-      <modifiers/>
-    </rule>
-    <rule id="5cde-ccd6-efeb-8537" name="(Spell) Regrowth" hidden="false" book="WEW" page="17">
-      <description>Regrowth has a casting value of 5. If successfully cast, select a Tree Kin model within 18&quot;. That model heals D3 wounds.</description>
       <modifiers/>
     </rule>
     <rule id="a910-e80d-3729-4571" name="(Spell) Roused to Wrath" hidden="false" book="WEW" page="16">
@@ -1012,6 +741,31 @@ the result equals or exceeds the number of wounds the enemy model has remaining,
     </rule>
     <rule id="8b02-d645-1278-82fd" name="Standard Bearer" hidden="false">
       <description>Add 1 to the Bravery of this unit. Add 2 if unit is in cover.</description>
+      <modifiers/>
+    </rule>
+    <rule id="2dda-973a-252b-c079" name="(Ability) Enrapturing Song" hidden="false" book="WEW" page="16">
+      <description>In your own combat phase, you can enrapture one enemy unit that is within 3&quot; of this unit. Add 1 to the hit rolls for attacks made by this unit against the enraptured unit in that combat phase.</description>
+      <modifiers/>
+    </rule>
+    <rule id="c02e-c8e6-3c34-188e" name="(Ability) Impenetrable Thicket" hidden="false" book="WEW" page="16">
+      <description>You can add 1 to the result of save rolls for this unit if it includes at least 12 models.</description>
+      <modifiers/>
+    </rule>
+    <rule id="f7a8-1d48-717f-8ee4" name="(Keyword) Sylvaneth" hidden="false">
+      <modifiers/>
+    </rule>
+    <rule id="d850-57ce-2223-b4c7" name="(Keyword) Dryads" hidden="false">
+      <modifiers/>
+    </rule>
+    <rule id="5ea1-8555-1861-19aa" name="(Ability) Roused to War" hidden="false" book="WEW" page="17">
+      <description>You can re-roll hit rolls of 1 if this unit is within 18&quot; of a Sylvaneth Hero.</description>
+      <modifiers/>
+    </rule>
+    <rule id="5cde-ccd6-efeb-8537" name="(Spell) Regrowth" hidden="false" book="WEW" page="17">
+      <description>Regrowth has a casting value of 5. If successfully cast, select a Tree Kin model within 18&quot;. That model heals D3 wounds.</description>
+      <modifiers/>
+    </rule>
+    <rule id="4df9-e8bf-9fb0-5cad" name="(Keyword) Tree Kin" hidden="false">
       <modifiers/>
     </rule>
   </sharedRules>
@@ -1060,28 +814,6 @@ the result equals or exceeds the number of wounds the enemy model has remaining,
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="d837-dc4c-72f3-7185" profileTypeId="69e7-9460-0985-44b0" name="Elder Wrath Sword" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="420c-6e7d-0b96-4289" name="Range" value="3&quot;"/>
-        <characteristic characteristicId="229e-c54a-7785-0e0f" name="Attacks" value="3"/>
-        <characteristic characteristicId="bdcd-ebcf-f909-49d9" name="To Hit" value="3+"/>
-        <characteristic characteristicId="0088-422c-55f2-2361" name="To Wound" value="3+"/>
-        <characteristic characteristicId="1b60-6be0-3cd0-df54" name="Rend" value="-2"/>
-        <characteristic characteristicId="dace-95f3-a99b-89b6" name="Damage" value="*"/>
-      </characteristics>
-      <modifiers/>
-    </profile>
-    <profile id="f2e8-bf72-d131-8cc2" profileTypeId="69e7-9460-0985-44b0" name="Massive Impaling Talons" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="420c-6e7d-0b96-4289" name="Range" value="1&quot;"/>
-        <characteristic characteristicId="229e-c54a-7785-0e0f" name="Attacks" value="1"/>
-        <characteristic characteristicId="bdcd-ebcf-f909-49d9" name="To Hit" value="3+"/>
-        <characteristic characteristicId="0088-422c-55f2-2361" name="To Wound" value="*"/>
-        <characteristic characteristicId="1b60-6be0-3cd0-df54" name="Rend" value="-2"/>
-        <characteristic characteristicId="dace-95f3-a99b-89b6" name="Damage" value="1"/>
-      </characteristics>
-      <modifiers/>
-    </profile>
     <profile id="2b65-c372-dd60-53b0" profileTypeId="69e7-9460-0985-44b0" name="Piercing Talons" hidden="false" book="WEW" page="16">
       <characteristics>
         <characteristic characteristicId="420c-6e7d-0b96-4289" name="Range" value="2&quot;"/>
@@ -1112,17 +844,6 @@ the result equals or exceeds the number of wounds the enemy model has remaining,
         <characteristic characteristicId="0088-422c-55f2-2361" name="To Wound" value="5+"/>
         <characteristic characteristicId="1b60-6be0-3cd0-df54" name="Rend" value="-"/>
         <characteristic characteristicId="dace-95f3-a99b-89b6" name="Damage" value="1"/>
-      </characteristics>
-      <modifiers/>
-    </profile>
-    <profile id="a65f-a441-aa32-73d9" profileTypeId="69e7-9460-0985-44b0" name="Sweeping Blows" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="420c-6e7d-0b96-4289" name="Range" value="3&quot;"/>
-        <characteristic characteristicId="229e-c54a-7785-0e0f" name="Attacks" value="*"/>
-        <characteristic characteristicId="bdcd-ebcf-f909-49d9" name="To Hit" value="3+"/>
-        <characteristic characteristicId="0088-422c-55f2-2361" name="To Wound" value="3+"/>
-        <characteristic characteristicId="1b60-6be0-3cd0-df54" name="Rend" value="-1"/>
-        <characteristic characteristicId="dace-95f3-a99b-89b6" name="Damage" value="D6"/>
       </characteristics>
       <modifiers/>
     </profile>

--- a/Order_-_9thBRB_Warscrolls.cat
+++ b/Order_-_9thBRB_Warscrolls.cat
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="1e0b-c068-a46a-8a22" revision="1" gameSystemId="13ba-994f-8c12-9f8d" gameSystemRevision="1" battleScribeVersion="1.15" name="Order - 9thBRB_Warscrolls" books="Wood Elves Warscroll, High Elves Warscroll, Dark Elves Warscroll, ..." authorName="Markus W. (taalas)" authorContact="" authorUrl="https://github.com/taalas" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="1e0b-c068-a46a-8a22" revision="3" gameSystemId="13ba-994f-8c12-9f8d" gameSystemRevision="1" battleScribeVersion="1.15" name="Order - 9thBRB_Warscrolls" books="Wood Elves Warscroll, High Elves Warscroll, Dark Elves Warscroll, ..." authorName="Markus W. (taalas)" authorContact="" authorUrl="https://github.com/taalas" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
-    <entry id="aa9f-52dc-e2ae-dc9e" name="Branchwraith" points="0.0" categoryId="bee2-43e8-42c4-b182" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="WEW" page="16">
+    <entry id="aa9f-52dc-e2ae-dc9e" name="Branchwraith" points="0.0" categoryId="c96d-1643-ed56-ba60" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="WEW" page="16">
       <entries/>
       <entryGroups/>
       <modifiers/>
@@ -35,7 +35,7 @@
         </link>
       </links>
     </entry>
-    <entry id="0ad4-ebb5-2ef2-41a5" name="Dryads" points="0.0" categoryId="bee2-43e8-42c4-b182" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="WEW" page="16">
+    <entry id="0ad4-ebb5-2ef2-41a5" name="Dryads" points="0.0" categoryId="c96d-1643-ed56-ba60" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="WEW" page="16">
       <entries>
         <entry id="361d-f7f1-7cf5-29b6" name="Dryad" points="0.0" categoryId="(No Category)" type="unit" minSelections="5" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="WEW" page="16">
           <entries/>
@@ -80,6 +80,83 @@
           <modifiers/>
         </link>
         <link id="a28e-36e5-a049-5387" targetId="d850-57ce-2223-b4c7" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="fd79-07a5-fb75-c79a" name="Durthu" points="0.0" categoryId="c96d-1643-ed56-ba60" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="e701-6feb-2bca-c053" name="(Ability) Elder Wrath Sword" hidden="false">
+          <description>Durthu makes an extra D3 attacks with the Elder Wrath Sword if he is within 3&quot; of a Sylvaneth Wyldwood when he attacks in the combat phase.</description>
+          <modifiers/>
+        </rule>
+        <rule id="b90a-139c-ac8e-41bb" name="(Table) Durthu Damage Table" hidden="false">
+          <description>&lt;table&gt;
+&lt;tr&gt;&lt;th colspan=4&gt;DAMAGE TABLE&lt;/th&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;th&gt;Wounds Suffered&lt;/th&gt;&lt;th&gt;Lamentations of Despair&lt;/th&gt;&lt;th&gt;Eldar Wrath Sword&lt;/th&gt;&lt;th&gt;Massive Impaling Talons&lt;/th&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;th&gt;0-2&lt;/th&gt;&lt;td&gt;12&lt;/td&gt;&lt;td&gt;6&lt;/td&gt;&lt;td&gt;2+&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;th&gt;3-4&lt;/th&gt;&lt;td&gt;10&lt;/td&gt;&lt;td&gt;D6&lt;/td&gt;&lt;td&gt;2+&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;th&gt;5-7&lt;/th&gt;&lt;td&gt;8&lt;/td&gt;&lt;td&gt;D6&lt;/td&gt;&lt;td&gt;3+&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;th&gt;8-9&lt;/th&gt;&lt;td&gt;6&lt;/td&gt;&lt;td&gt;D6&lt;/td&gt;&lt;td&gt;3+&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;th&gt;10+&lt;/th&gt;&lt;td&gt;4&lt;/td&gt;&lt;td&gt;D3&lt;/td&gt;&lt;td&gt;4+&lt;/td&gt;&lt;/tr&gt;
+&lt;/table&gt;</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="49b3-bb11-f120-29a7" profileTypeId="d42a-7ddd-953b-4d23" name="Durthu" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="0ae7-a2b1-6b97-8f4d" name="Move" value="5&quot;"/>
+            <characteristic characteristicId="0054-981e-bc82-2ce2" name="Wounds" value="12"/>
+            <characteristic characteristicId="d875-64d5-4fad-c5c3" name="Save" value="3+"/>
+            <characteristic characteristicId="2b7b-be5f-5b04-1ec4" name="Bravery" value="9"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+        <profile id="7209-d867-d427-d11d" profileTypeId="69e7-9460-0985-44b0" name="Lamentations of Despair" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="420c-6e7d-0b96-4289" name="Range" value="10&quot;"/>
+            <characteristic characteristicId="229e-c54a-7785-0e0f" name="Attacks" value="*"/>
+            <characteristic characteristicId="bdcd-ebcf-f909-49d9" name="To Hit" value="3+"/>
+            <characteristic characteristicId="0088-422c-55f2-2361" name="To Wound" value="5+"/>
+            <characteristic characteristicId="1b60-6be0-3cd0-df54" name="Rend" value="-"/>
+            <characteristic characteristicId="dace-95f3-a99b-89b6" name="Damage" value="1"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="fd56-a117-4363-01eb" targetId="d837-dc4c-72f3-7185" linkType="profile">
+          <modifiers/>
+        </link>
+        <link id="50cb-8f73-4860-20c5" targetId="3e7a-ae02-747e-b6ab" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="553a-d6bd-2424-6800" targetId="76f9-3a16-ecbe-3671" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="d7b2-f868-76ad-d8ce" targetId="b487-bb62-707f-cc51" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="74e6-5bf2-ad68-34b4" targetId="271b-f3a7-5650-dad2" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="7083-41c8-22b0-9b1e" targetId="3faf-938a-c642-8397" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="d5f0-d691-23d3-ecb8" targetId="877a-71fe-45fc-50cc" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="2a68-4702-754a-98c2" targetId="158e-2f95-0739-010b" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="6607-74aa-1b7a-671a" targetId="f7a8-1d48-717f-8ee4" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="bc89-637e-435d-a0c7" targetId="f2e8-bf72-d131-8cc2" linkType="profile">
           <modifiers/>
         </link>
       </links>
@@ -421,6 +498,218 @@
         </link>
       </links>
     </entry>
+    <entry id="863b-dc9e-8de4-841a" name="Sylvaneth Treelord" points="0.0" categoryId="c96d-1643-ed56-ba60" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="9247-9e43-c002-858a" name="(Table) Treelord Damage Table" hidden="false">
+          <description>&lt;table&gt;
+&lt;tr&gt;&lt;th colspan=4&gt;DAMAGE TABLE&lt;/th&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;th&gt;Wounds Suffered&lt;/th&gt;&lt;th&gt;Strangleroots&lt;/th&gt;&lt;th&gt;Sweeping Blows&lt;/th&gt;&lt;th&gt;Massive Impaling Talons&lt;/th&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;th&gt;0-2&lt;/th&gt;&lt;td&gt;2+&lt;/td&gt;&lt;td&gt;3&lt;/td&gt;&lt;td&gt;2+&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;th&gt;3-4&lt;/th&gt;&lt;td&gt;3+&lt;/td&gt;&lt;td&gt;2&lt;/td&gt;&lt;td&gt;2+&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;th&gt;5-7&lt;/th&gt;&lt;td&gt;4+&lt;/td&gt;&lt;td&gt;2&lt;/td&gt;&lt;td&gt;3+&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;th&gt;8-9&lt;/th&gt;&lt;td&gt;5+&lt;/td&gt;&lt;td&gt;1&lt;/td&gt;&lt;td&gt;3+&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;th&gt;10+&lt;/th&gt;&lt;td&gt;6+&lt;/td&gt;&lt;td&gt;1&lt;/td&gt;&lt;td&gt;4+&lt;/td&gt;&lt;/tr&gt;
+&lt;/table&gt;</description>
+          <modifiers/>
+        </rule>
+        <rule id="e5e0-179a-fb36-13a1" name="(Keyword) Treelord" hidden="false">
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="3972-00ed-7722-1326" profileTypeId="69e7-9460-0985-44b0" name="Strangleroots" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="420c-6e7d-0b96-4289" name="Range" value="12&quot;"/>
+            <characteristic characteristicId="229e-c54a-7785-0e0f" name="Attacks" value="5"/>
+            <characteristic characteristicId="bdcd-ebcf-f909-49d9" name="To Hit" value="*"/>
+            <characteristic characteristicId="0088-422c-55f2-2361" name="To Wound" value="3+"/>
+            <characteristic characteristicId="1b60-6be0-3cd0-df54" name="Rend" value="-1"/>
+            <characteristic characteristicId="dace-95f3-a99b-89b6" name="Damage" value="1"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+        <profile id="4cc1-8110-7229-983e" profileTypeId="d42a-7ddd-953b-4d23" name="Sylvaneth Treelord" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="0ae7-a2b1-6b97-8f4d" name="Move" value="6&quot;"/>
+            <characteristic characteristicId="0054-981e-bc82-2ce2" name="Wounds" value="12"/>
+            <characteristic characteristicId="d875-64d5-4fad-c5c3" name="Save" value="3+"/>
+            <characteristic characteristicId="2b7b-be5f-5b04-1ec4" name="Bravery" value="6"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="e944-9668-4042-ad95" targetId="3e7a-ae02-747e-b6ab" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="a8e9-75f9-2051-d027" targetId="76f9-3a16-ecbe-3671" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="00e6-b4d5-5b1d-780b" targetId="b487-bb62-707f-cc51" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="12fd-2dbc-5a57-5c4c" targetId="877a-71fe-45fc-50cc" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="58ef-e133-ec91-ac51" targetId="158e-2f95-0739-010b" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="57e8-ac1b-0aac-5e36" targetId="f7a8-1d48-717f-8ee4" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="4e52-8534-ce5d-9b27" targetId="f2e8-bf72-d131-8cc2" linkType="profile">
+          <modifiers/>
+        </link>
+        <link id="1c11-ddeb-1f6e-3e46" targetId="a65f-a441-aa32-73d9" linkType="profile">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="db3b-2809-7184-1744" name="Sylvaneth Treelord Ancient" points="0.0" categoryId="c96d-1643-ed56-ba60" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="3d6c-48d2-509a-e9a9" name="(Table) Treelord Ancient Damage Table" hidden="false">
+          <description>&lt;table&gt;
+&lt;tr&gt;&lt;th colspan=4&gt;DAMAGE TABLE&lt;/th&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;th&gt;Wounds Suffered&lt;/th&gt;&lt;th&gt;Doom Tendril Staff&lt;/th&gt;&lt;th&gt;Sweeping Blows&lt;/th&gt;&lt;th&gt;Massive Impaling Talons&lt;/th&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;th&gt;0-2&lt;/th&gt;&lt;td&gt;2+&lt;/td&gt;&lt;td&gt;3&lt;/td&gt;&lt;td&gt;2+&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;th&gt;3-4&lt;/th&gt;&lt;td&gt;3+&lt;/td&gt;&lt;td&gt;2&lt;/td&gt;&lt;td&gt;2+&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;th&gt;5-7&lt;/th&gt;&lt;td&gt;4+&lt;/td&gt;&lt;td&gt;2&lt;/td&gt;&lt;td&gt;3+&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;th&gt;8-9&lt;/th&gt;&lt;td&gt;5+&lt;/td&gt;&lt;td&gt;1&lt;/td&gt;&lt;td&gt;3+&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;th&gt;10+&lt;/th&gt;&lt;td&gt;6+&lt;/td&gt;&lt;td&gt;1&lt;/td&gt;&lt;td&gt;4+&lt;/td&gt;&lt;/tr&gt;
+&lt;/table&gt;</description>
+          <modifiers/>
+        </rule>
+        <rule id="3fa8-e741-e7c5-cc05" name="(Spell) Awakening the Wood" hidden="false">
+          <description>Awakening the Wood has a casting value of 6. If successfully cast, pick a Sylvaneth Wyldwood that is within 24&quot; of the caster. Each enemy unit within 3&quot; of this Sylvaneth Wyldwood suffers D3 mortal wounds the trees come to life and attack with twisted branches and thorny boughs.</description>
+          <modifiers/>
+        </rule>
+        <rule id="50e9-f167-36ef-ea67" name="(Keyword) Treelord Ancient" hidden="false">
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="99ad-ab02-69f5-a779" profileTypeId="69e7-9460-0985-44b0" name="Doom Tendril Staff" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="420c-6e7d-0b96-4289" name="Range" value="18&quot;"/>
+            <characteristic characteristicId="229e-c54a-7785-0e0f" name="Attacks" value="1"/>
+            <characteristic characteristicId="bdcd-ebcf-f909-49d9" name="To Hit" value="*"/>
+            <characteristic characteristicId="0088-422c-55f2-2361" name="To Wound" value="3+"/>
+            <characteristic characteristicId="1b60-6be0-3cd0-df54" name="Rend" value="-1"/>
+            <characteristic characteristicId="dace-95f3-a99b-89b6" name="Damage" value="D6"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+        <profile id="6145-36a4-d07f-695b" profileTypeId="d42a-7ddd-953b-4d23" name="Sylvaneth Treelord Ancient" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="0ae7-a2b1-6b97-8f4d" name="Move" value="5&quot;"/>
+            <characteristic characteristicId="0054-981e-bc82-2ce2" name="Wounds" value="12"/>
+            <characteristic characteristicId="d875-64d5-4fad-c5c3" name="Save" value="3+"/>
+            <characteristic characteristicId="2b7b-be5f-5b04-1ec4" name="Bravery" value="9"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="16ae-3bc0-968a-c3d1" targetId="3e7a-ae02-747e-b6ab" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="1e32-a3e2-aa35-70b5" targetId="76f9-3a16-ecbe-3671" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="11f3-df54-74b8-fbf5" targetId="b487-bb62-707f-cc51" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="e5b4-cbb5-ad4c-4dfa" targetId="877a-71fe-45fc-50cc" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="83ae-9327-2451-7208" targetId="158e-2f95-0739-010b" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="d0b3-730f-120c-0dbc" targetId="f7a8-1d48-717f-8ee4" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="0ea6-3978-4a15-0445" targetId="ca4f-d69a-f445-c7ce" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="5a35-7bd3-6315-2e2f" targetId="f2e8-bf72-d131-8cc2" linkType="profile">
+          <modifiers/>
+        </link>
+        <link id="9d9d-225b-4cd3-1e2c" targetId="a65f-a441-aa32-73d9" linkType="profile">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="8017-8554-c260-020e" name="Tree Kin" points="0.0" categoryId="bee2-43e8-42c4-b182" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="WEW" page="17">
+      <entries>
+        <entry id="5310-8701-c4b1-62f0" name="Tree Kin" points="0.0" categoryId="(No Category)" type="model" minSelections="3" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="WEW" page="17">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="517b-ac59-3f81-c988" profileTypeId="d42a-7ddd-953b-4d23" name="Tree Kin" hidden="false" book="WEW" page="17">
+              <characteristics>
+                <characteristic characteristicId="0ae7-a2b1-6b97-8f4d" name="Move" value="6&quot;"/>
+                <characteristic characteristicId="0054-981e-bc82-2ce2" name="Wounds" value="4"/>
+                <characteristic characteristicId="d875-64d5-4fad-c5c3" name="Save" value="4+"/>
+                <characteristic characteristicId="2b7b-be5f-5b04-1ec4" name="Bravery" value="6"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+      </entries>
+      <entryGroups>
+        <entryGroup id="7c17-40a0-7bd3-60bf" name="Spell references" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="b640-00ec-5d7a-6e92" name="Regrowth" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="1c10-edab-e534-9ffa" targetId="5cde-ccd6-efeb-8537" linkType="rule">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules>
+        <rule id="766c-ee4c-73a7-9f76" name="Tree Kin Spells" hidden="false" book="WEW" page="17">
+          <description>Sylvaneth Wizards know the Regrowth spell in addition to any other spell they know whilst there are any Tree Kin on the battlefield.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links>
+        <link id="e663-38b9-268a-1420" targetId="5ea1-8555-1861-19aa" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="cb1b-2d65-a1ef-2f55" targetId="158e-2f95-0739-010b" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="9aa0-ffc3-aedc-98f4" targetId="f7a8-1d48-717f-8ee4" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="7e82-8782-0ca8-9c90" targetId="4df9-e8bf-9fb0-5cad" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
     <entry id="a3cb-73f3-3a5d-2f70" name="Warhawk Riders" points="0.0" categoryId="bee2-43e8-42c4-b182" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="WEW" page="14">
       <entries>
         <entry id="49c2-1e2b-0aec-2e9f" name="Warhawk Rider" points="0.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="WEW" page="14">
@@ -572,71 +861,6 @@
         </link>
       </links>
     </entry>
-    <entry id="8017-8554-c260-020e" name="Tree Kin" points="0.0" categoryId="bee2-43e8-42c4-b182" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="WEW" page="17">
-      <entries>
-        <entry id="5310-8701-c4b1-62f0" name="Tree Kin" points="0.0" categoryId="(No Category)" type="model" minSelections="3" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="WEW" page="17">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="517b-ac59-3f81-c988" profileTypeId="d42a-7ddd-953b-4d23" name="Tree Kin" hidden="false" book="WEW" page="17">
-              <characteristics>
-                <characteristic characteristicId="0ae7-a2b1-6b97-8f4d" name="Move" value="6&quot;"/>
-                <characteristic characteristicId="0054-981e-bc82-2ce2" name="Wounds" value="4"/>
-                <characteristic characteristicId="d875-64d5-4fad-c5c3" name="Save" value="4+"/>
-                <characteristic characteristicId="2b7b-be5f-5b04-1ec4" name="Bravery" value="6"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="7c17-40a0-7bd3-60bf" name="Spell references" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="b640-00ec-5d7a-6e92" name="Regrowth" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="1c10-edab-e534-9ffa" targetId="5cde-ccd6-efeb-8537" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links/>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules>
-        <rule id="766c-ee4c-73a7-9f76" name="Tree Kin Spells" hidden="false" book="WEW" page="17">
-          <description>Sylvaneth Wizards know the Regrowth spell in addition to any other spell they know whilst there are any Tree Kin on the battlefield.</description>
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links>
-        <link id="e663-38b9-268a-1420" targetId="5ea1-8555-1861-19aa" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="cb1b-2d65-a1ef-2f55" targetId="158e-2f95-0739-010b" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="9aa0-ffc3-aedc-98f4" targetId="f7a8-1d48-717f-8ee4" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="7e82-8782-0ca8-9c90" targetId="4df9-e8bf-9fb0-5cad" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
   </entries>
   <rules/>
   <links/>
@@ -651,6 +875,10 @@
       <description>Makes 6 attacks rather than 4 if charged this turn.</description>
       <modifiers/>
     </rule>
+    <rule id="2dda-973a-252b-c079" name="(Ability) Enrapturing Song" hidden="false" book="WEW" page="16">
+      <description>In your own combat phase, you can enrapture one enemy unit that is within 3&quot; of this unit. Add 1 to the hit rolls for attacks made by this unit against the enraptured unit in that combat phase.</description>
+      <modifiers/>
+    </rule>
     <rule id="42cf-2dd1-7eb8-933e" name="(Ability) Fire on the Move" hidden="false" book="WEW" page="13">
       <description>Can run and shoot in the same turn.</description>
       <modifiers/>
@@ -663,16 +891,37 @@
       <description>Can re-roll failed save rolls of 1. Re-roll failed saves of 1 or 2 when in cover.</description>
       <modifiers/>
     </rule>
+    <rule id="3e7a-ae02-747e-b6ab" name="(Ability) Groundshaking Stomp" hidden="false">
+      <description>At the start of the combat phase this model stomps the ground; roll a dice for each enemy unit within 3&quot; of this model. On a roll of 4 or more that unit is knocked of their feet by the impact and must subtract 1 from all hit rolls in that combat phase as they regain their footing.</description>
+      <modifiers/>
+    </rule>
     <rule id="1a97-665b-edf2-0aac" name="(Ability) Guardians of the Wildwood" hidden="false" book="WEW" page="14">
       <description>Hand weapon inflicts D3 Damage on Monsters instead of 1.</description>
+      <modifiers/>
+    </rule>
+    <rule id="76f9-3a16-ecbe-3671" name="(Ability) Impale" hidden="false">
+      <description>If this model’s Massive Impaling Talons inflict a wound on an enemy model, roll a dice and subtract 1 from the roll. If
+the result equals or exceeds the number of wounds the enemy model has remaining, it is slain.</description>
+      <modifiers/>
+    </rule>
+    <rule id="c02e-c8e6-3c34-188e" name="(Ability) Impenetrable Thicket" hidden="false" book="WEW" page="16">
+      <description>You can add 1 to the result of save rolls for this unit if it includes at least 12 models.</description>
       <modifiers/>
     </rule>
     <rule id="a101-cc3e-a4bf-1277" name="(Ability) Predator&apos;s Descent" hidden="false" book="WEW" page="14">
       <description>Add 1 to all wound rolls if unit charged this turn.</description>
       <modifiers/>
     </rule>
+    <rule id="5ea1-8555-1861-19aa" name="(Ability) Roused to War" hidden="false" book="WEW" page="17">
+      <description>You can re-roll hit rolls of 1 if this unit is within 18&quot; of a Sylvaneth Hero.</description>
+      <modifiers/>
+    </rule>
     <rule id="af40-a6b2-5955-67b9" name="(Ability) Soar Away" hidden="false" book="WEW" page="15">
       <description>At the end of the combat phase, this unit can retreat from close combat and soar away if there are any enemy models within 3&quot; of their unit. If it does, roll three dice; the total scored is how far you can move the unit when it retreats. The unit must end this movement more than 3&quot; from any enemy units – if it can’t move far enough then it does not retreat.</description>
+      <modifiers/>
+    </rule>
+    <rule id="b487-bb62-707f-cc51" name="(Ability) Spirit Paths" hidden="false">
+      <description>If this model is within 3&quot; of a Sylvaneth Wyldwood at the start of your movement phase, it can travel along the spirit paths. If he does so, remove this model from the battlefield, and then set it up within 3&quot; of a different Sylvaneth Wyldwood, more than 9&quot; from any enemy models. This is its move for the movement phase.</description>
       <modifiers/>
     </rule>
     <rule id="9d11-a009-ed4e-8c88" name="(Ability) Sweep Through Their Lines" hidden="false" book="WEW" page="14">
@@ -686,6 +935,12 @@
     <rule id="e928-a366-0050-4451" name="(Keyword) Aelf" hidden="false">
       <modifiers/>
     </rule>
+    <rule id="d850-57ce-2223-b4c7" name="(Keyword) Dryads" hidden="false">
+      <modifiers/>
+    </rule>
+    <rule id="271b-f3a7-5650-dad2" name="(Keyword) Durthu" hidden="false">
+      <modifiers/>
+    </rule>
     <rule id="49f5-37e5-3f3a-c292" name="(Keyword) Eternal Guard" hidden="false">
       <modifiers/>
     </rule>
@@ -695,10 +950,22 @@
     <rule id="4464-c8ed-eaef-f9c0" name="(Keyword) Great Eagles" hidden="false">
       <modifiers/>
     </rule>
+    <rule id="3faf-938a-c642-8397" name="(Keyword) Hero" hidden="false">
+      <modifiers/>
+    </rule>
+    <rule id="877a-71fe-45fc-50cc" name="(Keyword) Monster" hidden="false">
+      <modifiers/>
+    </rule>
     <rule id="158e-2f95-0739-010b" name="(Keyword) Order" hidden="false">
       <modifiers/>
     </rule>
     <rule id="0d29-82f7-f90a-fad6" name="(Keyword) Sisters of the Thorn" hidden="false">
+      <modifiers/>
+    </rule>
+    <rule id="f7a8-1d48-717f-8ee4" name="(Keyword) Sylvaneth" hidden="false">
+      <modifiers/>
+    </rule>
+    <rule id="4df9-e8bf-9fb0-5cad" name="(Keyword) Tree Kin" hidden="false">
       <modifiers/>
     </rule>
     <rule id="ec02-d50f-468a-c7a8" name="(Keyword) Wanderer" hidden="false">
@@ -717,6 +984,10 @@
       <modifiers/>
     </rule>
     <rule id="3a6c-677d-79f6-0651" name="(Spell) Mystic Shield" hidden="false">
+      <modifiers/>
+    </rule>
+    <rule id="5cde-ccd6-efeb-8537" name="(Spell) Regrowth" hidden="false" book="WEW" page="17">
+      <description>Regrowth has a casting value of 5. If successfully cast, select a Tree Kin model within 18&quot;. That model heals D3 wounds.</description>
       <modifiers/>
     </rule>
     <rule id="a910-e80d-3729-4571" name="(Spell) Roused to Wrath" hidden="false" book="WEW" page="16">
@@ -741,31 +1012,6 @@
     </rule>
     <rule id="8b02-d645-1278-82fd" name="Standard Bearer" hidden="false">
       <description>Add 1 to the Bravery of this unit. Add 2 if unit is in cover.</description>
-      <modifiers/>
-    </rule>
-    <rule id="2dda-973a-252b-c079" name="(Ability) Enrapturing Song" hidden="false" book="WEW" page="16">
-      <description>In your own combat phase, you can enrapture one enemy unit that is within 3&quot; of this unit. Add 1 to the hit rolls for attacks made by this unit against the enraptured unit in that combat phase.</description>
-      <modifiers/>
-    </rule>
-    <rule id="c02e-c8e6-3c34-188e" name="(Ability) Impenetrable Thicket" hidden="false" book="WEW" page="16">
-      <description>You can add 1 to the result of save rolls for this unit if it includes at least 12 models.</description>
-      <modifiers/>
-    </rule>
-    <rule id="f7a8-1d48-717f-8ee4" name="(Keyword) Sylvaneth" hidden="false">
-      <modifiers/>
-    </rule>
-    <rule id="d850-57ce-2223-b4c7" name="(Keyword) Dryads" hidden="false">
-      <modifiers/>
-    </rule>
-    <rule id="5ea1-8555-1861-19aa" name="(Ability) Roused to War" hidden="false" book="WEW" page="17">
-      <description>You can re-roll hit rolls of 1 if this unit is within 18&quot; of a Sylvaneth Hero.</description>
-      <modifiers/>
-    </rule>
-    <rule id="5cde-ccd6-efeb-8537" name="(Spell) Regrowth" hidden="false" book="WEW" page="17">
-      <description>Regrowth has a casting value of 5. If successfully cast, select a Tree Kin model within 18&quot;. That model heals D3 wounds.</description>
-      <modifiers/>
-    </rule>
-    <rule id="4df9-e8bf-9fb0-5cad" name="(Keyword) Tree Kin" hidden="false">
       <modifiers/>
     </rule>
   </sharedRules>
@@ -814,6 +1060,28 @@
       </characteristics>
       <modifiers/>
     </profile>
+    <profile id="d837-dc4c-72f3-7185" profileTypeId="69e7-9460-0985-44b0" name="Elder Wrath Sword" hidden="false">
+      <characteristics>
+        <characteristic characteristicId="420c-6e7d-0b96-4289" name="Range" value="3&quot;"/>
+        <characteristic characteristicId="229e-c54a-7785-0e0f" name="Attacks" value="3"/>
+        <characteristic characteristicId="bdcd-ebcf-f909-49d9" name="To Hit" value="3+"/>
+        <characteristic characteristicId="0088-422c-55f2-2361" name="To Wound" value="3+"/>
+        <characteristic characteristicId="1b60-6be0-3cd0-df54" name="Rend" value="-2"/>
+        <characteristic characteristicId="dace-95f3-a99b-89b6" name="Damage" value="*"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="f2e8-bf72-d131-8cc2" profileTypeId="69e7-9460-0985-44b0" name="Massive Impaling Talons" hidden="false">
+      <characteristics>
+        <characteristic characteristicId="420c-6e7d-0b96-4289" name="Range" value="1&quot;"/>
+        <characteristic characteristicId="229e-c54a-7785-0e0f" name="Attacks" value="1"/>
+        <characteristic characteristicId="bdcd-ebcf-f909-49d9" name="To Hit" value="3+"/>
+        <characteristic characteristicId="0088-422c-55f2-2361" name="To Wound" value="*"/>
+        <characteristic characteristicId="1b60-6be0-3cd0-df54" name="Rend" value="-2"/>
+        <characteristic characteristicId="dace-95f3-a99b-89b6" name="Damage" value="1"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
     <profile id="2b65-c372-dd60-53b0" profileTypeId="69e7-9460-0985-44b0" name="Piercing Talons" hidden="false" book="WEW" page="16">
       <characteristics>
         <characteristic characteristicId="420c-6e7d-0b96-4289" name="Range" value="2&quot;"/>
@@ -844,6 +1112,17 @@
         <characteristic characteristicId="0088-422c-55f2-2361" name="To Wound" value="5+"/>
         <characteristic characteristicId="1b60-6be0-3cd0-df54" name="Rend" value="-"/>
         <characteristic characteristicId="dace-95f3-a99b-89b6" name="Damage" value="1"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="a65f-a441-aa32-73d9" profileTypeId="69e7-9460-0985-44b0" name="Sweeping Blows" hidden="false">
+      <characteristics>
+        <characteristic characteristicId="420c-6e7d-0b96-4289" name="Range" value="3&quot;"/>
+        <characteristic characteristicId="229e-c54a-7785-0e0f" name="Attacks" value="*"/>
+        <characteristic characteristicId="bdcd-ebcf-f909-49d9" name="To Hit" value="3+"/>
+        <characteristic characteristicId="0088-422c-55f2-2361" name="To Wound" value="3+"/>
+        <characteristic characteristicId="1b60-6be0-3cd0-df54" name="Rend" value="-1"/>
+        <characteristic characteristicId="dace-95f3-a99b-89b6" name="Damage" value="D6"/>
       </characteristics>
       <modifiers/>
     </profile>

--- a/Stormcast_Eternals_Warscrolls.cat
+++ b/Stormcast_Eternals_Warscrolls.cat
@@ -1,0 +1,504 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="2f75-cde7-4cdb-1210" revision="1" gameSystemId="13ba-994f-8c12-9f8d" gameSystemRevision="3" battleScribeVersion="1.15" name="Stormcast Eternals Warscrolls" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <entries>
+    <entry id="286d-8afd-87c2-ebaf" name="Gryph-hounds" points="0.0" categoryId="e092-c885-923d-1c82" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries>
+        <entry id="4d67-dccf-8058-ceb2" name="Gryph-hound" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules>
+            <rule id="06c1-35c5-3f28-39dd" name="[Ability] Loyal Companion" hidden="false">
+              <description>Once a Gryph-hound has bonded with a companion, it will defend it to the death. A Gryph-hound makes 4 attacks with its Beak and Claws rather than 2 if the target unit is within 3&quot; of a Lord-Castellant.</description>
+              <modifiers/>
+            </rule>
+            <rule id="72f0-fcf4-95ea-0173" name="[Ability] Darting attacks" hidden="false">
+              <description>Gryph-hounds attack in a series of darting strikes. Immediately after this unit attacks in the combat phase, roll a dice and move each model up to that many inches.</description>
+              <modifiers/>
+            </rule>
+            <rule id="58d7-69e2-56c5-2a5e" name="[Ability] Warning Cry" hidden="false">
+              <description>It is said that it is impossible to sneak up on a Gryph-hound. If an enemy unit is set up within 10&quot; of this unit, roll two dice. Any unit within that many inches of the Gryph-hounds is alerted to the enemy unit&apos;s presence, and can attack it with one of its weapons as though it were your shooting phase.</description>
+              <modifiers/>
+            </rule>
+            <rule id="6ff0-8f16-2bc8-7b63" name="[Keyword] Gryph-hounds" hidden="false">
+              <modifiers/>
+            </rule>
+          </rules>
+          <profiles/>
+          <links>
+            <link id="c418-52a6-7302-03b0" targetId="9f30-bc96-bd72-ebc3" linkType="profile">
+              <modifiers/>
+            </link>
+            <link id="a40f-f6a1-a431-e748" targetId="4860-946d-f9d6-7273" linkType="profile">
+              <modifiers/>
+            </link>
+            <link id="0419-422d-3ec0-f040" targetId="c10a-8c01-6cc7-79c3" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="48b5-41cb-ac7a-18d7" targetId="90f8-c45f-2fb7-d228" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="b866-20bd-5bb5-2b9f" targetId="5ecd-1fdb-46ae-a2c3" linkType="rule">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links/>
+    </entry>
+    <entry id="cde1-f466-62cb-3b96" name="Liberators" points="0.0" categoryId="e092-c885-923d-1c82" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries>
+        <entry id="3c55-0fb8-c297-32e3" name="Liberator" points="0.0" categoryId="(No Category)" type="model" minSelections="4" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="43c4-919e-3647-db40" targetId="a713-bf49-775e-a44c" linkType="profile">
+              <modifiers/>
+            </link>
+            <link id="2716-f2c1-841e-d792" targetId="0e3f-3a8a-b994-134b" linkType="entry group">
+              <modifiers>
+                <modifier type="increment" field="maxSelections" value="1.0" repeat="true" numRepeats="1" incrementParentId="cde1-f466-62cb-3b96" incrementChildId="3c55-0fb8-c297-32e3" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </link>
+          </links>
+        </entry>
+        <entry id="62db-07aa-cb50-f71d" name="Liberator Prime" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="3f93-a652-b39e-b935" targetId="4068-4071-a2f1-1b4b" linkType="entry group">
+              <modifiers/>
+            </link>
+            <link id="4016-e6a7-7f2b-da9e" targetId="a713-bf49-775e-a44c" linkType="profile">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="b014-76bd-5c90-0035" name="Usage restriction for Grandhammers and Grandblades" hidden="false">
+          <description>1 in every 5 models may instead be armed with either a Grandhammer, or a Grandblade.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links>
+        <link id="1da9-82e8-6013-1382" targetId="90f8-c45f-2fb7-d228" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="469a-4d7c-2fc5-886b" targetId="c10a-8c01-6cc7-79c3" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="476e-8f15-9b09-a327" targetId="1cf8-eebc-53b0-e612" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="831a-32d4-d94d-d7b9" targetId="5ecd-1fdb-46ae-a2c3" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="d764-dcd6-27f2-e26a" targetId="50ca-0d51-2fe4-c584" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="da31-37f9-c4d0-d38a" targetId="9ccb-7ceb-0961-0e44" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="a7f5-4886-cf1e-a9fa" targetId="37bd-edf2-1f3b-3697" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="a18d-b6dc-7cd7-6223" targetId="69cc-c899-f100-5c85" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="c9e4-e2b5-c59d-d443" targetId="53f0-3354-61ef-3b16" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="a0ab-03dd-f4c3-59c1" name="Lord-Castellant" points="0.0" categoryId="e092-c885-923d-1c82" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="a465-beb1-8a33-e83c" name="[Keyword] Lord-Castellant" hidden="false">
+          <modifiers/>
+        </rule>
+        <rule id="6736-0a49-e7fc-b8ee" name="[Ability] Warding Lantern" hidden="false">
+          <description>In your hero phase the Lord-Castellant may unleash the magical energies of his Warding Lantern. If he does so, pick either a Chaos unit or a Stormcast Eternal unit that is within 12&quot; of the Lord-Castellant.
+
+If a Chaos unit is chosen it is struck by the searing light of the Celestial Realm and suffers a mortal wound. Chaos Demon units cannot abide the touch of this light and suffer D3 mortal wounds instead.
+
+If a Stormcast Eternal unit is chosen it is bathed in the healing energies of the lantern and you can add 1 to all save rolls it has to make until your next hero phase. In addition, until your next hero phase, each time you make a save roll of 7 or more for that unit, one model in the unit heals a wound.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links>
+        <link id="0ba1-a136-9569-ad93" targetId="ea5e-c234-791a-e65d" linkType="profile">
+          <modifiers/>
+        </link>
+        <link id="6de1-ef08-f863-10a1" targetId="c10a-8c01-6cc7-79c3" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="e399-8503-fe13-2c17" targetId="17f4-66b0-1369-0bd9" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="6734-49ac-24cf-00c2" targetId="1cf8-eebc-53b0-e612" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="a2a8-d01f-3337-a489" targetId="90f8-c45f-2fb7-d228" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="826c-bbcf-a32e-d73e" targetId="5ecd-1fdb-46ae-a2c3" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="3510-3cd8-de25-7973" targetId="c128-5246-4bab-6110" linkType="profile">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="a562-def4-790d-28ed" name="Lord-Celestant" points="0.0" categoryId="e092-c885-923d-1c82" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="bc81-822d-bae1-e914" name="[Keyword] Lord-Celestant" hidden="false">
+          <modifiers/>
+        </rule>
+        <rule id="2f2c-d60e-049f-0aef" name="[Ability] Inescapable Vengeance" hidden="false">
+          <description>If this model has made a charge move this turn, it can make 1 extra attack with each of its melee weapons.</description>
+          <modifiers/>
+        </rule>
+        <rule id="7bca-a1e9-9e3c-46dd" name="[Ability] Sigmarite Warcloak" hidden="false">
+          <description>In your shooting phase, you can unleash D6 hammers from this model&apos;s Sigmarite Warcloak. Pick an enemy unit within 16&quot; of this model for each hammer that is unleashed, then roll a dice for each unit you picked. On a roll of 4 or more the unit suffers a mortal wound. Note that you can pick the same unit more than once in a phase.</description>
+          <modifiers/>
+        </rule>
+        <rule id="61bf-a3db-679e-2e8f" name="[Command Ability] Furious Retribution" hidden="false">
+          <description>If this model is your general and uses this ability, then until your next hero phase you can add 1 to the results of any hit rolls in the combat phase for this model and friendly Stormcast Eternal units within 9&quot; of him.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links>
+        <link id="ed3f-b268-bf4f-83e9" targetId="6fd4-9311-be46-30bf" linkType="profile">
+          <modifiers/>
+        </link>
+        <link id="4546-bf41-973c-851d" targetId="c10a-8c01-6cc7-79c3" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="69dd-d1dc-9612-405e" targetId="1cf8-eebc-53b0-e612" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="0669-ae53-4563-1370" targetId="90f8-c45f-2fb7-d228" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="36aa-7eed-7460-e063" targetId="5ecd-1fdb-46ae-a2c3" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="6ac2-a22c-d730-b7a8" targetId="17f4-66b0-1369-0bd9" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="a269-3fc2-31cb-f4f8" targetId="d09b-6f85-d21e-4b7c" linkType="profile">
+          <modifiers/>
+        </link>
+        <link id="129e-e02b-5edd-8c7e" targetId="39b8-85d7-a9f9-0010" linkType="profile">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+  </entries>
+  <rules/>
+  <links/>
+  <sharedEntries>
+    <entry id="2ead-97d0-c611-a094" name="Grandblade" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="41c8-4e32-0f01-8e53" targetId="441c-032e-3cab-b454" linkType="profile">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="fd5b-8fc1-ef4c-ca78" name="Grandhammer" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="0" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="a878-e2df-807d-763e" targetId="aed6-2d65-7556-c099" linkType="profile">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="b003-d928-e792-f76b" name="Sigmarite Runeblade" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="a1b3-3ae8-da48-f3d8" targetId="d09b-6f85-d21e-4b7c" linkType="profile">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="8537-d58c-f256-3fc7" name="Warblade" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="3db5-c8a8-339d-8e24" targetId="2154-a7d8-38c5-f500" linkType="profile">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="9f00-4134-f2d3-7894" name="Warhammer" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="8918-b0f7-17fe-2b2b" targetId="39b8-85d7-a9f9-0010" linkType="profile">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+  </sharedEntries>
+  <sharedEntryGroups>
+    <entryGroup id="4068-4071-a2f1-1b4b" name="Liberator Prime Weapon" defaultEntryId="b813-7450-8683-6eb6" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <links>
+        <link id="3ce9-0748-b83a-4e04" targetId="2ead-97d0-c611-a094" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="cd34-ed3b-9d46-9fa5" targetId="fd5b-8fc1-ef4c-ca78" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="fac9-9d01-9c0e-6807" targetId="8537-d58c-f256-3fc7" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="b813-7450-8683-6eb6" targetId="9f00-4134-f2d3-7894" linkType="entry">
+          <modifiers/>
+        </link>
+      </links>
+    </entryGroup>
+    <entryGroup id="0e3f-3a8a-b994-134b" name="Weapon" defaultEntryId="d745-dffe-baf4-67f0" minSelections="0" maxSelections="0" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <links>
+        <link id="5ad3-28dd-28d5-8f39" targetId="2ead-97d0-c611-a094" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="0767-cd78-79b1-ca53" targetId="fd5b-8fc1-ef4c-ca78" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="7aa7-3c4a-1352-032d" targetId="8537-d58c-f256-3fc7" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="d745-dffe-baf4-67f0" targetId="9f00-4134-f2d3-7894" linkType="entry">
+          <modifiers/>
+        </link>
+      </links>
+    </entryGroup>
+  </sharedEntryGroups>
+  <sharedRules>
+    <rule id="69cc-c899-f100-5c85" name="[Ability] Lay Low the Tyrants" hidden="false">
+      <description>If any model from this unit selects an enemy unit with a Wounds characteristic of 5 or more as the target for all of its attacks in a combat phase, add 1 to all of that model&apos;s hit rolls in that combat phase.</description>
+      <modifiers/>
+    </rule>
+    <rule id="37bd-edf2-1f3b-3697" name="[Ability] Paired Weapons" hidden="false">
+      <description>An extra weapon allows a Liberator to feint and parry, creating openings in their opponent&apos;s guard. You can re-roll hit rolls of 1 for models armed with more than one Warhammer or Warblade.</description>
+      <modifiers/>
+    </rule>
+    <rule id="53f0-3354-61ef-3b16" name="[Ability] Sigmarite Shields" hidden="false">
+      <description>You can re-roll save rolls of 1 for this unit if any models from the unit are carrying Sigmarite Shields.</description>
+      <modifiers/>
+    </rule>
+    <rule id="c10a-8c01-6cc7-79c3" name="[Keyword] Celestial" hidden="false">
+      <modifiers/>
+    </rule>
+    <rule id="17f4-66b0-1369-0bd9" name="[Keyword] Hero" hidden="false">
+      <modifiers/>
+    </rule>
+    <rule id="1cf8-eebc-53b0-e612" name="[Keyword] Human" hidden="false">
+      <modifiers/>
+    </rule>
+    <rule id="9ccb-7ceb-0961-0e44" name="[Keyword] Liberators" hidden="false">
+      <modifiers/>
+    </rule>
+    <rule id="90f8-c45f-2fb7-d228" name="[Keyword] Order" hidden="false">
+      <modifiers/>
+    </rule>
+    <rule id="50ca-0d51-2fe4-c584" name="[Keyword] Redeemer" hidden="false">
+      <modifiers/>
+    </rule>
+    <rule id="5ecd-1fdb-46ae-a2c3" name="[Keyword] Stormcast Eternal" hidden="false">
+      <modifiers/>
+    </rule>
+  </sharedRules>
+  <sharedProfiles>
+    <profile id="4860-946d-f9d6-7273" profileTypeId="69e7-9460-0985-44b0" name="Beak and Claws" hidden="false">
+      <characteristics>
+        <characteristic characteristicId="420c-6e7d-0b96-4289" name="Range" value="1&quot;"/>
+        <characteristic characteristicId="229e-c54a-7785-0e0f" name="Attacks" value="2"/>
+        <characteristic characteristicId="bdcd-ebcf-f909-49d9" name="To Hit" value="3+"/>
+        <characteristic characteristicId="0088-422c-55f2-2361" name="To Wound" value="4+"/>
+        <characteristic characteristicId="1b60-6be0-3cd0-df54" name="Rend" value="-"/>
+        <characteristic characteristicId="dace-95f3-a99b-89b6" name="Damage" value="1"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="c128-5246-4bab-6110" profileTypeId="69e7-9460-0985-44b0" name="Castellant&apos;s Halberd" hidden="false">
+      <characteristics>
+        <characteristic characteristicId="420c-6e7d-0b96-4289" name="Range" value="2&quot;"/>
+        <characteristic characteristicId="229e-c54a-7785-0e0f" name="Attacks" value="3"/>
+        <characteristic characteristicId="bdcd-ebcf-f909-49d9" name="To Hit" value="3+"/>
+        <characteristic characteristicId="0088-422c-55f2-2361" name="To Wound" value="3+"/>
+        <characteristic characteristicId="1b60-6be0-3cd0-df54" name="Rend" value="-1"/>
+        <characteristic characteristicId="dace-95f3-a99b-89b6" name="Damage" value="2"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="441c-032e-3cab-b454" profileTypeId="69e7-9460-0985-44b0" name="Grandblade" hidden="false">
+      <characteristics>
+        <characteristic characteristicId="420c-6e7d-0b96-4289" name="Range" value="1&quot;"/>
+        <characteristic characteristicId="229e-c54a-7785-0e0f" name="Attacks" value="2"/>
+        <characteristic characteristicId="bdcd-ebcf-f909-49d9" name="To Hit" value="3+"/>
+        <characteristic characteristicId="0088-422c-55f2-2361" name="To Wound" value="4+"/>
+        <characteristic characteristicId="1b60-6be0-3cd0-df54" name="Rend" value="-1"/>
+        <characteristic characteristicId="dace-95f3-a99b-89b6" name="Damage" value="2"/>
+      </characteristics>
+      <modifiers>
+        <modifier type="set" field="229e-c54a-7785-0e0f" value="3" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+          <conditions>
+            <condition parentId="direct parent" childId="62db-07aa-cb50-f71d" field="selections" type="instance of" value="0.0"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+    </profile>
+    <profile id="aed6-2d65-7556-c099" profileTypeId="69e7-9460-0985-44b0" name="Grandhammer" hidden="false">
+      <characteristics>
+        <characteristic characteristicId="420c-6e7d-0b96-4289" name="Range" value="1&quot;"/>
+        <characteristic characteristicId="229e-c54a-7785-0e0f" name="Attacks" value="2"/>
+        <characteristic characteristicId="bdcd-ebcf-f909-49d9" name="To Hit" value="4+"/>
+        <characteristic characteristicId="0088-422c-55f2-2361" name="To Wound" value="3+"/>
+        <characteristic characteristicId="1b60-6be0-3cd0-df54" name="Rend" value="-1"/>
+        <characteristic characteristicId="dace-95f3-a99b-89b6" name="Damage" value="2"/>
+      </characteristics>
+      <modifiers>
+        <modifier type="set" field="229e-c54a-7785-0e0f" value="3" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+          <conditions>
+            <condition parentId="direct parent" childId="62db-07aa-cb50-f71d" field="selections" type="instance of" value="0.0"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+    </profile>
+    <profile id="9f30-bc96-bd72-ebc3" profileTypeId="d42a-7ddd-953b-4d23" name="Gryph-Hound" hidden="false">
+      <characteristics>
+        <characteristic characteristicId="0ae7-a2b1-6b97-8f4d" name="Move" value="9&quot;"/>
+        <characteristic characteristicId="0054-981e-bc82-2ce2" name="Wounds" value="3"/>
+        <characteristic characteristicId="d875-64d5-4fad-c5c3" name="Save" value="-"/>
+        <characteristic characteristicId="2b7b-be5f-5b04-1ec4" name="Bravery" value="6"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="a713-bf49-775e-a44c" profileTypeId="d42a-7ddd-953b-4d23" name="Liberator" hidden="false">
+      <characteristics>
+        <characteristic characteristicId="0ae7-a2b1-6b97-8f4d" name="Move" value="5&quot;"/>
+        <characteristic characteristicId="0054-981e-bc82-2ce2" name="Wounds" value="2"/>
+        <characteristic characteristicId="d875-64d5-4fad-c5c3" name="Save" value="4+"/>
+        <characteristic characteristicId="2b7b-be5f-5b04-1ec4" name="Bravery" value="6"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="ea5e-c234-791a-e65d" profileTypeId="d42a-7ddd-953b-4d23" name="Lord-Castellant" hidden="false">
+      <characteristics>
+        <characteristic characteristicId="0ae7-a2b1-6b97-8f4d" name="Move" value="5&quot;"/>
+        <characteristic characteristicId="0054-981e-bc82-2ce2" name="Wounds" value="6"/>
+        <characteristic characteristicId="d875-64d5-4fad-c5c3" name="Save" value="3+"/>
+        <characteristic characteristicId="2b7b-be5f-5b04-1ec4" name="Bravery" value="9"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="6fd4-9311-be46-30bf" profileTypeId="d42a-7ddd-953b-4d23" name="Lord-Celestant" hidden="false">
+      <characteristics>
+        <characteristic characteristicId="0ae7-a2b1-6b97-8f4d" name="Move" value="5&quot;"/>
+        <characteristic characteristicId="0054-981e-bc82-2ce2" name="Wounds" value="5"/>
+        <characteristic characteristicId="d875-64d5-4fad-c5c3" name="Save" value="3+"/>
+        <characteristic characteristicId="2b7b-be5f-5b04-1ec4" name="Bravery" value="9"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="d09b-6f85-d21e-4b7c" profileTypeId="69e7-9460-0985-44b0" name="Sigmarite Runeblade" hidden="false">
+      <characteristics>
+        <characteristic characteristicId="420c-6e7d-0b96-4289" name="Range" value="1&quot;"/>
+        <characteristic characteristicId="229e-c54a-7785-0e0f" name="Attacks" value="4"/>
+        <characteristic characteristicId="bdcd-ebcf-f909-49d9" name="To Hit" value="3+"/>
+        <characteristic characteristicId="0088-422c-55f2-2361" name="To Wound" value="3+"/>
+        <characteristic characteristicId="1b60-6be0-3cd0-df54" name="Rend" value="-1"/>
+        <characteristic characteristicId="dace-95f3-a99b-89b6" name="Damage" value="1"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="2154-a7d8-38c5-f500" profileTypeId="69e7-9460-0985-44b0" name="Warblade" hidden="false">
+      <characteristics>
+        <characteristic characteristicId="420c-6e7d-0b96-4289" name="Range" value="1&quot;"/>
+        <characteristic characteristicId="229e-c54a-7785-0e0f" name="Attacks" value="2"/>
+        <characteristic characteristicId="bdcd-ebcf-f909-49d9" name="To Hit" value="3+"/>
+        <characteristic characteristicId="0088-422c-55f2-2361" name="To Wound" value="4+"/>
+        <characteristic characteristicId="1b60-6be0-3cd0-df54" name="Rend" value="-"/>
+        <characteristic characteristicId="dace-95f3-a99b-89b6" name="Damage" value="1"/>
+      </characteristics>
+      <modifiers>
+        <modifier type="set" field="229e-c54a-7785-0e0f" value="3" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+          <conditions>
+            <condition parentId="direct parent" childId="62db-07aa-cb50-f71d" field="selections" type="instance of" value="0.0"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+    </profile>
+    <profile id="39b8-85d7-a9f9-0010" profileTypeId="69e7-9460-0985-44b0" name="Warhammer" hidden="false">
+      <characteristics>
+        <characteristic characteristicId="420c-6e7d-0b96-4289" name="Range" value="1&quot;"/>
+        <characteristic characteristicId="229e-c54a-7785-0e0f" name="Attacks" value="2"/>
+        <characteristic characteristicId="bdcd-ebcf-f909-49d9" name="To Hit" value="4+"/>
+        <characteristic characteristicId="0088-422c-55f2-2361" name="To Wound" value="3+"/>
+        <characteristic characteristicId="1b60-6be0-3cd0-df54" name="Rend" value="-"/>
+        <characteristic characteristicId="dace-95f3-a99b-89b6" name="Damage" value="1"/>
+      </characteristics>
+      <modifiers>
+        <modifier type="set" field="229e-c54a-7785-0e0f" value="3" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+          <conditions>
+            <condition parentId="direct parent" childId="62db-07aa-cb50-f71d" field="selections" type="instance of" value="0.0"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+    </profile>
+  </sharedProfiles>
+</catalogue>

--- a/Sylvaneth.cat
+++ b/Sylvaneth.cat
@@ -342,16 +342,25 @@
         </link>
       </links>
     </entry>
-    <entry id="cac2-b4a9-380b-0ce6" name="Sylvaneth Wyldwood" points="0.0" categoryId="c96d-1643-ed56-ba60" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
+    <entry id="cac2-b4a9-380b-0ce6" name="Sylvaneth Wyldwood" points="0.0" categoryId="c96d-1643-ed56-ba60" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries>
+        <entry id="8b3d-2777-e27c-d31e" name="Citadel Wood" points="0.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links/>
+        </entry>
+      </entries>
       <entryGroups/>
       <modifiers/>
       <rules>
-        <rule id="2858-7465-6017-693b" name="Wyldwood" hidden="false">
+        <rule id="2858-7465-6017-693b" name="[Scenery] Wyldwood" hidden="false">
           <description> Roll a dice for each model that makes a run or charge move across, or finishing on, a Sylvaneth Wyldwood. On a roll of 1 the model is slain. Do not roll for models that have the Sylvaneth, Monster, or Hero keywords. </description>
           <modifiers/>
         </rule>
-        <rule id="7ac6-0edf-c184-02dd" name="Roused by Magic" hidden="false">
+        <rule id="7ac6-0edf-c184-02dd" name="[Scenery] Roused by Magic" hidden="false">
           <description> Roll a dice whenever a spell is successfully cast within 6&quot; of a Sylvaneth Wyldwood (even if it is unbound). On a roll of 5 or more the forest is roused by the magical energy and attacks. If this happens, all units within 1&quot; of the Sylvaneth Wyldwood suffer D3 mortal wounds. Sylvaneth units are not attacked if a Wyldwood is roused in this way.</description>
           <modifiers/>
         </rule>

--- a/Sylvaneth.cat
+++ b/Sylvaneth.cat
@@ -193,6 +193,9 @@
         <link id="85e2-f597-e6af-36e1" targetId="2ed2-e02a-e948-67a9" linkType="rule">
           <modifiers/>
         </link>
+        <link id="a1ad-6480-0c6e-c2f9" targetId="aed5-b376-f968-1ade" linkType="profile">
+          <modifiers/>
+        </link>
       </links>
     </entry>
     <entry id="db73-b360-cb20-bd06" name="Sylvaneth Treelord" points="0.0" categoryId="c96d-1643-ed56-ba60" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">

--- a/Sylvaneth.cat
+++ b/Sylvaneth.cat
@@ -1,0 +1,434 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="6edd-afbd-20c7-9ac2" revision="1" gameSystemId="13ba-994f-8c12-9f8d" gameSystemRevision="3" battleScribeVersion="1.15" name="Sylvaneth" authorName="Chevalric" authorContact="chevalric@gmail.com" authorUrl="https://github.com/chevalric" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <entries>
+    <entry id="53cc-89df-44cf-9998" name="Branchwraith" points="0.0" categoryId="c96d-1643-ed56-ba60" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="1f91-c7bb-b952-3188" name="[Keyword] Branchwraith" hidden="false">
+          <modifiers/>
+        </rule>
+        <rule id="18fc-0e67-a002-49ff" name="[Spell] Roused to Wrath" hidden="false">
+          <description>Roused to Wrath has a casting value of 7. If successfully cast, set up a unit of 2D6 Dryads more than 3&quot; from the enemy, and fully within a Sylvaneth Wyldwood that is within 12&quot; of the caster.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="9e64-2b81-c134-e2f4" profileTypeId="d42a-7ddd-953b-4d23" name="Branchwraith" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="0ae7-a2b1-6b97-8f4d" name="Move" value="7&quot;"/>
+            <characteristic characteristicId="0054-981e-bc82-2ce2" name="Wounds" value="5"/>
+            <characteristic characteristicId="d875-64d5-4fad-c5c3" name="Save" value="5+"/>
+            <characteristic characteristicId="2b7b-be5f-5b04-1ec4" name="Bravery" value="8"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+        <profile id="8ab1-e545-819d-5238" profileTypeId="69e7-9460-0985-44b0" name="Piercing Talons" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="420c-6e7d-0b96-4289" name="Range" value="2&quot;"/>
+            <characteristic characteristicId="229e-c54a-7785-0e0f" name="Attacks" value="3"/>
+            <characteristic characteristicId="bdcd-ebcf-f909-49d9" name="To Hit" value="4+"/>
+            <characteristic characteristicId="0088-422c-55f2-2361" name="To Wound" value="4+"/>
+            <characteristic characteristicId="1b60-6be0-3cd0-df54" name="Rend" value="-1"/>
+            <characteristic characteristicId="dace-95f3-a99b-89b6" name="Damage" value="1"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="513f-aba6-878f-8db6" targetId="6fad-cc87-7c05-ed33" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="38e3-6d48-3778-fa34" targetId="686f-1c35-187d-37d9" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="6aca-b5d2-0317-f141" targetId="9652-d810-618b-df90" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="f74d-fd42-62cc-089f" targetId="1d61-0e3c-f60a-ac2a" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="12e6-830f-f567-c5a4" targetId="ea62-123b-a4de-cf72" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="3ef7-276e-ef2c-9963" name="Dryads" points="0.0" categoryId="c96d-1643-ed56-ba60" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries>
+        <entry id="6fa0-4d08-d70f-cf31" name="Dryad" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="5" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules>
+            <rule id="2a19-6837-0f1b-fade" name="[Keyword] Dryad" hidden="false">
+              <modifiers/>
+            </rule>
+            <rule id="d66d-e121-d35c-dd4b" name="[Ability] Enrapturing Song" hidden="false">
+              <description> In your own combat phase, you can enrapture one enemy unit that is within 3&quot; of this unit. Add 1 to the hit rolls for attacks made by this unit against the enraptured unit in that combat phase.</description>
+              <modifiers/>
+            </rule>
+            <rule id="be0a-00f5-63be-9332" name="[Ability] Impenetrable Shield" hidden="false">
+              <description>When Dryads gather in great numbers their many twisting limbs and branches form an interlocking shield of thorns that protects them against the enemy’s blows. You can add 1 to the result of save rolls for this unit if it includes at least 12 models.</description>
+              <modifiers/>
+            </rule>
+          </rules>
+          <profiles>
+            <profile id="d900-6b81-84e5-445d" profileTypeId="d42a-7ddd-953b-4d23" name="Dryad" hidden="false">
+              <characteristics>
+                <characteristic characteristicId="0ae7-a2b1-6b97-8f4d" name="Move" value="7&quot;"/>
+                <characteristic characteristicId="0054-981e-bc82-2ce2" name="Wounds" value="1"/>
+                <characteristic characteristicId="d875-64d5-4fad-c5c3" name="Save" value="5+"/>
+                <characteristic characteristicId="2b7b-be5f-5b04-1ec4" name="Bravery" value="6"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+            <profile id="ded7-1438-9204-5131" profileTypeId="69e7-9460-0985-44b0" name="Wracking Talons" hidden="false">
+              <characteristics>
+                <characteristic characteristicId="420c-6e7d-0b96-4289" name="Range" value="2&quot;"/>
+                <characteristic characteristicId="229e-c54a-7785-0e0f" name="Attacks" value="2"/>
+                <characteristic characteristicId="bdcd-ebcf-f909-49d9" name="To Hit" value="4+"/>
+                <characteristic characteristicId="0088-422c-55f2-2361" name="To Wound" value="4+"/>
+                <characteristic characteristicId="1b60-6be0-3cd0-df54" name="Rend" value="-"/>
+                <characteristic characteristicId="dace-95f3-a99b-89b6" name="Damage" value="1"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links>
+            <link id="7be2-ca93-adce-e275" targetId="ea62-123b-a4de-cf72" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="70a0-c790-8880-38c7" targetId="686f-1c35-187d-37d9" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="89a7-43b4-7567-cdff" targetId="6fad-cc87-7c05-ed33" linkType="rule">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links/>
+    </entry>
+    <entry id="0691-0723-8e85-ce42" name="Durthu" points="0.0" categoryId="c96d-1643-ed56-ba60" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="013e-2669-bb70-09d1" name="[Keyword] Durthu" hidden="false">
+          <modifiers/>
+        </rule>
+        <rule id="f684-498f-6f4f-7638" name="Durthu Damage Table" hidden="false">
+          <description>&lt;table&gt;
+&lt;tr&gt;&lt;th colspan=&quot;4&quot;&gt;DAMAGE TABLE&lt;/th&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;th&gt;Wounds suffered&lt;/th&gt;&lt;th&gt;Lamentations of Despair&lt;/th&gt;&lt;th&gt;Eldar Wrath Sword&lt;/th&gt;&lt;th&gt;Massive Impaling Talons&lt;/th&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;0-2&lt;/td&gt;&lt;td&gt;12&lt;/td&gt;&lt;td&gt;6&lt;/td&gt;&lt;td&gt;2+&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;3-4&lt;/td&gt;&lt;td&gt;10&lt;/td&gt;&lt;td&gt;D6&lt;/td&gt;&lt;td&gt;2+&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;5-7&lt;/td&gt;&lt;td&gt;8&lt;/td&gt;&lt;td&gt;D6&lt;/td&gt;&lt;td&gt;3+&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;8-9&lt;/td&gt;&lt;td&gt;6&lt;/td&gt;&lt;td&gt;D6&lt;/td&gt;&lt;td&gt;3+&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;10+&lt;/td&gt;&lt;td&gt;4&lt;/td&gt;&lt;td&gt;D3&lt;/td&gt;&lt;td&gt;4+&lt;/td&gt;&lt;/tr&gt;
+&lt;/table&gt;</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="2877-f4c4-4c16-4e34" profileTypeId="69e7-9460-0985-44b0" name="Eldar Wrath Sword" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="420c-6e7d-0b96-4289" name="Range" value="3&quot;"/>
+            <characteristic characteristicId="229e-c54a-7785-0e0f" name="Attacks" value="3"/>
+            <characteristic characteristicId="bdcd-ebcf-f909-49d9" name="To Hit" value="3+"/>
+            <characteristic characteristicId="0088-422c-55f2-2361" name="To Wound" value="3+"/>
+            <characteristic characteristicId="1b60-6be0-3cd0-df54" name="Rend" value="-2"/>
+            <characteristic characteristicId="dace-95f3-a99b-89b6" name="Damage" value="*"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+        <profile id="813c-c2e6-aec3-934e" profileTypeId="69e7-9460-0985-44b0" name="Lamentations of Despair" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="420c-6e7d-0b96-4289" name="Range" value="10&quot;"/>
+            <characteristic characteristicId="229e-c54a-7785-0e0f" name="Attacks" value="*"/>
+            <characteristic characteristicId="bdcd-ebcf-f909-49d9" name="To Hit" value="3+"/>
+            <characteristic characteristicId="0088-422c-55f2-2361" name="To Wound" value="5+"/>
+            <characteristic characteristicId="1b60-6be0-3cd0-df54" name="Rend" value="-"/>
+            <characteristic characteristicId="dace-95f3-a99b-89b6" name="Damage" value="1"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+        <profile id="7859-9383-beca-0fc3" profileTypeId="d42a-7ddd-953b-4d23" name="Durthu" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="0ae7-a2b1-6b97-8f4d" name="Move" value="5&quot;"/>
+            <characteristic characteristicId="0054-981e-bc82-2ce2" name="Wounds" value="12"/>
+            <characteristic characteristicId="d875-64d5-4fad-c5c3" name="Save" value="3+"/>
+            <characteristic characteristicId="2b7b-be5f-5b04-1ec4" name="Bravery" value="9"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="86e1-1383-5b08-7045" targetId="d9c0-8d85-d150-f46c" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="be43-6f9d-7b67-0a0e" targetId="6fad-cc87-7c05-ed33" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="6f3f-92af-2dcb-3c6a" targetId="686f-1c35-187d-37d9" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="b1ca-6125-d87d-d392" targetId="1d61-0e3c-f60a-ac2a" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="78e1-7448-60c8-2698" targetId="7122-d8d5-ab6c-c2e0" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="32fe-603f-36fd-fbf2" targetId="fadd-4001-d9dc-40db" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="01dc-adbf-5200-5cc7" targetId="25cc-8c49-fe50-c08a" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="85e2-f597-e6af-36e1" targetId="2ed2-e02a-e948-67a9" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="db73-b360-cb20-bd06" name="Sylvaneth Treelord" points="0.0" categoryId="c96d-1643-ed56-ba60" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="f12f-65d6-957b-8d92" name="Sylvaneth Treelord Damage Table" hidden="false">
+          <description>&lt;table&gt;
+&lt;tr&gt;&lt;th colspan=&quot;4&quot;&gt;DAMAGE TABLE&lt;/th&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;th&gt;Wounds suffered&lt;/th&gt;&lt;th&gt;Strangleroots&lt;/th&gt;&lt;th&gt;Sweeping blows&lt;/th&gt;&lt;th&gt;Massive Impaling Talons&lt;/th&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;0-2&lt;/td&gt;&lt;td&gt;2+&lt;/td&gt;&lt;td&gt;4&lt;/td&gt;&lt;td&gt;2+&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;3-4&lt;/td&gt;&lt;td&gt;3+&lt;/td&gt;&lt;td&gt;3&lt;/td&gt;&lt;td&gt;2+&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;5-7&lt;/td&gt;&lt;td&gt;4+&lt;/td&gt;&lt;td&gt;2&lt;/td&gt;&lt;td&gt;3+&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;8-9&lt;/td&gt;&lt;td&gt;5+&lt;/td&gt;&lt;td&gt;2&lt;/td&gt;&lt;td&gt;3+&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;10+&lt;/td&gt;&lt;td&gt;6+&lt;/td&gt;&lt;td&gt;1&lt;/td&gt;&lt;td&gt;4+&lt;/td&gt;&lt;/tr&gt;
+&lt;/table&gt;</description>
+          <modifiers/>
+        </rule>
+        <rule id="ca69-541d-b822-b067" name="[Keyword] Treelord" hidden="false">
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="2c41-ecd9-b313-f722" profileTypeId="69e7-9460-0985-44b0" name="Strangleroots" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="420c-6e7d-0b96-4289" name="Range" value="12&quot;"/>
+            <characteristic characteristicId="229e-c54a-7785-0e0f" name="Attacks" value="5"/>
+            <characteristic characteristicId="bdcd-ebcf-f909-49d9" name="To Hit" value="*"/>
+            <characteristic characteristicId="0088-422c-55f2-2361" name="To Wound" value="3+"/>
+            <characteristic characteristicId="1b60-6be0-3cd0-df54" name="Rend" value="-1"/>
+            <characteristic characteristicId="dace-95f3-a99b-89b6" name="Damage" value="1"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+        <profile id="f9a5-4fa1-2ada-6eec" profileTypeId="d42a-7ddd-953b-4d23" name="Sylvaneth Treelord" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="0ae7-a2b1-6b97-8f4d" name="Move" value="6&quot;"/>
+            <characteristic characteristicId="0054-981e-bc82-2ce2" name="Wounds" value="12"/>
+            <characteristic characteristicId="d875-64d5-4fad-c5c3" name="Save" value="3+"/>
+            <characteristic characteristicId="2b7b-be5f-5b04-1ec4" name="Bravery" value="6"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="2556-5626-e1e2-e82c" targetId="6fad-cc87-7c05-ed33" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="47a2-cc28-7dba-d57d" targetId="686f-1c35-187d-37d9" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="94d2-6923-8f6e-fbdb" targetId="7122-d8d5-ab6c-c2e0" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="960d-0277-0848-9de5" targetId="fadd-4001-d9dc-40db" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="0d5f-47c0-3bec-4780" targetId="25cc-8c49-fe50-c08a" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="ec49-5810-42c3-b624" targetId="2ed2-e02a-e948-67a9" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="ad7f-ba99-f8fd-7c29" targetId="aab2-fe74-b781-76f2" linkType="profile">
+          <modifiers/>
+        </link>
+        <link id="453c-54b6-84b3-eb1a" targetId="aed5-b376-f968-1ade" linkType="profile">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="1471-063b-2b4e-11a3" name="Sylvaneth Treelord Ancient" points="0.0" categoryId="c96d-1643-ed56-ba60" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="8047-d8c4-bcc3-51f7" name="[Keyword] Treelord Ancient" hidden="false">
+          <modifiers/>
+        </rule>
+        <rule id="0063-70f6-5aab-991a" name="Sylvaneth Treelord Ancient Damage Table" hidden="false">
+          <description>&lt;table&gt;
+&lt;tr&gt;&lt;th colspan=&quot;4&quot;&gt;DAMAGE TABLE&lt;/th&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;th&gt;Wounds suffered&lt;/th&gt;&lt;th&gt;Doom Tendril Staff&lt;/th&gt;&lt;th&gt;Sweeping blows&lt;/th&gt;&lt;th&gt;Massive Impaling Talons&lt;/th&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;0-2&lt;/td&gt;&lt;td&gt;2+&lt;/td&gt;&lt;td&gt;3&lt;/td&gt;&lt;td&gt;2+&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;3-4&lt;/td&gt;&lt;td&gt;3+&lt;/td&gt;&lt;td&gt;2&lt;/td&gt;&lt;td&gt;2+&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;5-7&lt;/td&gt;&lt;td&gt;4+&lt;/td&gt;&lt;td&gt;2&lt;/td&gt;&lt;td&gt;3+&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;8-9&lt;/td&gt;&lt;td&gt;5+&lt;/td&gt;&lt;td&gt;1&lt;/td&gt;&lt;td&gt;3+&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;10+&lt;/td&gt;&lt;td&gt;6+&lt;/td&gt;&lt;td&gt;1&lt;/td&gt;&lt;td&gt;4+&lt;/td&gt;&lt;/tr&gt;
+&lt;/table&gt;</description>
+          <modifiers/>
+        </rule>
+        <rule id="e77c-3558-0dbe-0f4c" name="[Spell] Awakening the Wood" hidden="false">
+          <description>Awakening the Wood has a casting value of 6. If successfully cast, pick a Sylvaneth Wyldwood that is within 24&quot; of the caster. Each enemy unit within 3&quot; of this Sylvaneth Wyldwood suffers D3 mortal wounds as the trees come to life and attack with twisted branches and thorny boughs. </description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="d06e-e5b2-c487-8388" profileTypeId="69e7-9460-0985-44b0" name="Doom Tendril Staff" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="420c-6e7d-0b96-4289" name="Range" value="18&quot;"/>
+            <characteristic characteristicId="229e-c54a-7785-0e0f" name="Attacks" value="1"/>
+            <characteristic characteristicId="bdcd-ebcf-f909-49d9" name="To Hit" value="*"/>
+            <characteristic characteristicId="0088-422c-55f2-2361" name="To Wound" value="3+"/>
+            <characteristic characteristicId="1b60-6be0-3cd0-df54" name="Rend" value="-1"/>
+            <characteristic characteristicId="dace-95f3-a99b-89b6" name="Damage" value="D6"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+        <profile id="ce85-4c71-4293-c79f" profileTypeId="d42a-7ddd-953b-4d23" name="Sylvaneth Treelord" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="0ae7-a2b1-6b97-8f4d" name="Move" value="5&quot;"/>
+            <characteristic characteristicId="0054-981e-bc82-2ce2" name="Wounds" value="12"/>
+            <characteristic characteristicId="d875-64d5-4fad-c5c3" name="Save" value="3+"/>
+            <characteristic characteristicId="2b7b-be5f-5b04-1ec4" name="Bravery" value="9"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="0d81-0b59-b05e-8b6c" targetId="6fad-cc87-7c05-ed33" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="c141-80c0-36f0-1fad" targetId="686f-1c35-187d-37d9" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="e88c-4cd2-fdf6-ae47" targetId="7122-d8d5-ab6c-c2e0" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="c269-a3b0-4026-267b" targetId="fadd-4001-d9dc-40db" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="ad27-3360-406b-d51f" targetId="25cc-8c49-fe50-c08a" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="ba0d-38cd-1ecf-bf68" targetId="2ed2-e02a-e948-67a9" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="1781-0aa4-4296-b81a" targetId="9652-d810-618b-df90" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="19bc-cd1f-2d2d-6d44" targetId="aed5-b376-f968-1ade" linkType="profile">
+          <modifiers/>
+        </link>
+        <link id="9e22-cdd6-469d-d3cb" targetId="aab2-fe74-b781-76f2" linkType="profile">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="cac2-b4a9-380b-0ce6" name="Sylvaneth Wyldwood" points="0.0" categoryId="c96d-1643-ed56-ba60" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="2858-7465-6017-693b" name="Wyldwood" hidden="false">
+          <description> Roll a dice for each model that makes a run or charge move across, or finishing on, a Sylvaneth Wyldwood. On a roll of 1 the model is slain. Do not roll for models that have the Sylvaneth, Monster, or Hero keywords. </description>
+          <modifiers/>
+        </rule>
+        <rule id="7ac6-0edf-c184-02dd" name="Roused by Magic" hidden="false">
+          <description> Roll a dice whenever a spell is successfully cast within 6&quot; of a Sylvaneth Wyldwood (even if it is unbound). On a roll of 5 or more the forest is roused by the magical energy and attacks. If this happens, all units within 1&quot; of the Sylvaneth Wyldwood suffer D3 mortal wounds. Sylvaneth units are not attacked if a Wyldwood is roused in this way.</description>
+          <modifiers/>
+        </rule>
+        <rule id="00a7-3653-2cd7-9761" name="[Keyword] Scenery" hidden="false">
+          <modifiers/>
+        </rule>
+        <rule id="2626-dbfb-2d0a-91b7" name="[Keyword] Sylvaneth Wyldwood" hidden="false">
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links/>
+    </entry>
+  </entries>
+  <rules/>
+  <links/>
+  <sharedEntries/>
+  <sharedEntryGroups/>
+  <sharedRules>
+    <rule id="ea62-123b-a4de-cf72" name="[Ability] Blessings of the Forest" hidden="false">
+      <description>Subtract 1 from all hit rolls made against this unit if it is within 3&quot; of a Sylvaneth Wyldwood.</description>
+      <modifiers/>
+    </rule>
+    <rule id="d9c0-8d85-d150-f46c" name="[Ability] Eldar Wrath Sword" hidden="false">
+      <description>This model makes an extra D3 attacks with the Elder Wrath Sword if he is within 3&amp;quot; of a Sylvaneth Wyldwood when he attacks in the combat phase.</description>
+      <modifiers/>
+    </rule>
+    <rule id="fadd-4001-d9dc-40db" name="[Ability] Groundshaking stomp" hidden="false">
+      <description>At the start of the combat phase this model stomps the ground; roll a dice for each enemy unit within 3&quot; of this model. On a roll of 4 or more that unit is knocked off their feet by the impact and must subtract 1 from all hit rolls in that combat phase as they regain their footing.</description>
+      <modifiers/>
+    </rule>
+    <rule id="25cc-8c49-fe50-c08a" name="[Ability] Impale" hidden="false">
+      <description>If Massive Impaling Talons inflict a wound on an enemy model, roll a dice and subtract 1 from the roll. If the result equals or exceeds the number of wounds the enemy model has remaining, it is slain.</description>
+      <modifiers/>
+    </rule>
+    <rule id="2ed2-e02a-e948-67a9" name="[Ability] Spirit paths" hidden="false">
+      <description>If this model is within 3&quot; of a Sylvaneth Wyldwood at the start of your movement phase, he can travel along the spirit paths. If he does so, remove this model from the battlefield, and then set him up within 3&quot; of a different Sylvaneth Wyldwood, more than 9&quot; from any enemy models. This is his move for the movement phase.</description>
+      <modifiers/>
+    </rule>
+    <rule id="1d61-0e3c-f60a-ac2a" name="[Keyword] Hero" hidden="false">
+      <modifiers/>
+    </rule>
+    <rule id="7122-d8d5-ab6c-c2e0" name="[Keyword] Monster" hidden="false">
+      <modifiers/>
+    </rule>
+    <rule id="686f-1c35-187d-37d9" name="[Keyword] Order" hidden="false">
+      <modifiers/>
+    </rule>
+    <rule id="6fad-cc87-7c05-ed33" name="[Keyword] Sylvaneth" hidden="false">
+      <modifiers/>
+    </rule>
+    <rule id="9652-d810-618b-df90" name="[Keyword] Wizard" hidden="false">
+      <modifiers/>
+    </rule>
+  </sharedRules>
+  <sharedProfiles>
+    <profile id="aed5-b376-f968-1ade" profileTypeId="69e7-9460-0985-44b0" name="Massive Impaling Talons" hidden="false">
+      <characteristics>
+        <characteristic characteristicId="420c-6e7d-0b96-4289" name="Range" value="1&quot;"/>
+        <characteristic characteristicId="229e-c54a-7785-0e0f" name="Attacks" value="1"/>
+        <characteristic characteristicId="bdcd-ebcf-f909-49d9" name="To Hit" value="3+"/>
+        <characteristic characteristicId="0088-422c-55f2-2361" name="To Wound" value="*"/>
+        <characteristic characteristicId="1b60-6be0-3cd0-df54" name="Rend" value="-2"/>
+        <characteristic characteristicId="dace-95f3-a99b-89b6" name="Damage" value="1"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="aab2-fe74-b781-76f2" profileTypeId="69e7-9460-0985-44b0" name="Sweeping blows" hidden="false">
+      <characteristics>
+        <characteristic characteristicId="420c-6e7d-0b96-4289" name="Range" value="3&quot;"/>
+        <characteristic characteristicId="229e-c54a-7785-0e0f" name="Attacks" value="*"/>
+        <characteristic characteristicId="bdcd-ebcf-f909-49d9" name="To Hit" value="3+"/>
+        <characteristic characteristicId="0088-422c-55f2-2361" name="To Wound" value="3+"/>
+        <characteristic characteristicId="1b60-6be0-3cd0-df54" name="Rend" value="-1"/>
+        <characteristic characteristicId="dace-95f3-a99b-89b6" name="Damage" value="D6"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+  </sharedProfiles>
+</catalogue>

--- a/Warhammer Age of Sigmar.gst
+++ b/Warhammer Age of Sigmar.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="13ba-994f-8c12-9f8d" revision="1" battleScribeVersion="1.15" name="Warhammer Age of Sigmar" authorName="Markus W. (taalas)" authorUrl="https://github.com/taalas" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="13ba-994f-8c12-9f8d" revision="3" battleScribeVersion="1.15" name="Warhammer Age of Sigmar" authorName="Markus W. (taalas)" authorUrl="https://github.com/taalas" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <forceTypes>
     <forceType id="14ea-1c32-3c73-06a2" name="Order" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
       <categories>

--- a/Warhammer Age of Sigmar.gst
+++ b/Warhammer Age of Sigmar.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="13ba-994f-8c12-9f8d" revision="3" battleScribeVersion="1.15" name="Warhammer Age of Sigmar" authorName="Markus W. (taalas)" authorUrl="https://github.com/taalas" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="13ba-994f-8c12-9f8d" revision="2" battleScribeVersion="1.15" name="Warhammer Age of Sigmar" authorName="Markus W. (taalas)" authorUrl="https://github.com/taalas" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <forceTypes>
     <forceType id="14ea-1c32-3c73-06a2" name="Order" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
       <categories>

--- a/Warhammer Age of Sigmar.gst
+++ b/Warhammer Age of Sigmar.gst
@@ -27,6 +27,9 @@
         <category id="e092-c885-923d-1c82" name="Stormcast Eternal" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
           <modifiers/>
         </category>
+        <category id="c96d-1643-ed56-ba60" name="Sylvaneth" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
+          <modifiers/>
+        </category>
       </categories>
       <forceTypes/>
     </forceType>


### PR DESCRIPTION
- Sylvaneth category added to game system file
- Created separate catalogue file for Sylvaneth units
- Branchwraith and Dryads moved to Sylvaneth catalogue
- Added Sylvaneth Wyldwoods, Durthu, Treelord and Treelord Ancient to Sylvaneth catalogue
- Started on Stormcast Eternals, 4 units left