### PR TITLE
Split Collegiate Arcane from Order Catalog

### DIFF
--- a/Age of Sigmar.gst
+++ b/Age of Sigmar.gst
@@ -1054,7 +1054,15 @@
           <constraints>
             <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ae99-e895-08b5-bf60" type="max"/>
           </constraints>
-          <categoryLinks/>
+          <categoryLinks>
+            <categoryLink id="b1ea-11ea-2990-b9d1" name="New CategoryLink" hidden="false" targetId="3564-4c26-10b4-d953" primary="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </categoryLink>
+          </categoryLinks>
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
@@ -1080,7 +1088,15 @@
           <constraints>
             <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8e73-d153-8a05-e403" type="max"/>
           </constraints>
-          <categoryLinks/>
+          <categoryLinks>
+            <categoryLink id="d96c-b586-00b6-2deb" name="New CategoryLink" hidden="false" targetId="3564-4c26-10b4-d953" primary="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </categoryLink>
+          </categoryLinks>
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
@@ -1106,7 +1122,15 @@
           <constraints>
             <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="819a-782f-5496-9885" type="max"/>
           </constraints>
-          <categoryLinks/>
+          <categoryLinks>
+            <categoryLink id="601b-b6f0-94d1-cd3a" name="New CategoryLink" hidden="false" targetId="3564-4c26-10b4-d953" primary="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </categoryLink>
+          </categoryLinks>
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
@@ -1132,7 +1156,15 @@
           <constraints>
             <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1464-64f1-8374-3f0c" type="max"/>
           </constraints>
-          <categoryLinks/>
+          <categoryLinks>
+            <categoryLink id="827d-a112-0f50-e58f" name="New CategoryLink" hidden="false" targetId="3564-4c26-10b4-d953" primary="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </categoryLink>
+          </categoryLinks>
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
@@ -1158,7 +1190,15 @@
           <constraints>
             <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7ebe-39a0-aeb6-7d08" type="max"/>
           </constraints>
-          <categoryLinks/>
+          <categoryLinks>
+            <categoryLink id="fce5-ffa8-6118-a04a" name="New CategoryLink" hidden="false" targetId="3564-4c26-10b4-d953" primary="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </categoryLink>
+          </categoryLinks>
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
@@ -1184,7 +1224,15 @@
           <constraints>
             <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="68ac-70ca-db4f-c7a0" type="max"/>
           </constraints>
-          <categoryLinks/>
+          <categoryLinks>
+            <categoryLink id="1c34-cb7a-bfb7-bab0" name="New CategoryLink" hidden="false" targetId="3564-4c26-10b4-d953" primary="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </categoryLink>
+          </categoryLinks>
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
@@ -1390,7 +1438,15 @@
           <infoLinks/>
           <modifiers/>
           <constraints/>
-          <categoryLinks/>
+          <categoryLinks>
+            <categoryLink id="05a1-082d-0c9f-b63d" name="New CategoryLink" hidden="false" targetId="3564-4c26-10b4-d953" primary="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </categoryLink>
+          </categoryLinks>
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
@@ -1414,7 +1470,15 @@
           <infoLinks/>
           <modifiers/>
           <constraints/>
-          <categoryLinks/>
+          <categoryLinks>
+            <categoryLink id="1498-8111-b71e-2c79" name="New CategoryLink" hidden="false" targetId="3564-4c26-10b4-d953" primary="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </categoryLink>
+          </categoryLinks>
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
@@ -1438,7 +1502,15 @@
           <infoLinks/>
           <modifiers/>
           <constraints/>
-          <categoryLinks/>
+          <categoryLinks>
+            <categoryLink id="4963-8263-9449-d0b7" name="New CategoryLink" hidden="false" targetId="3564-4c26-10b4-d953" primary="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </categoryLink>
+          </categoryLinks>
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
@@ -1462,7 +1534,15 @@
           <infoLinks/>
           <modifiers/>
           <constraints/>
-          <categoryLinks/>
+          <categoryLinks>
+            <categoryLink id="0943-73b6-1080-7b58" name="New CategoryLink" hidden="false" targetId="3564-4c26-10b4-d953" primary="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </categoryLink>
+          </categoryLinks>
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
@@ -1486,7 +1566,15 @@
           <infoLinks/>
           <modifiers/>
           <constraints/>
-          <categoryLinks/>
+          <categoryLinks>
+            <categoryLink id="c10f-514d-7ead-ea4f" name="New CategoryLink" hidden="false" targetId="3564-4c26-10b4-d953" primary="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </categoryLink>
+          </categoryLinks>
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
@@ -1510,7 +1598,15 @@
           <infoLinks/>
           <modifiers/>
           <constraints/>
-          <categoryLinks/>
+          <categoryLinks>
+            <categoryLink id="fa96-9d2b-0053-d3cd" name="New CategoryLink" hidden="false" targetId="3564-4c26-10b4-d953" primary="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </categoryLink>
+          </categoryLinks>
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>

