### PR TITLE
Stormcast Eternals - Prosecutors Fix

### DIFF
--- a/Order.cat
+++ b/Order.cat
@@ -12819,7 +12819,23 @@
         </modifier>
         <modifier type="increment" field="points" value="100">
           <repeats/>
-          <conditions/>
+          <conditions>
+            <condition field="selections" scope="432b-fe7d-867c-7e7d" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="432b-fe7d-867c-7e7d" type="greaterThan"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+        <modifier type="increment" field="points" value="100">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="432b-fe7d-867c-7e7d" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="432b-fe7d-867c-7e7d" type="greaterThan"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+        <modifier type="increment" field="points" value="100">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="432b-fe7d-867c-7e7d" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="432b-fe7d-867c-7e7d" type="greaterThan"/>
+          </conditions>
           <conditionGroups/>
         </modifier>
       </modifiers>

--- a/Order.cat
+++ b/Order.cat
@@ -12817,25 +12817,9 @@
             </conditionGroup>
           </conditionGroups>
         </modifier>
-        <modifier type="increment" field="points" value="80">
+        <modifier type="increment" field="points" value="100">
           <repeats/>
-          <conditions>
-            <condition field="selections" scope="432b-fe7d-867c-7e7d" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0b98-4d92-b7d5-5a2d" type="greaterThan"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-        <modifier type="increment" field="points" value="80">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="432b-fe7d-867c-7e7d" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0b98-4d92-b7d5-5a2d" type="greaterThan"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-        <modifier type="increment" field="points" value="80">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="432b-fe7d-867c-7e7d" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0b98-4d92-b7d5-5a2d" type="greaterThan"/>
-          </conditions>
+          <conditions/>
           <conditionGroups/>
         </modifier>
       </modifiers>

--- a/Order.cat
+++ b/Order.cat
@@ -12820,21 +12820,21 @@
         <modifier type="increment" field="points" value="100">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="432b-fe7d-867c-7e7d" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="432b-fe7d-867c-7e7d" type="greaterThan"/>
+            <condition field="selections" scope="432b-fe7d-867c-7e7d" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0b98-4d92-b7d5-5a2d" type="greaterThan"/>
           </conditions>
           <conditionGroups/>
         </modifier>
         <modifier type="increment" field="points" value="100">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="432b-fe7d-867c-7e7d" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="432b-fe7d-867c-7e7d" type="greaterThan"/>
+            <condition field="selections" scope="432b-fe7d-867c-7e7d" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0b98-4d92-b7d5-5a2d" type="greaterThan"/>
           </conditions>
           <conditionGroups/>
         </modifier>
         <modifier type="increment" field="points" value="100">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="432b-fe7d-867c-7e7d" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="432b-fe7d-867c-7e7d" type="greaterThan"/>
+            <condition field="selections" scope="432b-fe7d-867c-7e7d" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0b98-4d92-b7d5-5a2d" type="greaterThan"/>
           </conditions>
           <conditionGroups/>
         </modifier>

--- a/Order.cat
+++ b/Order.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="ec09-7606-dae2-0b3d" name="Grand Alliance: Order" book="Grand Alliance: Order" revision="30" battleScribeVersion="2.00" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="ec09-7606-dae2-0b3d" name="Grand Alliance: Order" book="Grand Alliance: Order" revision="31" battleScribeVersion="2.00" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>


### PR DESCRIPTION
Prior to this fix Prosecutors with Celestial Hammers were incorrectly incrementing by 80 instead of 100.

