### PR TITLE
Profile Updates for DEATH - Legions of Nagash

### DIFF
--- a/Death - Legions of Nagash.cat
+++ b/Death - Legions of Nagash.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="e320-d5ec-ac8e-03dd" name="Death: Legions of Nagash" book="Battletome: Legions of Nagash" revision="6" battleScribeVersion="2.01" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="7" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="e320-d5ec-ac8e-03dd" name="Death: Legions of Nagash" book="Battletome: Legions of Nagash" revision="7" battleScribeVersion="2.01" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="7" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks>
@@ -4616,14 +4616,14 @@
             <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="At the end of any combat phase in which Arkhan slew any models, you can heal 2 wounds that have been allocated to him."/>
           </characteristics>
         </profile>
-        <profile id="ccd8-879c-72bc-040e" name="Magic" hidden="false" profileTypeId="f55d-ee3a-1597-110f" profileTypeName="Magic">
+        <profile id="ccd8-879c-72bc-040e" name="Arkhan" hidden="false" profileTypeId="f55d-ee3a-1597-110f" profileTypeName="Magic">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <characteristics>
             <characteristic name="Cast/Unbind" characteristicTypeId="8294-f605-2c0f-8f92" value="2/2"/>
-            <characteristic name="Spells Known" characteristicTypeId="dc9c-47d3-6931-859c" value="He knows the Arcane Bolt, Mystic Shield and Curse of Years spells. Arkhan also knows the spells of any DEATH WIZARD that is within 18&quot; of him."/>
+            <characteristic name="Spells Known" characteristicTypeId="dc9c-47d3-6931-859c" value="Arcane Bolt, Mystic Shield and Curse of Years spells. Arkhan also knows the spells of any DEATH WIZARD that is within 18&quot; of him."/>
           </characteristics>
         </profile>
         <profile id="2bbe-2ed9-c7ad-859a" name="Arkhan the Black, Mortarch of Sacrament" hidden="false" profileTypeId="1960-ca8e-67ce-2014" profileTypeName="Unit">
@@ -7593,7 +7593,7 @@
             <characteristic name="Vigour of Undeath" characteristicTypeId="5c3f-6350-a9ce-c498" value="3&quot;"/>
           </characteristics>
         </profile>
-        <profile id="c732-78be-a56d-3168" name="Magic" hidden="false" profileTypeId="f55d-ee3a-1597-110f" profileTypeName="Magic">
+        <profile id="c732-78be-a56d-3168" name="Mannfred" hidden="false" profileTypeId="f55d-ee3a-1597-110f" profileTypeName="Magic">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -8862,7 +8862,7 @@
             <characteristic name="Alakanash" characteristicTypeId="a90a-6b92-7baf-7503" value="+1 cast / +1 unbind"/>
           </characteristics>
         </profile>
-        <profile id="6f9a-6c88-aba3-e02e" name="Magic" hidden="false" profileTypeId="f55d-ee3a-1597-110f" profileTypeName="Magic">
+        <profile id="6f9a-6c88-aba3-e02e" name="Nagash" hidden="false" profileTypeId="f55d-ee3a-1597-110f" profileTypeName="Magic">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -9255,7 +9255,7 @@
     </selectionEntry>
     <selectionEntry id="aef7-e01a-dd19-2b1d" name="Necromancer" page="" hidden="false" collective="false" type="upgrade">
       <profiles>
-        <profile id="e285-cd4f-0868-62dd" name="Magic" hidden="false" profileTypeId="f55d-ee3a-1597-110f" profileTypeName="Magic">
+        <profile id="e285-cd4f-0868-62dd" name="Necromancer" hidden="false" profileTypeId="f55d-ee3a-1597-110f" profileTypeName="Magic">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -9454,7 +9454,7 @@
     </selectionEntry>
     <selectionEntry id="0167-7f06-0132-a7ca" name="Neferata, Mortarch of Blood" page="135" hidden="false" collective="false" type="unit">
       <profiles>