--- a/Order - Collegiate Arcane.cat
+++ b/Order - Collegiate Arcane.cat
@@ -1,0 +1,2411 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="f747-e79f-844e-360d" name="Order - Collegiate Arcane" book="Grand Alliance: Order" revision="1" battleScribeVersion="2.01" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <profiles/>
+  <rules/>
+  <infoLinks/>
+  <costTypes/>
+  <profileTypes>
+    <profileType id="9cb4-15df-780d-f4ee" name="Crew Table">
+      <characteristicTypes>
+        <characteristicType id="16e7-fc98-da3d-921d" name="Variable1"/>
+        <characteristicType id="93ac-2863-3f94-b8ac" name="Variable2"/>
+        <characteristicType id="c11c-4fd8-5dac-cb38" name="Variable3"/>
+      </characteristicTypes>
+    </profileType>
+  </profileTypes>
+  <categoryEntries>
+    <categoryEntry id="c945-c89f-4053-6479" name="REDEEMER" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="2308-7db2-829e-94b3" name="HUMAN" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="7c69-4225-cf08-7991" name="CELESTIAL" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="945b-2f5e-58f0-75e2" name="DUARDIN" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="7fe9-bc03-2c82-0a00" name="AELF" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="0a32-77ff-3434-17bf" name="SWIFTHAWK AGENTS" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="93d3-8c19-a0ca-41b4" name="CHARIOTS" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="d555-0035-a853-868b" name="SHADOWBLADES" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="c06d-bb09-2c32-444b" name="ASSASSIN" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="9136-3ac6-ef7e-ccdf" name="DARK RIDERS" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="aeb6-9c22-cdf2-87b5" name="SCOURGE PRIVATEERS" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="57bc-d00d-6ef1-aae2" name="SCOURGERUNNER CHARIOTS" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="5f77-bdf8-d9cb-bf05" name="KHARIBDYSS" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="2349-073e-4b3e-78f2" name="BLACK ARK FLEETMASTER" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="b6ba-83f0-98ff-9cf1" name="BLACK ARK CORSAIRS" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="3c34-40ab-1a45-7972" name="FROSTHEART PHOENIX" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="f432-2565-9147-77eb" name="PHOENIX TEMPLE" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="ecc6-02d2-cd21-9f1e" name="ANOINTED" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="42c2-57c1-55f4-e376" name="PHOENIX GUARD" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="99d3-6baf-e0bc-a1e0" name="FLAMESPYRE PHOENIX" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="9816-610d-b13e-ea5b" name="DRAGON BLADES" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="55c7-9a88-fb09-583e" name="CANNON" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="920f-7600-9c65-a179" name="COGSMITH" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="b825-7b2f-9a1e-7c32" name="ENGINEER" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="4807-239b-4c1d-3211" name="IRONWELD ARSENAL" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="eb9d-026c-8282-15ef" name="GUNMASTER" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="c0c3-8fb0-b48a-596f" name="GYROBOMBERS" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="75be-5b58-c14b-0395" name="GYROCOPTERS" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="fb7a-5518-128d-c331" name="HELBLASTER VOLLEY GUN" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="3dfb-ff02-f0e1-6cb1" name="HELSTORM ROCKET BATTERY" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="db6e-b4df-35e6-1658" name="ORGAN GUN" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="3805-83b3-bdf5-6342" name="STEAM TANK" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="a3ec-bd7c-12bb-241d" name="ORDER DRACONIS" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="4253-34e6-e990-9ce1" name="DRAGONLORD" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="6032-4742-2cd4-7423" name="DRAGON" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="c8c0-bb4c-0a56-8ef5" name="DRAGON NOBLE" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="2ad6-a10f-526b-bd2a" name="DRAKESPAWN CHARIOTS" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="24f8-2dcc-2a69-6c30" name="ORDER SERPENTIS" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="03d2-2db4-1124-2c4c" name="DRAKESPAWN KNIGHTS" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="b81b-7ece-9632-e052" name="DREADLORD" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="691f-fe2d-18fc-173b" name="WAR HYDRA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="10ea-6ce2-b106-f9f8" name="LION RANGERS" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="6c47-e2b7-a6da-7040" name="WHITE LIONS" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="6c32-32f7-2494-01f9" name="WHITE LION CHARIOTS" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="2e31-b1a1-10c7-22d4" name="GRIFFON" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="ad77-e7a0-9c3b-de74" name="ARCHMAGE" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="947c-4b48-4995-8c57" name="ELDRITCH COUNCIL" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="af41-6880-73ab-cc2e" name="DRAKESEER" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="6e0d-0747-9418-a1e8" name="LOREMASTER" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="49a3-0151-f70e-5ebb" name="SWORDMASTERS" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="be0e-cccd-8b64-3a9f" name="TENEBRAEL SHARD" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="c9d5-f481-3cd6-c3f1" name="MISTWEAVER SAIH" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="e16a-1ef0-948a-a79c" name="DEVOTED OF SIGMAR" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="b7c7-5c53-ddd3-d0f6" name="EXCELSIOR WARPRIEST" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="404a-f5b7-cb6c-79ba" name="FLAGELLANTS" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="97dc-501c-b627-060e" name="WARRIOR PRIEST" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="3b72-9044-75bf-c8f0" name="WITCH HUNTER" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="2065-9c25-54d0-793e" name="WAR ALTAR OF SIGMAR" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="d2e0-123f-1dd2-7992" name="COLLEGIATE ARCANE" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="0cda-4c8e-b048-9cfe" name="LUMINARK OF HYSH" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="18e1-27b1-33f8-2955" name="BATTLEMAGE" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="ae44-d523-ca44-b38b" name="CELESTIAL HURRICANUM" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="7108-4397-8dc8-52bc" name="CARMINE DRAGON" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="ab93-034c-295f-1472" name="SKYWARDEN" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="2ee4-a64f-ffe3-deec" name="SKYCUTTERS" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="f91c-2b26-1311-29a2" name="SHADOW WARRIORS" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="1531-e02a-b80f-f039" name="SPIREGUARD" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="468a-728e-f6ea-c6e8" name="REAVERS" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="5511-bd56-15b9-f523" name="HIGH WARDEN" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+  </categoryEntries>
+  <forceEntries/>
+  <selectionEntries/>
+  <entryLinks>
+    <entryLink id="7332-f387-438b-852c" name="Allegiance" hidden="false" targetId="8171-f17c-d43c-5e0b" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="5a85-239e-8b35-3a74" name="New CategoryLink" hidden="false" targetId="87e8-c095-f059-5f7b" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="ba25-7cb9-2478-28aa" name="Celestial Hurricanum" hidden="false" targetId="d4dd-f8cd-fa3d-6555" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="ba25-7cb9-2478-28aa-fa0c-9044-2568-fa02" hidden="false" targetId="fa0c-9044-2568-fa02" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="4d56-a3f6-6e1b-6035" name="Luminark of Hysh" hidden="false" targetId="ec08-7605-f909-609e" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="4d56-a3f6-6e1b-6035-fa0c-9044-2568-fa02" hidden="false" targetId="fa0c-9044-2568-fa02" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="04b3-46e2-f167-79d0" name="Battlemage on Griffon" hidden="false" targetId="cb63-b9fd-e4ab-828a" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="7699-eba7-f0d3-fa9e" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="7505-1fcb-08fb-d048" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="8c54-0bb6-d5a0-9c83" name="Battlemage" hidden="false" targetId="2a82-51b8-c8cc-4fe6" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="8c54-0bb6-d5a0-9c83-6c6b-e787-f9b8-a510" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="2231-96d4-4e40-b314" name="Battalion: War Council" hidden="false" targetId="10e9-cfb5-4b4e-d108" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="2231-96d4-4e40-b314-be17-6bbd-b857-3f43" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+    </entryLink>
+  </entryLinks>
+  <sharedSelectionEntries>
+    <selectionEntry id="8171-f17c-d43c-5e0b" name="Allegiance" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="c054-2350-5f5d-85b4" name="Allegiance" hidden="false" collective="false" defaultSelectionEntryId="d51d-dec8-f7a7-351d">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="d51d-dec8-f7a7-351d" name="Allegiance: Order" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="f6bb-9b06-85bf-e4ce" name="Defiant Avengers" hidden="false" profileTypeId="c137-4d1f-9d1a-524d" profileTypeName="Battle Trait">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Battle Trait Details" characteristicTypeId="9fdd-b4b1-5f7a-0970" value="You can re-roll battleshock tests for friendly ORDER units in the battleshock phase."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="10e9-cfb5-4b4e-d108" name="Battalion: War Council" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="ab73-09f5-e8df-e846" name="Augmented Might" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Any Battlemages in a War Council can choose to forgo casting a spell in their hero phase in order to augment a spell cast by another model from the same battalion that is within 6&quot;.  Declare that they will do so before making the casting roll.  Add 1 to the casting roll and 6&quot; to the range of the spell for each Battlemage that helps to augment it."/>
+          </characteristics>
+        </profile>
+        <profile id="2be2-0ec5-a975-511a" name="-" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="A War Council consists of the following units:"/>
+          </characteristics>
+        </profile>
+        <profile id="a72a-9993-c365-1c23" name="Battlemage of Griffon" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1"/>
+          </characteristics>
+        </profile>
+        <profile id="3c23-dd99-4f84-d937" name="Battlemages" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="3-8"/>
+          </characteristics>
+        </profile>
+        <profile id="2e67-c957-22ed-d7a9" name="Luminark of Hysh" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1"/>
+          </characteristics>
+        </profile>
+        <profile id="ace0-fa9e-feea-42fc" name="Celestial Hurricanum" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="250.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2a82-51b8-c8cc-4fe6" name="Battlemage" hidden="false" collective="false" type="unit">
+      <profiles>
+        <profile id="4320-a77a-953a-ca60" name="Magic" book="" hidden="false" profileTypeId="f55d-ee3a-1597-110f">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Cast/Unbind" characteristicTypeId="8294-f605-2c0f-8f92" value="1/1"/>
+            <characteristic name="Spells Known" characteristicTypeId="dc9c-47d3-6931-859c" value="Arcane Bolt, Mystic Shield, Specialisation Spell"/>
+          </characteristics>
+        </profile>
+        <profile id="d78f-29ab-ba62-74c6" name="Battlemage" hidden="false" profileTypeId="1960-ca8e-67ce-2014" profileTypeName="Unit">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Move" characteristicTypeId="8655-6213-2824-1752" value="5&quot;"/>
+            <characteristic name="Wounds" characteristicTypeId="cd0e-fea6-411f-904d" value="5"/>
+            <characteristic name="Bravery" characteristicTypeId="0c85-bf79-836b-759e" value="6"/>
+            <characteristic name="Save" characteristicTypeId="f8dd-4f2a-8543-4f36" value="6+"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="18db-0620-b209-574c" name="Arcane Bolt" hidden="false" targetId="ae02-a84f-a903-1ff8" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="e9bd-2d56-b6d4-3e8c" name="Mystic Shield" hidden="false" targetId="b41f-f1ce-7aa5-4f81" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="92ff-1fed-f053-80d1" name="New CategoryLink" hidden="false" targetId="18e1-27b1-33f8-2955" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="cf9a-bd58-dcb2-7f41" name="New CategoryLink" hidden="false" targetId="4e0e-664d-51ea-0929" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="a257-b89c-e9b5-20a0" name="New CategoryLink" hidden="false" targetId="2308-7db2-829e-94b3" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="fa4e-69ae-c745-09c8" name="New CategoryLink" hidden="false" targetId="4f53-8230-2f02-9639" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="ff7b-2cb6-b7fe-7f17" name="New CategoryLink" hidden="false" targetId="d2e0-123f-1dd2-7992" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="2ab7-f31d-e8c4-0a52" name="New CategoryLink" hidden="false" targetId="b970-b3bf-e1a4-a6fc" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="96e3-5c7d-8fdb-bf37" name="Battlemage&apos;s Staff" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="920d-62ea-2ad0-0f2d" name="Battlemage&apos;s Staff" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="2&quot;"/>
+                <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="1"/>
+                <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="4+"/>
+                <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+                <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-1"/>
+                <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="D3"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f646-fe7d-a695-237e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a7cf-c349-bcb0-dccb" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs/>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="956e-cdb0-8c35-91d7" name="Specialisation" hidden="false" collective="false" defaultSelectionEntryId="8f0f-4c8f-6e6b-d2d1">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="b055-ef5d-e69b-96fe" name="Heavens" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="26eb-6441-c23e-1161" name="Chain Lightning" book="" hidden="false" profileTypeId="2e81-5e22-c6e1-73cb">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Casting Value" characteristicTypeId="2508-b604-1258-a920" value="6"/>
+                    <characteristic name="Description" characteristicTypeId="76ff-781d-b8e6-5f27" value="If successfully cast. pick a visible enemy unit within 18&quot;. That unit suffers D3 mortal wounds. Then, roll a dice for every other enemy unit within 6&quot; of the original target; on a 6 the lightning has leapt to that unit and it also suffers D3 mortal wounds. "/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c5df-6959-d382-0860" name="Bright" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="dcf7-2c0e-a175-8956" name="Fireball" book="" hidden="false" profileTypeId="2e81-5e22-c6e1-73cb">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Casting Value" characteristicTypeId="2508-b604-1258-a920" value="5"/>
+                    <characteristic name="Description" characteristicTypeId="76ff-781d-b8e6-5f27" value="If successfully cast. pick a visible enemy unit within 18&quot; and roll a dice. On a 1 or a 2 that unit suffers a mortal wound. on a 3 or a 4 it suffers D3 mortal wounda and on a 5 or a 6 it suffers D6 mortal wounds. "/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1e9d-8f67-4816-4cdd" name="Amethyst" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="b525-c61f-42d0-c5c5" name="Soul Steal" book="" hidden="false" profileTypeId="2e81-5e22-c6e1-73cb">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Casting Value" characteristicTypeId="2508-b604-1258-a920" value="5"/>
+                    <characteristic name="Description" characteristicTypeId="76ff-781d-b8e6-5f27" value="If successfully cast, pick a visible enemy unit within 18&quot;. You and your opponent then both roll a dice; add the caster&apos;s Bravery to your dice roll and add the Bravery of the target to your opponent&apos;s. If your score is the highest, the enemy unit suffers a number of mortal wounds equal to the difference in the scores (for example, if your score was 10 and your opponent&apos;s 8, the unit suffers 2 mortal wounds). "/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3d62-4377-f466-a55e" name="White" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="9685-4c4e-ba40-2981" name="Light of Battle" book="" hidden="false" profileTypeId="2e81-5e22-c6e1-73cb">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Casting Value" characteristicTypeId="2508-b604-1258-a920" value="4"/>
+                    <characteristic name="Description" characteristicTypeId="76ff-781d-b8e6-5f27" value="If successfully cast, pick a unit within 18&quot;. That unit does not need to take battleshock tests until your next hero phase. The magical aura surrounding that unit alao ennobles nearby allies until your next hero phase; other units from your army within 6&quot; of this unit in the battleshock phase add 1 to their Bravery."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f223-5ad7-7f97-9c62" name="Gold" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="7ed2-2076-7176-b308" name="Final Transmutation" book="" hidden="false" profileTypeId="2e81-5e22-c6e1-73cb">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Casting Value" characteristicTypeId="2508-b604-1258-a920" value="6"/>
+                    <characteristic name="Description" characteristicTypeId="76ff-781d-b8e6-5f27" value="If successfully cast. pick a visible enemy unit within 18&quot;. Your opponent then picks any model in that unit and rolls a dice; if the result is more than that model&apos;s remaining number of wounds, it is transformed into a gleaming golden statue and slain."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="541d-ef61-2259-f936" name="Grey" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="5a01-764d-2fd7-580e" name="Mystifying Miasma" book="" hidden="false" profileTypeId="2e81-5e22-c6e1-73cb">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Casting Value" characteristicTypeId="2508-b604-1258-a920" value="6"/>
+                    <characteristic name="Description" characteristicTypeId="76ff-781d-b8e6-5f27" value="If successfully cast, pick a visible enemy unit within 18&quot;. Until your next hero phase your opponent must subtract 1 from all hit rolls for that unit."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8f0f-4c8f-6e6b-d2d1" name="Amber" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="c0cb-f9f6-1b66-9a32" name="Wildform" book="" hidden="false" profileTypeId="2e81-5e22-c6e1-73cb">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Casting Value" characteristicTypeId="2508-b604-1258-a920" value="6"/>
+                    <characteristic name="Description" characteristicTypeId="76ff-781d-b8e6-5f27" value="If successfully cast, pick a unit within 18&quot;. Until your next hero phase you can add 1 to all wound rolls for that unit in the combat phase."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d845-24d1-7b79-8e0d" name="Jade" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="c36f-eecc-417d-9dfa" name="Lifesurge" book="" hidden="false" profileTypeId="2e81-5e22-c6e1-73cb">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Casting Value" characteristicTypeId="2508-b604-1258-a920" value="5"/>
+                    <characteristic name="Description" characteristicTypeId="76ff-781d-b8e6-5f27" value="If successfully cast, pick a unit within 18&quot;. One model in that unit heals D3 wounds. In addition, until your next hero phase the energies of this spell persist; roll a dice each time a model in the unit suffers a wound or mortal wound. On a 6, that wound is instantly healed and is ignored."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="0d54-0cfd-6757-e910" name="General" hidden="false" targetId="b341-0885-3f1c-7d8a" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="c495-80c6-567a-51ec" name="Artefacts" hidden="false" targetId="083e-a950-b54a-c2a4" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="100.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cb63-b9fd-e4ab-828a" name="Battlemage on Griffon" hidden="false" collective="false" type="unit">
+      <profiles>
+        <profile id="a0b8-685c-c565-56cb" name="Battlemage on Griffon" book="" hidden="false" profileTypeId="f55d-ee3a-1597-110f">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Cast/Unbind" characteristicTypeId="8294-f605-2c0f-8f92" value="1/1"/>
+            <characteristic name="Spells Known" characteristicTypeId="dc9c-47d3-6931-859c" value="Arcane Bolt, Mystic Shield, Amber Spear"/>
+          </characteristics>
+        </profile>
+        <profile id="4d69-5306-30ad-c5ba" name="Amber Spear" book="" hidden="false" profileTypeId="2e81-5e22-c6e1-73cb">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Casting Value" characteristicTypeId="2508-b604-1258-a920" value="7"/>
+            <characteristic name="Description" characteristicTypeId="76ff-781d-b8e6-5f27" value="If successfully cast, pick a visible model within 18&quot;. Draw a straight line bteween that model and the caster; the target model&apos;s unit, and each other unit that this line passess through, suffers D3 mortal wounds."/>
+          </characteristics>
+        </profile>
+        <profile id="5af6-3467-a6ab-82c3" name="Wounds0" hidden="false" profileTypeId="90d1-a434-348d-a861" profileTypeName="Damage Table">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Variable 1" characteristicTypeId="420a-645a-ab28-93a0" value="Wounds Suffered"/>
+            <characteristic name="Variable 2" characteristicTypeId="4cdd-1e03-530f-0ff7" value="Move"/>
+            <characteristic name="Variable 3" characteristicTypeId="b1ea-56be-ba52-16e9" value="Twin Beaks"/>
+            <characteristic name="Variable 4" characteristicTypeId="ad26-bf56-95c4-80f1" value="Razor Claws"/>
+          </characteristics>
+        </profile>
+        <profile id="49bb-9fe2-476f-bc1b" name="Wounds1" hidden="false" profileTypeId="90d1-a434-348d-a861" profileTypeName="Damage Table">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Variable 1" characteristicTypeId="420a-645a-ab28-93a0" value="0-3"/>
+            <characteristic name="Variable 2" characteristicTypeId="4cdd-1e03-530f-0ff7" value="15&quot;"/>
+            <characteristic name="Variable 3" characteristicTypeId="b1ea-56be-ba52-16e9" value="3"/>
+            <characteristic name="Variable 4" characteristicTypeId="ad26-bf56-95c4-80f1" value="6"/>
+          </characteristics>
+        </profile>
+        <profile id="1ba5-f801-e31d-e4e2" name="Wounds2" hidden="false" profileTypeId="90d1-a434-348d-a861" profileTypeName="Damage Table">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Variable 1" characteristicTypeId="420a-645a-ab28-93a0" value="4-6"/>
+            <characteristic name="Variable 2" characteristicTypeId="4cdd-1e03-530f-0ff7" value="13&quot;"/>
+            <characteristic name="Variable 3" characteristicTypeId="b1ea-56be-ba52-16e9" value="D3"/>
+            <characteristic name="Variable 4" characteristicTypeId="ad26-bf56-95c4-80f1" value="5"/>
+          </characteristics>
+        </profile>
+        <profile id="d23c-2964-f26c-8a64" name="Wounds3" hidden="false" profileTypeId="90d1-a434-348d-a861" profileTypeName="Damage Table">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Variable 1" characteristicTypeId="420a-645a-ab28-93a0" value="7-9"/>
+            <characteristic name="Variable 2" characteristicTypeId="4cdd-1e03-530f-0ff7" value="11&quot;"/>
+            <characteristic name="Variable 3" characteristicTypeId="b1ea-56be-ba52-16e9" value="D3"/>
+            <characteristic name="Variable 4" characteristicTypeId="ad26-bf56-95c4-80f1" value="4"/>
+          </characteristics>
+        </profile>
+        <profile id="6fad-c54c-8abe-1dca" name="Wounds4" hidden="false" profileTypeId="90d1-a434-348d-a861" profileTypeName="Damage Table">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Variable 1" characteristicTypeId="420a-645a-ab28-93a0" value="10-11"/>
+            <characteristic name="Variable 2" characteristicTypeId="4cdd-1e03-530f-0ff7" value="9&quot;"/>
+            <characteristic name="Variable 3" characteristicTypeId="b1ea-56be-ba52-16e9" value="1"/>
+            <characteristic name="Variable 4" characteristicTypeId="ad26-bf56-95c4-80f1" value="3"/>
+          </characteristics>
+        </profile>
+        <profile id="10d1-2b23-2966-aed3" name="Wounds5" hidden="false" profileTypeId="90d1-a434-348d-a861" profileTypeName="Damage Table">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Variable 1" characteristicTypeId="420a-645a-ab28-93a0" value="12+"/>
+            <characteristic name="Variable 2" characteristicTypeId="4cdd-1e03-530f-0ff7" value="7&quot;"/>
+            <characteristic name="Variable 3" characteristicTypeId="b1ea-56be-ba52-16e9" value="1"/>
+            <characteristic name="Variable 4" characteristicTypeId="ad26-bf56-95c4-80f1" value="2"/>
+          </characteristics>
+        </profile>
+        <profile id="2bf8-b136-1adc-ec0e" name="Battlemage on Griffon" hidden="false" profileTypeId="1960-ca8e-67ce-2014" profileTypeName="Unit">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Move" characteristicTypeId="8655-6213-2824-1752" value="*"/>
+            <characteristic name="Wounds" characteristicTypeId="cd0e-fea6-411f-904d" value="13"/>
+            <characteristic name="Bravery" characteristicTypeId="0c85-bf79-836b-759e" value="6"/>
+            <characteristic name="Save" characteristicTypeId="f8dd-4f2a-8543-4f36" value="5+"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="a7e9-5727-629c-6440" name="Mystic Shield" hidden="false" targetId="b41f-f1ce-7aa5-4f81" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="bfbe-5fbc-b851-2efa" name="Arcane Bolt" hidden="false" targetId="ae02-a84f-a903-1ff8" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="88d9-590e-182b-41d6" name="New CategoryLink" hidden="false" targetId="18e1-27b1-33f8-2955" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="606f-31e7-2028-853b" name="New CategoryLink" hidden="false" targetId="d2e0-123f-1dd2-7992" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="0020-43a1-27af-06b2" name="New CategoryLink" hidden="false" targetId="2e31-b1a1-10c7-22d4" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="c31b-0a61-1979-cdf1" name="New CategoryLink" hidden="false" targetId="2308-7db2-829e-94b3" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="5c99-73c4-faeb-4bd8" name="New CategoryLink" hidden="false" targetId="4e0e-664d-51ea-0929" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="51af-fe8b-d323-ff49" name="New CategoryLink" hidden="false" targetId="1959-9f6a-3056-913a" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="1708-cf92-5c16-b377" name="New CategoryLink" hidden="false" targetId="4f53-8230-2f02-9639" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="ff47-45fd-18ad-57e8" name="New CategoryLink" hidden="false" targetId="b970-b3bf-e1a4-a6fc" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="df39-a27a-a78a-fb82" name="Beaststaff" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="8ca0-c781-a407-2aae" name="Beaststaff" book="" hidden="false" profileTypeId="96df-ab28-5d72-bbb3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="2&quot;"/>
+                <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="1"/>
+                <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="4+"/>
+                <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+                <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-1"/>
+                <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="D3"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3b66-b554-ca6d-b531" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ad6d-726a-7ea1-bde2" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs/>
+        </selectionEntry>
+        <selectionEntry id="81b0-2087-80d0-188b" name="Griffon&apos;s Razor Claws" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="d199-b109-4723-3ffc" name="Griffon&apos;s Razor Claws" book="" hidden="false" profileTypeId="96df-ab28-5d72-bbb3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="2&quot;"/>
+                <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="*"/>
+                <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="4+"/>
+                <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+                <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-1"/>
+                <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="2"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="da74-774d-faaf-b6e3" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d4ef-da8f-16c6-7125" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs/>
+        </selectionEntry>
+        <selectionEntry id="59ef-9c14-03d8-a897" name="Griffon&apos;s Twin Beaks" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="1644-de8a-cbc6-83ca" name="Griffon&apos;s Twin Beaks" book="" hidden="false" profileTypeId="96df-ab28-5d72-bbb3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="2&quot;"/>
+                <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="4"/>
+                <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="3+"/>
+                <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+                <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-1"/>
+                <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="*"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6cb2-bdb8-b4ba-09f3" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2dc3-f91a-97a4-129e" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs/>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="d25e-0277-ffc1-7e8f" name="General" hidden="false" targetId="b341-0885-3f1c-7d8a" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="4e1e-d1c1-c666-0a37" name="Artefacts" hidden="false" targetId="083e-a950-b54a-c2a4" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="260.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d4dd-f8cd-fa3d-6555" name="Celestial Hurricanum" hidden="false" collective="false" type="unit">
+      <profiles>
+        <profile id="f5f8-932f-c004-0640" name="Celestial Hurricanum" book="" hidden="false" profileTypeId="1960-ca8e-67ce-2014">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Move" characteristicTypeId="8655-6213-2824-1752" value="*"/>
+            <characteristic name="Wounds" characteristicTypeId="cd0e-fea6-411f-904d" value="11"/>
+            <characteristic name="Bravery" characteristicTypeId="0c85-bf79-836b-759e" value="6"/>
+            <characteristic name="Save" characteristicTypeId="f8dd-4f2a-8543-4f36" value="4+"/>
+          </characteristics>
+        </profile>
+        <profile id="5666-a3f4-8961-e90b" name="Portents of Battle" book="" hidden="false" profileTypeId="c924-5a68-471a-2fd5">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="You can add 1 to the hit rolls of any Order units from yoru army within range of any Celestial Hurricanum&apos;s Portents of Battle ability when they attack; the range of this abliity is shown in the Damage Table."/>
+          </characteristics>
+        </profile>
+        <profile id="5bce-7a3d-f46a-d258" name="Locus of Azyr" book="" hidden="false" profileTypeId="c924-5a68-471a-2fd5">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="Add 1 to the casting rolls for Collegiate Arcane Wizards from your army within 10&quot; of any Celestial Hurricanums in the hero phase."/>
+          </characteristics>
+        </profile>
+        <profile id="0772-f0df-a664-ce72" name="Wounds0" hidden="false" profileTypeId="90d1-a434-348d-a861" profileTypeName="Damage Table">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Variable 1" characteristicTypeId="420a-645a-ab28-93a0" value="Wounds Suffered"/>
+            <characteristic name="Variable 2" characteristicTypeId="4cdd-1e03-530f-0ff7" value="Move"/>
+            <characteristic name="Variable 3" characteristicTypeId="b1ea-56be-ba52-16e9" value="Portents of Battle"/>
+            <characteristic name="Variable 4" characteristicTypeId="ad26-bf56-95c4-80f1" value="Storm of Shemtek"/>
+          </characteristics>
+        </profile>
+        <profile id="78c2-6eb0-e7e2-2b3c" name="Wounds1" hidden="false" profileTypeId="90d1-a434-348d-a861" profileTypeName="Damage Table">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Variable 1" characteristicTypeId="420a-645a-ab28-93a0" value="0-2"/>
+            <characteristic name="Variable 2" characteristicTypeId="4cdd-1e03-530f-0ff7" value="10&quot;"/>
+            <characteristic name="Variable 3" characteristicTypeId="b1ea-56be-ba52-16e9" value="10&quot;"/>
+            <characteristic name="Variable 4" characteristicTypeId="ad26-bf56-95c4-80f1" value="3"/>
+          </characteristics>
+        </profile>
+        <profile id="0d2a-802f-abba-5f31" name="Wounds2" hidden="false" profileTypeId="90d1-a434-348d-a861" profileTypeName="Damage Table">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Variable 1" characteristicTypeId="420a-645a-ab28-93a0" value="3-4"/>
+            <characteristic name="Variable 2" characteristicTypeId="4cdd-1e03-530f-0ff7" value="9&quot;"/>
+            <characteristic name="Variable 3" characteristicTypeId="b1ea-56be-ba52-16e9" value="8&quot;"/>
+            <characteristic name="Variable 4" characteristicTypeId="ad26-bf56-95c4-80f1" value="2"/>
+          </characteristics>
+        </profile>
+        <profile id="d279-0d92-94fa-36e6" name="Wounds3" hidden="false" profileTypeId="90d1-a434-348d-a861" profileTypeName="Damage Table">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Variable 1" characteristicTypeId="420a-645a-ab28-93a0" value="5-6"/>
+            <characteristic name="Variable 2" characteristicTypeId="4cdd-1e03-530f-0ff7" value="8&quot;"/>
+            <characteristic name="Variable 3" characteristicTypeId="b1ea-56be-ba52-16e9" value="6&quot;"/>
+            <characteristic name="Variable 4" characteristicTypeId="ad26-bf56-95c4-80f1" value="2"/>
+          </characteristics>
+        </profile>
+        <profile id="d554-b84a-3879-3a5e" name="Wounds4" hidden="false" profileTypeId="90d1-a434-348d-a861" profileTypeName="Damage Table">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Variable 1" characteristicTypeId="420a-645a-ab28-93a0" value="7-8"/>
+            <characteristic name="Variable 2" characteristicTypeId="4cdd-1e03-530f-0ff7" value="7&quot;"/>
+            <characteristic name="Variable 3" characteristicTypeId="b1ea-56be-ba52-16e9" value="4&quot;"/>
+            <characteristic name="Variable 4" characteristicTypeId="ad26-bf56-95c4-80f1" value="1"/>
+          </characteristics>
+        </profile>
+        <profile id="785b-f4f9-93f6-5bca" name="Wounds5" hidden="false" profileTypeId="90d1-a434-348d-a861" profileTypeName="Damage Table">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Variable 1" characteristicTypeId="420a-645a-ab28-93a0" value="9+"/>
+            <characteristic name="Variable 2" characteristicTypeId="4cdd-1e03-530f-0ff7" value="6&quot;"/>
+            <characteristic name="Variable 3" characteristicTypeId="b1ea-56be-ba52-16e9" value="2&quot;"/>
+            <characteristic name="Variable 4" characteristicTypeId="ad26-bf56-95c4-80f1" value="1"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers>
+        <modifier type="append" field="name" value="with Celestial Battlemage [LEADER]">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="d4dd-f8cd-fa3d-6555" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1b60-0f13-7ae2-65a9" type="greaterThan"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="c967-1ddc-1526-e517" name="New CategoryLink" hidden="false" targetId="ae44-d523-ca44-b38b" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="d9b4-f389-4c38-d4fb" name="New CategoryLink" hidden="false" targetId="d2e0-123f-1dd2-7992" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="1095-4518-dfc5-d6b7" name="New CategoryLink" hidden="false" targetId="2308-7db2-829e-94b3" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="17b5-b764-81c9-3cb9" name="New CategoryLink" hidden="false" targetId="4f53-8230-2f02-9639" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="0fb2-3078-18d0-b023" name="New CategoryLink" hidden="false" targetId="b970-b3bf-e1a4-a6fc" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="b0fe-31fb-56db-c237" name="Warhorses&apos; Steel-shod Hooves" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="a1dc-1e39-db3e-419f" name="Warhorses&apos; Steel-shod Hooves" book="" hidden="false" profileTypeId="96df-ab28-5d72-bbb3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
+                <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="4"/>
+                <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="4+"/>
+                <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="4+"/>
+                <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-"/>
+                <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="552d-b121-5388-93f1" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="de36-7311-efd4-52a3" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs/>
+        </selectionEntry>
+        <selectionEntry id="bcad-b200-0ba0-0ae9" name="Acolytes&apos; Arcane Tools" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="e8ab-5e03-68b0-ae6e" name="Acolytes&apos; Arcane Tools" book="" hidden="false" profileTypeId="96df-ab28-5d72-bbb3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
+                <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="4"/>
+                <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="5+"/>
+                <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="5+"/>
+                <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-"/>
+                <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e8a9-377d-e284-1c0f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5c82-2ac5-33fd-6cc0" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs/>
+        </selectionEntry>
+        <selectionEntry id="e8e4-bbe8-9e2e-7392" name="Storm of Shemtek" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="2133-0d43-f604-747f" name="Storm of Shemtek" book="" hidden="false" profileTypeId="96df-ab28-5d72-bbb3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Missile"/>
+                <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="18&quot;"/>
+                <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="*"/>
+                <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="N/A"/>
+                <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="N/A"/>
+                <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="N/A"/>
+                <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="N/A"/>
+              </characteristics>
+            </profile>
+            <profile id="1294-0e8a-b41b-5948" name="Storm of Shemtek" book="" hidden="false" profileTypeId="c924-5a68-471a-2fd5">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="Each time you make a Storm of Shemtek attack, select a target unit that is visible and in rane, then roll a dice to see what kind of fury is unleashed from the heavens:  1-3: The Target suffers a mortal wound 4-5: The target suffers D3 mortal wounds 6: The target suffers D6 mortal wounds"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="afaf-0145-964f-dcd4" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b84d-f83d-0d51-a727" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs/>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="efd0-2552-98ba-5865" name="Celestial Battlemage" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="1b60-0f13-7ae2-65a9" name="Celestial Battlemage" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="f3c1-6f0b-1b99-9817" name="Celestial Battlemage" book="" hidden="false" profileTypeId="f55d-ee3a-1597-110f">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Cast/Unbind" characteristicTypeId="8294-f605-2c0f-8f92" value="1/1"/>
+                    <characteristic name="Spells Known" characteristicTypeId="dc9c-47d3-6931-859c" value="Arcane Bolt, Mystic Shield, Comet of Casandora"/>
+                  </characteristics>
+                </profile>
+                <profile id="5a9b-eecf-2fe6-5735" name="Comet of Casandora" book="" hidden="false" profileTypeId="2e81-5e22-c6e1-73cb">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Casting Value" characteristicTypeId="2508-b604-1258-a920" value="6"/>
+                    <characteristic name="Description" characteristicTypeId="76ff-781d-b8e6-5f27" value="If successfully cast, pick a unit within 18&quot; of the caster.  Your opponent must then select one of his units that is within 18&quot; of the caster (this can be the same unit as the one you chose).  Then roll a dice; on a 1, 2, or 3 the unit your opponent picked is struck by the falling comet, and on a 4 or more, the unit you picked is struck.  That unit suffers D6 mortal wounds."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks>
+                <infoLink id="31bb-cd6b-7150-28e6" name="Arcane Bolt" hidden="false" targetId="ae02-a84f-a903-1ff8" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="cf28-dce0-ec3b-c1fc" name="Mystic Shield" hidden="false" targetId="b41f-f1ce-7aa5-4f81" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fc78-d275-5225-d659" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="15d6-77da-501c-4d5e" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="c702-ac64-8540-7742" name="New CategoryLink" hidden="false" targetId="4e0e-664d-51ea-0929" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="b631-b535-67c8-500d" name="Artefacts" hidden="false" targetId="083e-a950-b54a-c2a4" type="selectionEntryGroup">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="02f5-bf70-2f02-33cf" name="Battlemage&apos;s Staff" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="f08b-6b38-b69c-0e96" name="Battlemage&apos;s Staff" book="" hidden="false" profileTypeId="96df-ab28-5d72-bbb3">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                    <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="2&quot;"/>
+                    <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="1"/>
+                    <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="4+"/>
+                    <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+                    <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-1"/>
+                    <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="D3"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c3a4-31a1-fed0-8246" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a4f6-aa1e-d25e-6ddd" type="min"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs/>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="28e2-ed9c-a33d-53dd" name="General" hidden="false" targetId="b341-0885-3f1c-7d8a" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1b60-0f13-7ae2-65a9" type="notEqualTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="380.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ec08-7605-f909-609e" name="Luminark of Hysh" hidden="false" collective="false" type="unit">
+      <profiles>
+        <profile id="955e-9c80-b598-0614" name="Luminark of Hysh" book="" hidden="false" profileTypeId="1960-ca8e-67ce-2014">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Move" characteristicTypeId="8655-6213-2824-1752" value="*"/>
+            <characteristic name="Wounds" characteristicTypeId="cd0e-fea6-411f-904d" value="11"/>
+            <characteristic name="Bravery" characteristicTypeId="0c85-bf79-836b-759e" value="6"/>
+            <characteristic name="Save" characteristicTypeId="f8dd-4f2a-8543-4f36" value="4+"/>
+          </characteristics>
+        </profile>
+        <profile id="4fd5-3398-47e4-4e0a" name="Aura of Protection" book="" hidden="false" profileTypeId="c924-5a68-471a-2fd5">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="You can roll a dice each time an ORDER model from your army suffers a wound or mortal wound whilst within range of a Luminark&apos;s Aura of Protection ability; on a 6 that attack is deflected by the aura and that wound is ignored.  The range of this ability is shown in the Damage Table."/>
+          </characteristics>
+        </profile>
+        <profile id="943c-d043-d68b-3180" name="Locus of Hysh" book="" hidden="false" profileTypeId="c924-5a68-471a-2fd5">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="Add 1 to the unbinding rolls for COLLEGIATE ARCANE WIZARDS from your army within 10&quot; of any Luminarks of Hysh."/>
+          </characteristics>
+        </profile>
+        <profile id="2a2f-1084-dd12-90cb" name="Wounds0" hidden="false" profileTypeId="90d1-a434-348d-a861" profileTypeName="Damage Table">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Variable 1" characteristicTypeId="420a-645a-ab28-93a0" value="Wounds Suffered"/>
+            <characteristic name="Variable 2" characteristicTypeId="4cdd-1e03-530f-0ff7" value="Move"/>
+            <characteristic name="Variable 3" characteristicTypeId="b1ea-56be-ba52-16e9" value="Aura of Protection"/>
+            <characteristic name="Variable 4" characteristicTypeId="ad26-bf56-95c4-80f1" value="Searing Beam of Light"/>
+          </characteristics>
+        </profile>
+        <profile id="03f8-7e3f-e543-90db" name="Wounds1" hidden="false" profileTypeId="90d1-a434-348d-a861" profileTypeName="Damage Table">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Variable 1" characteristicTypeId="420a-645a-ab28-93a0" value="0-2"/>
+            <characteristic name="Variable 2" characteristicTypeId="4cdd-1e03-530f-0ff7" value="10&quot;"/>
+            <characteristic name="Variable 3" characteristicTypeId="b1ea-56be-ba52-16e9" value="10&quot;"/>
+            <characteristic name="Variable 4" characteristicTypeId="ad26-bf56-95c4-80f1" value="6"/>
+          </characteristics>
+        </profile>
+        <profile id="d7dc-9ea3-ab1a-2ef5" name="Wounds2" hidden="false" profileTypeId="90d1-a434-348d-a861" profileTypeName="Damage Table">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Variable 1" characteristicTypeId="420a-645a-ab28-93a0" value="3-4"/>
+            <characteristic name="Variable 2" characteristicTypeId="4cdd-1e03-530f-0ff7" value="9&quot;"/>
+            <characteristic name="Variable 3" characteristicTypeId="b1ea-56be-ba52-16e9" value="8&quot;"/>
+            <characteristic name="Variable 4" characteristicTypeId="ad26-bf56-95c4-80f1" value="D6"/>
+          </characteristics>
+        </profile>
+        <profile id="d0a8-6fb9-c7ad-72d8" name="Wounds3" hidden="false" profileTypeId="90d1-a434-348d-a861" profileTypeName="Damage Table">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Variable 1" characteristicTypeId="420a-645a-ab28-93a0" value="5-6"/>
+            <characteristic name="Variable 2" characteristicTypeId="4cdd-1e03-530f-0ff7" value="8&quot;"/>
+            <characteristic name="Variable 3" characteristicTypeId="b1ea-56be-ba52-16e9" value="6&quot;"/>
+            <characteristic name="Variable 4" characteristicTypeId="ad26-bf56-95c4-80f1" value="D6"/>
+          </characteristics>
+        </profile>
+        <profile id="5af1-bbb2-508c-21b5" name="Wounds4" hidden="false" profileTypeId="90d1-a434-348d-a861" profileTypeName="Damage Table">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Variable 1" characteristicTypeId="420a-645a-ab28-93a0" value="7-8"/>
+            <characteristic name="Variable 2" characteristicTypeId="4cdd-1e03-530f-0ff7" value="7&quot;"/>
+            <characteristic name="Variable 3" characteristicTypeId="b1ea-56be-ba52-16e9" value="4&quot;"/>
+            <characteristic name="Variable 4" characteristicTypeId="ad26-bf56-95c4-80f1" value="D3"/>
+          </characteristics>
+        </profile>
+        <profile id="49eb-5b1a-fcc0-07fc" name="Wounds5" hidden="false" profileTypeId="90d1-a434-348d-a861" profileTypeName="Damage Table">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Variable 1" characteristicTypeId="420a-645a-ab28-93a0" value="9+"/>
+            <characteristic name="Variable 2" characteristicTypeId="4cdd-1e03-530f-0ff7" value="6&quot;"/>
+            <characteristic name="Variable 3" characteristicTypeId="b1ea-56be-ba52-16e9" value="2&quot;"/>
+            <characteristic name="Variable 4" characteristicTypeId="ad26-bf56-95c4-80f1" value="D3"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers>
+        <modifier type="append" field="name" value="with White Battlemage [LEADER]">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="ec08-7605-f909-609e" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="845e-c4c8-6076-0c35" type="greaterThan"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="95e2-654d-b6bb-9338" name="New CategoryLink" hidden="false" targetId="d2e0-123f-1dd2-7992" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="fa4a-524e-3d5b-e218" name="New CategoryLink" hidden="false" targetId="2308-7db2-829e-94b3" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="860f-43c3-209a-4b6f" name="New CategoryLink" hidden="false" targetId="0cda-4c8e-b048-9cfe" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="91d5-97b0-5e6f-6879" name="New CategoryLink" hidden="false" targetId="4f53-8230-2f02-9639" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="6e05-235f-91e8-3094" name="New CategoryLink" hidden="false" targetId="b970-b3bf-e1a4-a6fc" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="486c-2076-1f71-903e" name="Warhorses&apos; Steel-shod Hooves" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="db9a-1bae-12a3-b287" name="Warhorses&apos; Steel-shod Hooves" book="" hidden="false" profileTypeId="96df-ab28-5d72-bbb3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
+                <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="4"/>
+                <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="4+"/>
+                <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="4+"/>
+                <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-"/>
+                <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="154d-4e7f-bb14-561a" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f796-7a4b-c3df-8c95" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs/>
+        </selectionEntry>
+        <selectionEntry id="7c6b-ff0a-560a-8299" name="Searing Beam of Light" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="e925-7d4a-662f-5d77" name="Searing Beam of Light" book="" hidden="false" profileTypeId="96df-ab28-5d72-bbb3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Missile"/>
+                <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="30&quot;"/>
+                <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="1"/>
+                <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="3+"/>
+                <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+                <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-2"/>
+                <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="*"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="73c2-2aba-ff71-d335" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4571-e3e7-3314-8be7" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs/>
+        </selectionEntry>
+        <selectionEntry id="cc40-bfa5-c662-0cfc" name="Acolytes&apos; Arcane Tools" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="2814-b914-9f78-f30e" name="Acolytes&apos; Arcane Tools" book="" hidden="false" profileTypeId="96df-ab28-5d72-bbb3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
+                <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="4"/>
+                <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="5+"/>
+                <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="5+"/>
+                <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-"/>
+                <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6ebb-c25c-79e7-066f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a773-aedf-a466-7e6e" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs/>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="a142-2405-da0a-e59c" name="White Battlemage" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="845e-c4c8-6076-0c35" name="White Battlemage" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="a1ae-5788-ffa9-ceb9" name="Burning Gaze" book="" hidden="false" profileTypeId="2e81-5e22-c6e1-73cb">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Casting Value" characteristicTypeId="2508-b604-1258-a920" value="6"/>
+                    <characteristic name="Description" characteristicTypeId="76ff-781d-b8e6-5f27" value="If successfully cast, pick a visible unit within 18&quot;. That unit suffers D3 mortal wounds.  Double the number of wounds inflicted if the target has 10 or more models, and tripple them if the target has 20 or more."/>
+                  </characteristics>
+                </profile>
+                <profile id="ab0e-d1fe-bd15-96b4" name="White Battlemage" book="" hidden="false" profileTypeId="f55d-ee3a-1597-110f">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Cast/Unbind" characteristicTypeId="8294-f605-2c0f-8f92" value="1/1"/>
+                    <characteristic name="Spells Known" characteristicTypeId="dc9c-47d3-6931-859c" value="Arcane Bolt, Mystic Shield, Burning Gaze"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks>
+                <infoLink id="88eb-a48f-38b6-39f9" name="Arcane Bolt" hidden="false" targetId="ae02-a84f-a903-1ff8" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="7df9-000e-9ed2-97f1" name="Mystic Shield" hidden="false" targetId="b41f-f1ce-7aa5-4f81" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1892-2305-f1f1-9cea" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="a612-9443-88a2-c7c4" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="50c0-6946-06cc-21ea" name="New CategoryLink" hidden="false" targetId="4e0e-664d-51ea-0929" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+              <selectionEntries>
+                <selectionEntry id="7625-6d19-c781-82d0" name="Battlemage&apos;s Staff" hidden="false" collective="false" type="upgrade">
+                  <profiles>
+                    <profile id="3f11-e247-fb42-f655" name="Battlemage&apos;s Staff" book="" hidden="false" profileTypeId="96df-ab28-5d72-bbb3">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                        <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="2&quot;"/>
+                        <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="1"/>
+                        <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="4+"/>
+                        <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+                        <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-1"/>
+                        <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="D3"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ee5e-4f9b-3d82-f20d" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1887-b550-1c04-25ee" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs/>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="a196-b599-3b59-4f91" name="Artefacts" hidden="false" targetId="083e-a950-b54a-c2a4" type="selectionEntryGroup">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="2ea8-653d-5c71-1b32" name="General" hidden="false" targetId="b341-0885-3f1c-7d8a" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="845e-c4c8-6076-0c35" type="notEqualTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="240.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b341-0885-3f1c-7d8a" name="General" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <repeats/>
+          <conditions/>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
+              </conditions>
+              <conditionGroups/>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="732b-2c98-83ac-ed2a" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="4bef-db68-92fe-6b80" name="New CategoryLink" hidden="false" targetId="b745-17c4-8fbf-8b04" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="4e6c-1d81-17f6-5507" name="Command Traits" hidden="false" targetId="1d10-2017-059e-f52d" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedSelectionEntryGroups>
+    <selectionEntryGroup id="083e-a950-b54a-c2a4" name="Artefacts" hidden="false" collective="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="903c-54ee-5c65-eed8" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="0efd-5714-dbd3-bad6" name="Artefacts of Order" hidden="false" targetId="19d0-4499-b76e-96c1" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d51d-dec8-f7a7-351d" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="1d10-2017-059e-f52d" name="Command Traits" hidden="false" collective="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b745-17c4-8fbf-8b04" type="notInstanceOf"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b7cd-9b0e-9faf-6ea4" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="f506-fb61-f543-c4a8" name="Order Command Traits" hidden="false" targetId="50aa-000b-1848-15c3" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+    </selectionEntryGroup>
+  </sharedSelectionEntryGroups>
+  <sharedRules/>
+  <sharedProfiles>
+    <profile id="b4dd-317b-c960-f38d" name="Darkshields" book="" hidden="false" profileTypeId="c924-5a68-471a-2fd5">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="You can re-roll save rolls of 1 for a unit with Darkshields.  You can re-roll failed save rolls of 1 or 2 for this unit in the combat phase instead."/>
+      </characteristics>
+    </profile>
+    <profile id="3bf7-7f3a-771e-069a" name="Skyhook" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Missile"/>
+        <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="24&quot;"/>
+        <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="1"/>
+        <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="4+"/>
+        <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+        <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-2"/>
+        <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="3"/>
+      </characteristics>
+    </profile>
+    <profile id="16f6-72fd-bc23-c437" name="Pistol (Hero)" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Missile"/>
+        <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="9&quot;"/>
+        <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="1"/>
+        <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="3+"/>
+        <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+        <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-1"/>
+        <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
+      </characteristics>
+    </profile>
+    <profile id="3851-5e47-b865-496a" name="Freeguild Handgun" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Missile"/>
+        <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="16&quot;"/>
+        <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="1"/>
+        <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="5+"/>
+        <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+        <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-1"/>
+        <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
+      </characteristics>
+    </profile>
+    <profile id="1c01-dbfd-49c6-5461" name="Brace of Pistols (Missile)" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Missile"/>
+        <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="9&quot;"/>
+        <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="2"/>
+        <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="5+"/>
+        <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+        <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-1"/>
+        <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
+      </characteristics>
+    </profile>
+    <profile id="a9b7-f1fb-0a97-72c0" name="Brace of Pistols (Melee)" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+        <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
+        <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="2"/>
+        <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="5+"/>
+        <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+        <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-1"/>
+        <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
+      </characteristics>
+    </profile>
+    <profile id="2193-422c-65a5-b9ce" name="Repeater Handgun (Leader)" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Missile"/>
+        <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="14&quot;"/>
+        <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="D3"/>
+        <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="5+"/>
+        <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+        <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-1"/>
+        <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
+      </characteristics>
+    </profile>
+    <profile id="8d04-7317-cce0-80e8" name="Sigmarite Warhammer" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+        <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
+        <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="4"/>
+        <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="4+"/>
+        <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="4+"/>
+        <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-"/>
+        <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
+      </characteristics>
+    </profile>
+  </sharedProfiles>
+</catalogue>


### PR DESCRIPTION
Updated Collegiate Arcane:
Celestial Hurricanum incorrectly showing as 'Leader' when Celestial Mage not added
Luminark of Hysh incorrectly showing as 'Leader' when White Mage not added
Luminark and Hurricanum missing Artefacts
Updated Weapons to include SE on unit
Luminark and Hurricanum unable to be selected as general