-        <profile id="2fe0-edde-907c-e584" name="Magic" hidden="false" profileTypeId="f55d-ee3a-1597-110f" profileTypeName="Magic">
+        <profile id="2fe0-edde-907c-e584" name="Neferata" hidden="false" profileTypeId="f55d-ee3a-1597-110f" profileTypeName="Magic">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -10681,14 +10681,14 @@
             <characteristic name="Save" characteristicTypeId="f8dd-4f2a-8543-4f36" value="4+"/>
           </characteristics>
         </profile>
-        <profile id="da4c-774b-2275-5fd9" name="Magic" hidden="false" profileTypeId="f55d-ee3a-1597-110f" profileTypeName="Magic">
+        <profile id="da4c-774b-2275-5fd9" name="Vampire Lord" hidden="false" profileTypeId="f55d-ee3a-1597-110f" profileTypeName="Magic">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <characteristics>
             <characteristic name="Cast/Unbind" characteristicTypeId="8294-f605-2c0f-8f92" value="1/1"/>
-            <characteristic name="Spells Known" characteristicTypeId="dc9c-47d3-6931-859c" value="A Vampire Lord on Zombie Dragon is a WIZARD. He can attempt to cast one spell in your hero phase, and attempt to unbind one spell in the enemy hero phase. He knows the Arcane Bolt, Mystic Shield spells."/>
+            <characteristic name="Spells Known" characteristicTypeId="dc9c-47d3-6931-859c" value="A Vampire Lord is a WIZARD. He can attempt to cast one spell in your hero phase, and attempt to unbind one spell in the enemy hero phase. He knows the Arcane Bolt, Mystic Shield spells."/>
           </characteristics>
         </profile>
         <profile id="96b2-3406-809d-182b" name="Blood Feast" hidden="false" profileTypeId="f71f-b0a4-730e-ced3" profileTypeName="Command Abilities">
@@ -11024,7 +11024,7 @@
             <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="At the start of your hero phase, pick up to 3 different friendly SUMMONABLE units within 12&quot; of this model. You can heal D3 wounds that have been allocated to each unit you picked (roll separately for each unit). If no wounds are currently allocated to a unit you have picked, you may instead return a number of slain models to it that have a combined Wounds characteristic equal to or less than the roll of a D3"/>
           </characteristics>
         </profile>
-        <profile id="f49f-aece-5de4-38f2" name="Magic" hidden="false" profileTypeId="f55d-ee3a-1597-110f" profileTypeName="Magic">
+        <profile id="f49f-aece-5de4-38f2" name="Vampire Lord on Zombie Dragon" hidden="false" profileTypeId="f55d-ee3a-1597-110f" profileTypeName="Magic">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -15194,7 +15194,7 @@
     </selectionEntry>
     <selectionEntry id="f08a-0379-143b-4ea1" name="Bloodseeker Palanquin" hidden="false" collective="false" type="unit">
       <profiles>
-        <profile id="dfee-eda6-d0bc-b15c" name="Magic" hidden="false" profileTypeId="f55d-ee3a-1597-110f" profileTypeName="Magic">
+        <profile id="dfee-eda6-d0bc-b15c" name="Bloodseeker Palanquin" hidden="false" profileTypeId="f55d-ee3a-1597-110f" profileTypeName="Magic">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -15587,7 +15587,7 @@
             <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="&apos;At the start of your shooting phase, pick an enemy unit within 8&quot; of this model that is visible to it.&apos; *FAQ v1.3* Then roll a dice, adding 1 to the result if this model slew any enemy models in the previous combat phase. On a 3+ that unit suffers a number of mortal wounds as shown on the damage table above."/>
           </characteristics>
         </profile>
-        <profile id="09c8-dee4-0a13-68fd" name="Magic" hidden="false" profileTypeId="f55d-ee3a-1597-110f" profileTypeName="Magic">
+        <profile id="09c8-dee4-0a13-68fd" name="Prince Vhordrai" hidden="false" profileTypeId="f55d-ee3a-1597-110f" profileTypeName="Magic">
           <profiles/>
           <rules/>
           <infoLinks/>


### PR DESCRIPTION
Changed 'Magic' field to identify the name of the Unit to better assist when dispaying field in Battalions.
Corrected issues from #243