### PR TITLE
Chaos khorne updates

### DIFF
--- a/Chaos - Khorne.cat
+++ b/Chaos - Khorne.cat
@@ -62,6 +62,31 @@
         <characteristicType id="9bc8-570b-da79-8611" name="Mighty Axe of Khorne"/>
       </characteristicTypes>
     </profileType>
+    <profileType id="9c58-8858-0964-2b7d" name="Soul Grinder Wounds Suffered">
+      <characteristicTypes>
+        <characteristicType id="b0a4-7abe-3239-c92a" name="Move"/>
+        <characteristicType id="ebc9-9350-e12b-84a9" name="Harvester Cannon"/>
+        <characteristicType id="1394-0752-952b-55e7" name="Piston-driven Legs"/>
+      </characteristicTypes>
+    </profileType>
+    <profileType id="65ac-ba71-6bc2-4365" name="Gigantic Chaos Spawn Wounds Suffered">
+      <characteristicTypes>
+        <characteristicType id="4a7e-f7c8-6c21-acad" name="Move"/>
+        <characteristicType id="8ea1-0116-40b5-1b41" name="Crushing Jaws"/>
+      </characteristicTypes>
+    </profileType>
+    <profileType id="b6a2-008f-9e59-df68" name="Plaything of the Gods">
+      <characteristicTypes>
+        <characteristicType id="0152-6755-50dd-c13d" name="Effect"/>
+      </characteristicTypes>
+    </profileType>
+    <profileType id="9850-0517-4974-24ba" name="Mazrall Wounds Suffered">
+      <characteristicTypes>
+        <characteristicType id="03ed-1cd2-0d05-559d" name="Move"/>
+        <characteristicType id="2b90-338b-0385-ad6f" name="Harrow Meat"/>
+        <characteristicType id="a7b0-c2ce-697b-fba1" name="Ancyte&apos;s Shield Blades"/>
+      </characteristicTypes>
+    </profileType>
   </profileTypes>
   <categoryEntries>
     <categoryEntry id="28cc-5c0c-ed3e-fa91" name="BLOODBOUND" hidden="false">
@@ -331,6 +356,55 @@
       <constraints/>
     </categoryEntry>
     <categoryEntry id="5d90-1f99-fb4d-2fd7" name="RIPTOOTH" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="1c84-df70-ead8-d11c" name="CHAOS SPAWN" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="a154-9fce-7de2-439f" name="SOUL GRINDER" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="37de-a6c9-b8c0-610e" name="TAMURKHAN&apos;S HORDE" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="9156-9f50-b935-6006" name="DAEMON PRINCE" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="0adb-3e44-760d-015f" name="FURIES" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="0124-e1e8-c2e7-ef6b" name="MAZRALL THE BUTCHER" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="0d42-43fb-57b1-0841" name="SKAARAC THE BLOODBORN" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -1606,6 +1680,123 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
+    <entryLink id="c922-0e7f-61d6-c680" name="Daemon Prince (of Khorne)" hidden="false" targetId="8ce7-8f12-7675-5e3d" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="3ee4-b9a7-3425-1ce6" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="b0f7-4970-4339-6935" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="ceb1-ff45-e64c-2344" name="Chaos Spawn" hidden="false" targetId="3c49-5d28-4581-6b78" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="39c5-bab0-b8e2-9978" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="26bd-f17b-cf45-1b40" name="Gigantic Chaos Spawn of Khorne" hidden="false" targetId="83fa-dff7-c115-8f42" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="f215-8b97-ce34-c67c" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="43b0-a38d-3d6e-339f" name="Furies (of Khorne)" hidden="false" targetId="6549-dda6-35e3-8010" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="dc7f-0fbc-aa99-a469" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="f726-d283-09ad-8220" name="Mazrall the Butcher, Daemon Prince of Khorne" hidden="false" targetId="de8c-b9b6-51fb-6c9a" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="24c3-f643-11d6-3bc6" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="7b97-c17a-02cd-50cd" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="9c94-d329-5bd2-7ba3" name="Skaarac the Bloodborn" hidden="false" targetId="5582-7a1b-e477-10d5" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="57be-2947-930a-d8d7" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="43dc-d6b8-bb10-04b4" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+    </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="7ab9-de0a-88c2-4fd1" name="General" hidden="false" collective="false" type="upgrade">
@@ -2489,7 +2680,9 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="cb7a-2a30-c407-d701" name="Battalion: Blood Hunt" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -2728,7 +2921,9 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="d39a-4082-0c4c-b899" name="Blood Throne" hidden="false" collective="false" type="unit">
       <profiles>
@@ -3624,8 +3819,8 @@
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a1b7-725b-29a7-3d51" type="min"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cc3d-45b6-d5d8-2f57" type="max"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1b7-725b-29a7-3d51" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc3d-45b6-d5d8-2f57" type="max"/>
           </constraints>
           <categoryLinks/>
           <selectionEntries/>
@@ -3701,8 +3896,8 @@
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0c4a-0055-7fb1-fa83" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c622-e1b5-d2f8-6789" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c4a-0055-7fb1-fa83" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c622-e1b5-d2f8-6789" type="max"/>
           </constraints>
           <categoryLinks/>
           <selectionEntries/>
@@ -3778,8 +3973,8 @@
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ff7c-b807-9901-7848" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7d1a-3070-28c2-3b1a" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff7c-b807-9901-7848" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d1a-3070-28c2-3b1a" type="max"/>
           </constraints>
           <categoryLinks/>
           <selectionEntries/>
@@ -3805,7 +4000,9 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="45b7-db81-23e4-78c8" name="Battalion: Bloodbound Warhorde" hidden="false" collective="false" type="upgrade">
       <profiles/>
@@ -3924,6 +4121,22 @@
                 </categoryLink>
               </categoryLinks>
             </entryLink>
+            <entryLink id="af8a-2983-5180-b697" name="Khorgos Khull" hidden="false" targetId="595a-599f-1b18-246c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="1211-42b4-24c5-eee5" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="4713-0df6-50c3-1511" name="The Gorechosen" hidden="false" collective="false">
@@ -3932,8 +4145,8 @@
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="782f-b2a0-e512-5110" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d685-bc6a-7a65-f7c1" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="782f-b2a0-e512-5110" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d685-bc6a-7a65-f7c1" type="max"/>
           </constraints>
           <categoryLinks/>
           <selectionEntries/>
@@ -4133,7 +4346,9 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="e52f-0fd9-6fe1-5c89" name="Bloodcrushers" hidden="false" collective="false" type="unit">
       <profiles>
@@ -4417,42 +4632,6 @@
             <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Roll a dice for each enemy model within 3&quot; of a Bloodforged model at the start of each of your hero phases. On a roll of 6, you can immediately attack (but not pile in) with all of the melee weapons of the enemy model being rolled for as though it was part of your army. The model can attack its own unit, and even itself."/>
           </characteristics>
         </profile>
-        <profile id="7007-fbfc-d30d-0367" name="-" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="A Bloodforged battalion consists of the following units:"/>
-          </characteristics>
-        </profile>
-        <profile id="699b-1ab0-3f0c-afec" name="Skullgrinder" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1"/>
-          </characteristics>
-        </profile>
-        <profile id="ae81-9ffd-8c99-9015" name="Wrathmongers" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="2-4 units"/>
-          </characteristics>
-        </profile>
-        <profile id="e2da-b153-2940-9e7c" name="Blood Warriors" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1-3 units"/>
-          </characteristics>
-        </profile>
       </profiles>
       <rules/>
       <infoLinks/>
@@ -4478,9 +4657,151 @@
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="9dd3-3024-5e59-d79f" name="1-3 units of Blood Warriors" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be51-82cb-e3fa-623b" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d78-9855-f901-a302" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="cbb9-68ee-3b96-fa78" name="Blood Warriors" hidden="false" targetId="9361-fa26-31b7-4a10" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="notInstanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="6c20-ea20-7b13-6e73" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="79df-535a-6a94-21da" name="Blood Warriors" hidden="false" targetId="9361-fa26-31b7-4a10" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="b765-8cc7-b976-411d" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="1f83-7644-23a5-0e21" name="1 Skullgrinder" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2fb-ac73-11c6-ccbc" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="16f4-8b95-7742-0140" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="f67c-757d-063c-3828" name="Skullgrinder" hidden="false" targetId="e167-7729-8c8b-bf26" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="77a2-d1e7-14c7-7d77" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="aae6-2088-6456-4035" name="2-4 units of Wrathmongers" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="581e-182d-1bb4-b71d" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09a4-ab2f-fcdd-07ca" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="4e7f-e778-eb27-e035" name="Wrathmongers" hidden="false" targetId="4fc6-7808-d334-a716" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="29dc-45da-0da4-b176" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="3012-ad18-c49d-24c2" name="Bloodletters" hidden="false" collective="false" type="unit">
       <profiles>
@@ -6272,7 +6593,9 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="54ed-273a-ff0d-b1d0" name="Battalion: Brass Stampede" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -6303,33 +6626,6 @@
             <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="If a unit uses its Murderous Charge ability within 3&quot; of another unit in the Brass Stampede, you do not need to roll a dice - it automatically inflicts D3 mortal wounds (or D6 if the Mighty Skullcrusher unit includes 6 or more models) as the enemy is trampled to a bloody pulp."/>
           </characteristics>
         </profile>
-        <profile id="d206-08f4-0db9-0f3b" name="-" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="A Brass Stampede consists of the following units:"/>
-          </characteristics>
-        </profile>
-        <profile id="557a-ba5e-9c01-49cd" name="Lords of Khorne on Juggernaut" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="0-1"/>
-          </characteristics>
-        </profile>
-        <profile id="16ca-ce05-bbf5-a248" name="Mighty Skullcrushers" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="3-7 units"/>
-          </characteristics>
-        </profile>
       </profiles>
       <rules/>
       <infoLinks/>
@@ -6355,9 +6651,118 @@
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="057e-a4c6-420c-e4e8" name="0-1 Lords of Khorne on Juggernaut" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="059a-143b-fa95-4998" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ccac-1d42-f802-3d13" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="c8dd-ee6a-71e9-6872" name="Mighty Lord of Khorne" hidden="false" targetId="50ba-f44c-8f95-a084" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="0994-7bc0-c9ac-578d" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="066a-79a9-f546-37ec" name="3-7 units of Mighty Skullcrushers" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85c8-6f2e-2a9a-3f44" type="min"/>
+            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="38b0-f13b-5ff9-1bf8" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="f895-147e-48ca-e748" name="Mighty Skullcrushers" hidden="false" targetId="f22b-7afb-d696-5145" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0472-ec32-ce10-0540" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8918-313c-dfeb-b3cc" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="fa1e-1aad-2696-9fee" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="1748-b457-cfe0-0abe" name="Mighty Skullcrushers" hidden="false" targetId="f22b-7afb-d696-5145" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8918-313c-dfeb-b3cc" type="equalTo"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0472-ec32-ce10-0540" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="4f38-cf5f-aaa2-0abf" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="a765-6bbb-3d30-5dda" name="Battalion: Charnel Host" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -6589,7 +6994,9 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="4871-f8d1-52f4-c5e0" name="Battalion: Council of Blood" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -6791,7 +7198,9 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="502c-6a0a-4fc2-5bcc" name="Battalion: Daemon Legion of Khorne" hidden="false" collective="false" type="upgrade">
       <profiles/>
@@ -6993,7 +7402,9 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="ed0a-8b27-5e9c-2d74" name="Battalion: Dark Feast" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -7013,42 +7424,6 @@
           <modifiers/>
           <characteristics>
             <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="The Bloodstoker drives the warriors of the Dark Feast ever onwards with the barbs of his lash - units from this battalion within 12&quot; of him do not need to take battleshock tests."/>
-          </characteristics>
-        </profile>
-        <profile id="6d4f-daf7-7462-2f3b" name="-" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="A Dark Feast consists of the following units:"/>
-          </characteristics>
-        </profile>
-        <profile id="845d-6470-0524-6123" name="SLAUGHTERPRIEST" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1"/>
-          </characteristics>
-        </profile>
-        <profile id="5941-7ca7-5de3-c73e" name="Bloodstoker" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1"/>
-          </characteristics>
-        </profile>
-        <profile id="1973-dca3-1048-a63a" name="Bloodreavers" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="3-6 units"/>
           </characteristics>
         </profile>
       </profiles>
@@ -7076,9 +7451,151 @@
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="423d-f6d6-8dca-e82d" name="1 SLAUGHTERPRIEST" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="808c-f5cb-bff3-7140" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d38-d99d-b6ac-0b48" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="6ba5-67af-857c-5817" name="Slaughterpriest" hidden="false" targetId="b805-6a44-d7ec-92e0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="0557-3697-0cf9-5507" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="1c0f-14ae-d474-c53d" name="1 Bloodstoker" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f8e-0d34-2a71-b266" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0204-ab13-6337-e326" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="dbf0-ed5c-4de6-ab58" name="Bloodstoker" hidden="false" targetId="7ee0-2ba0-c052-200a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="d58d-5e86-95cd-c051" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="91aa-1827-a194-ec53" name="3-6 units of Bloodreavers" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e8b-dddd-71de-b543" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5034-792b-e379-c41f" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="c8c7-78c2-913e-56c4" name="Bloodreavers" hidden="false" targetId="78be-9de2-98c0-1b84" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="3aac-e709-13a5-f4cc" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="d114-ec5e-abe8-4155" name="Bloodreavers" hidden="false" targetId="78be-9de2-98c0-1b84" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="notInstanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="c0a6-6c31-1d56-2113" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="e888-8eef-c485-8b83" name="Exalted Deathbringer" hidden="false" collective="false" type="unit">
       <profiles>
@@ -7902,51 +8419,6 @@
             <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Increase the range of the Portal of Skulls ability of this battalion&apos;s Bloodsecrator by 6&quot; for each of this battalion&apos;s SLAUGHTERPRIESTS that are within 8&quot; of him when he opens the Portal of Skulls."/>
           </characteristics>
         </profile>
-        <profile id="c98b-9c47-76e4-b4dc" name="-" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="A Gore Pilgrims battalion consists of the following units:"/>
-          </characteristics>
-        </profile>
-        <profile id="8d9e-0478-7829-4039" name="Bloodsecrator" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1"/>
-          </characteristics>
-        </profile>
-        <profile id="9051-31f9-d37e-5944" name="SLAUGHTERPRIEST" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5"/>
-          </characteristics>
-        </profile>
-        <profile id="30b5-6ddd-132d-265c" name="Blood Warriors" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1-2 units"/>
-          </characteristics>
-        </profile>
-        <profile id="d310-c489-8af7-f387" name="Bloodreavers" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1-2 units"/>
-          </characteristics>
-        </profile>
       </profiles>
       <rules/>
       <infoLinks/>
@@ -7972,9 +8444,228 @@
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="116f-af67-ef27-9cb6" name="2-3 SLAUGHTERPRIESTS" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c68a-1b7c-7e95-15b1" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dfdc-7e9a-1d8c-d2e5" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="37c5-79b6-78aa-55d1" name="Slaughterpriest" hidden="false" targetId="b805-6a44-d7ec-92e0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="0db6-58c8-871b-2b91" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="467c-e9ed-dbb0-c8b0" name="1-2 units of Bloodreavers" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae04-7c0d-806d-864f" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="759c-a8f0-7ff9-e5ce" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="aa0b-3166-4675-bb99" name="Bloodreavers" hidden="false" targetId="78be-9de2-98c0-1b84" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="2d07-7ccf-c217-87c7" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="a4a6-958e-dd29-f39e" name="Bloodreavers" hidden="false" targetId="78be-9de2-98c0-1b84" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="notInstanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="ccad-3ca2-1b2f-ca40" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="1064-c56e-f40e-7901" name="1 Bloodsecrator" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7314-5a62-eec1-1d69" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a89b-79a3-830e-d3d4" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="2246-7069-cbd1-8e7a" name="Bloodsecrator" hidden="false" targetId="56be-4ba7-aa8b-81d6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="7d11-4ad4-0332-7162" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="a142-a683-64c3-00dc" name="1-2 units of Blood Warriors" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="66fd-8ee2-4012-5d9a" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="536a-9ca9-ee4e-17f8" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="0d5d-fd2f-c020-9b2c" name="Blood Warriors" hidden="false" targetId="9361-fa26-31b7-4a10" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="notInstanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="4281-6bd5-6b4e-ddde" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="9609-0e7c-ab20-77ae" name="Blood Warriors" hidden="false" targetId="9361-fa26-31b7-4a10" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="c343-3784-a86a-c724" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="38b0-9eab-8717-1264" name="Battalion: Gorethunder Cohort" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -7985,33 +8676,6 @@
           <modifiers/>
           <characteristics>
             <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="In each of your hero phases, D3 Skull Cannons from a Gorethunder Cohort that are withihn 8&quot; of their battalion&apos;s Blood Throne can shoot as if it were the shooting phase. If a Gorethunder Cohort contained the maximum number of units at the start of the battle, then all Skull Cannons that are within 8&quot; of their battalion&apos;s Blood Throne can shoot as if it were the shooting phase."/>
-          </characteristics>
-        </profile>
-        <profile id="6147-d983-3b38-741f" name="-" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="A Gorethunder Cohort consists of the following units:"/>
-          </characteristics>
-        </profile>
-        <profile id="f0bd-3b9a-952e-d52a" name="Blood Throne" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1"/>
-          </characteristics>
-        </profile>
-        <profile id="03ca-ede3-144b-3abd" name="Skull Cannons" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="3-8 units"/>
           </characteristics>
         </profile>
       </profiles>
@@ -8104,7 +8768,9 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="6578-af62-39ff-f9f2" name="Karanak" hidden="false" collective="false" type="unit">
       <profiles>
@@ -8152,7 +8818,7 @@
       <infoLinks/>
       <modifiers/>
       <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1458-76bd-d2d6-c1e4" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1458-76bd-d2d6-c1e4" type="max"/>
       </constraints>
       <categoryLinks>
         <categoryLink id="db19-1920-a68a-1677" name="New CategoryLink" hidden="false" targetId="7cdd-80ea-cbeb-8e16" primary="false">
@@ -8519,7 +9185,7 @@
       <infoLinks/>
       <modifiers/>
       <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4224-6a6a-ccf3-2e42" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4224-6a6a-ccf3-2e42" type="max"/>
       </constraints>
       <categoryLinks>
         <categoryLink id="4950-0ed3-8b13-fcca" name="New CategoryLink" hidden="false" targetId="7cdd-80ea-cbeb-8e16" primary="false">
@@ -9688,7 +10354,9 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="c470-a112-03b6-9129" name="Battalion: Red Headsmen" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -9708,42 +10376,6 @@
           <modifiers/>
           <characteristics>
             <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Red Headsmen always count as being within range of their Skullgrinder&apos;s Altar of Skulls ability. In addition, if the Skullgrinder slays a worthy foe, the range of his Altar of Skulls ability is doubled."/>
-          </characteristics>
-        </profile>
-        <profile id="9be3-6906-96ae-352a" name="-" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="A Red Headsmen battalion consists of the following units:"/>
-          </characteristics>
-        </profile>
-        <profile id="4001-7b7c-7924-3036" name="ASPIRING DEATHBRINGER" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1"/>
-          </characteristics>
-        </profile>
-        <profile id="5e21-f342-d8ba-3dfc" name="Skullgrinder" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1"/>
-          </characteristics>
-        </profile>
-        <profile id="54fb-f15d-218e-82e9" name="Blood Warriors" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="3-6 units"/>
           </characteristics>
         </profile>
       </profiles>
@@ -9771,9 +10403,151 @@
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="bfe8-5b2e-e766-d153" name="3-6 units of Blood Warriors" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f9c-bccd-4fc6-90cf" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a32-10e5-dfbd-a413" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="ad0b-4636-8a40-991c" name="Blood Warriors" hidden="false" targetId="9361-fa26-31b7-4a10" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="notInstanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="7bb3-f6bb-0509-5c46" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="98bd-6d9b-18eb-c061" name="Blood Warriors" hidden="false" targetId="9361-fa26-31b7-4a10" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="b463-5da5-a7ff-5d0d" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="fe64-1fd8-aed0-9389" name="1 Skullgrinder" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32de-c8b8-388d-e124" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f1e0-6807-9818-7dc4" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="5e7c-0f50-51d5-dcd5" name="Skullgrinder" hidden="false" targetId="e167-7729-8c8b-bf26" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="bf2c-a287-6930-036f" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="7621-3969-3ac3-d03d" name="1 ASPIRING DEATHBRINGER" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="273f-da20-8594-9461" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3b01-5c99-acaa-891c" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="4bbd-3be8-cb3e-5806" name="Aspiring Deathbringer" hidden="false" targetId="c098-9c13-471b-7fc8" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="0df0-4e7c-c276-abd1" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="6067-346b-d05a-72dc" name="Scyla Anfingrimm" hidden="false" collective="false" type="unit">
       <profiles>
@@ -10034,7 +10808,7 @@
       <infoLinks/>
       <modifiers/>
       <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7a20-6e2a-f4e3-2764" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7a20-6e2a-f4e3-2764" type="max"/>
       </constraints>
       <categoryLinks>
         <categoryLink id="fc58-a56e-d1c2-fae4" name="New CategoryLink" hidden="false" targetId="7cdd-80ea-cbeb-8e16" primary="false">
@@ -11107,51 +11881,6 @@
             <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="In each of your hero phases, you can make an attack with any Skull Cannons from a Skullseeker Host that are within 8&quot; of a KHORNE HERO from the same battalion. After resolving any attacks made in this manner, any other units in the same Skullseeker Host can immediately attempt to charge any units that suffers any unsaved wounds from these attcks, and can attack as described in Giant Killers if the unit they charge is a MONSTER."/>
           </characteristics>
         </profile>
-        <profile id="23d5-181c-f27b-f526" name="-" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="A Skullseeker Host consists of the following units:"/>
-          </characteristics>
-        </profile>
-        <profile id="b412-dd8e-3c51-c08b" name="Bloodthirster of Insensate Rage" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5"/>
-          </characteristics>
-        </profile>
-        <profile id="a564-250b-0328-423f" name="Bloodmaster, Herald of Khorne" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1"/>
-          </characteristics>
-        </profile>
-        <profile id="a255-972e-8149-9815" name="Bloodcrushers" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="2-5 units"/>
-          </characteristics>
-        </profile>
-        <profile id="b76a-3e84-3e52-f248" name="Skull Cannons" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1-3 units"/>
-          </characteristics>
-        </profile>
       </profiles>
       <rules/>
       <infoLinks/>
@@ -11355,7 +12084,9 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="3258-9691-5f0d-19e0" name="Battalion: Skulltake" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -11375,51 +12106,6 @@
           <modifiers/>
           <characteristics>
             <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="The Skulltake&apos;s Khorgoraths make 8 attacks wih their Claws and Fangs rather than 5, as long as their unit is within 6&quot; of any of the battalion&apos;s Skullreapers."/>
-          </characteristics>
-        </profile>
-        <profile id="3775-9cb4-2726-32cf" name="-" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="A Skulltake consists of the following units:"/>
-          </characteristics>
-        </profile>
-        <profile id="5787-faed-46b0-6b4f" name="Bloodstoker" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1"/>
-          </characteristics>
-        </profile>
-        <profile id="951b-690c-8333-d95a" name="Skullreapers" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="2-3 units"/>
-          </characteristics>
-        </profile>
-        <profile id="8cde-5aab-bc01-df6e" name="Khorgoraths" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1-2 units"/>
-          </characteristics>
-        </profile>
-        <profile id="c632-00fa-c73d-eeee" name="Blood Warriors, Bloodreavers" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="0-2 units in any combination."/>
           </characteristics>
         </profile>
       </profiles>
@@ -11447,9 +12133,244 @@
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="3eae-c0d8-94f7-720f" name="2-3 units of Skullreapers" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5cfb-178f-ec53-7b4d" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6a3-6619-92f8-a292" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="6e5b-afb7-a4e5-c013" name="Skullreapers" hidden="false" targetId="be0c-d1b0-5f46-48c4" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="caeb-8f88-aea6-d0d6" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6d0e-b400-6e5c-de92" name="1 Bloodstoker" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="66cb-79ff-4b59-0447" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a9a-734b-4f17-2572" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="d5e4-f54d-bb60-8b2c" name="Bloodstoker" hidden="false" targetId="7ee0-2ba0-c052-200a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="b0c5-e5fa-9e9b-1ca0" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="0723-f7ff-add5-932a" name="1-2 units of Khorgoraths" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d55-e2cb-74fe-2629" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26f5-0155-aede-43ba" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="720b-4c5d-b653-c03d" name="Khorgoraths" hidden="false" targetId="86c6-8197-045c-d1bb" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="8012-389f-d6a4-a2f4" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="fb22-edcd-c794-d93d" name="0-2 units chosen in any combination from the following list:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed81-52cd-4fa6-07e9" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="16ae-5161-63f2-aee0" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="ff10-068d-d364-336a" name="Blood Warriors" hidden="false" targetId="9361-fa26-31b7-4a10" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="notInstanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="46cb-1e3f-bfc2-3ba7" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="3701-b5c3-d025-8464" name="Blood Warriors" hidden="false" targetId="9361-fa26-31b7-4a10" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="457e-99de-6461-7107" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="6fa1-992e-f5b7-9c8c" name="Bloodreavers" hidden="false" targetId="78be-9de2-98c0-1b84" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="notInstanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="21ca-ef84-00c9-730a" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="8fa9-2587-e431-60a7" name="Bloodreavers" hidden="false" targetId="78be-9de2-98c0-1b84" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="a6b2-a796-b792-fe33" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="d0d5-c7ce-b8ef-4805" name="Skulltaker" hidden="false" collective="false" type="unit">
       <profiles>
@@ -11488,7 +12409,7 @@
       <infoLinks/>
       <modifiers/>
       <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9bc4-bc0c-1a68-4af1" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9bc4-bc0c-1a68-4af1" type="max"/>
       </constraints>
       <categoryLinks>
         <categoryLink id="bfe9-19cc-321c-e3c0" name="New CategoryLink" hidden="false" targetId="7cdd-80ea-cbeb-8e16" primary="false">
@@ -11689,7 +12610,9 @@
       </selectionEntries>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="f7da-d7af-dfa7-865d" name="Battalion: The Gorechosen" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -11709,33 +12632,6 @@
           <modifiers/>
           <characteristics>
             <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="The Gorexhosen are uquestionable paragons of violence, each one handpicked for his ferocity and might - add 1 to the Attacks characteristic of all of their melee weapons."/>
-          </characteristics>
-        </profile>
-        <profile id="3af6-b2c1-9bd7-0b33" name="-" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="A Gorechosen battalion consists of the following units:"/>
-          </characteristics>
-        </profile>
-        <profile id="7afb-e195-1dc4-94ed" name="EXALTED DEATHBRINGER" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5"/>
-          </characteristics>
-        </profile>
-        <profile id="7b95-7e0d-f375-2f5b" name="ASPIRING DEATHBRINGER, SLAUGHTERPRIEST, Skullgrinder, Bloodstoker, Bloodsecrator" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="7 units in any combination."/>
           </characteristics>
         </profile>
       </profiles>
@@ -11763,9 +12659,198 @@
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="49c6-032f-cf93-6a96" name="1 EXALTED DEATHBRINGER" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b9ae-d84d-401d-7758" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aae4-6046-162d-c102" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="749c-ab8b-006f-618f" name="Exalted Deathbringer" hidden="false" targetId="e888-8eef-c485-8b83" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="979b-7671-0f46-4270" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="d23e-72dd-1936-09a9" name="7 units chosen in any combination from the following list:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f54-9703-568a-b953" type="min"/>
+            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="77eb-789e-4e8b-b796" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="e0a3-dc6b-73e0-3780" name="ASPIRING DEATHBRINGER" hidden="false" collective="false" defaultSelectionEntryId="8591-8416-4c85-4878">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="8591-8416-4c85-4878" name="Aspiring Deathbringer" hidden="false" targetId="c098-9c13-471b-7fc8" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks>
+                    <categoryLink id="2c7a-c633-d352-9000" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="45b2-5bc1-14b4-2f00" name="Bloodstoker" hidden="false" collective="false" defaultSelectionEntryId="734a-5f99-dc9e-b6ed">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="734a-5f99-dc9e-b6ed" name="Bloodstoker" hidden="false" targetId="7ee0-2ba0-c052-200a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks>
+                    <categoryLink id="3df5-5334-1914-889d" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="91c5-59a0-472f-b0a8" name="Skullgrinder" hidden="false" collective="false" defaultSelectionEntryId="56f3-461b-4e5f-76a9">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="56f3-461b-4e5f-76a9" name="Skullgrinder" hidden="false" targetId="e167-7729-8c8b-bf26" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks>
+                    <categoryLink id="93d1-29b6-79ce-9fc5" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="4b7a-fcd9-2336-cddc" name="SLAUGHTERPRIEST" hidden="false" collective="false" defaultSelectionEntryId="74b7-f59c-4181-3187">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="74b7-f59c-4181-3187" name="Slaughterpriest" hidden="false" targetId="b805-6a44-d7ec-92e0" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks>
+                    <categoryLink id="2c2f-6de1-3b5d-69fa" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="24a9-62f0-b256-b3b3" name="Bloodsecrator" hidden="false" collective="false" defaultSelectionEntryId="8cbe-276d-160d-e1c0">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="8cbe-276d-160d-e1c0" name="Bloodsecrator" hidden="false" targetId="56be-4ba7-aa8b-81d6" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks>
+                    <categoryLink id="7686-3a7e-51ff-0bb4" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="0cb6-312b-58a5-927a" name="Battalion: The Goretide" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -11890,7 +12975,9 @@
       </selectionEntries>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="7f72-a078-1db0-e0b8" name="Battalion: The Reapers of Vengeance" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -11997,7 +13084,9 @@
       </selectionEntries>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="4b62-5ef4-4293-14a9" name="Battalion: The Skullfiend Tribe" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -12128,42 +13217,6 @@
             <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="If your general is a KHORNE HERO and they are within 3&quot; of anyy enemy units in the hero phase, any Slaughterborn units thatr are within 12&quot; of your general can immediately attempt to charge those enemy units. Any Slaughterborn units that make successful charges in this manner can immediately pile in and each model in those units can make a single attack vwith one of their melee weapons during that hero phase."/>
           </characteristics>
         </profile>
-        <profile id="58a5-ff88-594f-2b24" name="-" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="A Slaughterborn battalion consists of the following units:"/>
-          </characteristics>
-        </profile>
-        <profile id="80b8-8756-d8be-c051" name="EXALTED DEATHBRINGER" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1"/>
-          </characteristics>
-        </profile>
-        <profile id="60f8-5961-ebfc-4273" name="Skullreapers" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="2-4 units"/>
-          </characteristics>
-        </profile>
-        <profile id="a383-0f4e-c8af-1bc4" name="Blood Warriors" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1-3 units"/>
-          </characteristics>
-        </profile>
       </profiles>
       <rules/>
       <infoLinks/>
@@ -12189,9 +13242,151 @@
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="0a69-799a-3dbc-2853" name="2-4 units of Skullreapers" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30b2-d98a-4afb-753c" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cee0-0a32-abb3-a209" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="5d77-7974-40dd-7478" name="Skullreapers" hidden="false" targetId="be0c-d1b0-5f46-48c4" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="c432-baf7-7487-144a" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="f0da-8077-b992-f0f6" name="1-3 units of Blood Warriors" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9523-95b0-b529-1128" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e179-9597-3e39-d9ae" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="5783-5b77-2dee-659c" name="Blood Warriors" hidden="false" targetId="9361-fa26-31b7-4a10" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="notInstanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="be60-4aae-3bee-e94d" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="8fb5-3dcf-d829-0a5d" name="Blood Warriors" hidden="false" targetId="9361-fa26-31b7-4a10" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="86a0-f789-3ac3-d770" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="2bb4-27bd-26f8-2029" name="1 EXALTED DEATHBRINGER" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9adb-bb71-20ad-606b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="544c-2139-eaf6-8db2" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="a7fc-3396-f9a0-aad8" name="Exalted Deathbringer" hidden="false" targetId="e888-8eef-c485-8b83" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="5e6c-81ac-4dd6-a99f" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="29f7-0f99-f720-3119" name="Slaughterbrute of Khorne" hidden="false" collective="false" type="unit">
       <profiles>
@@ -13955,7 +15150,9 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks/>
-              <costs/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups/>
@@ -14191,7 +15388,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>
@@ -14200,7 +15399,7 @@
         <cost name="pts" costTypeId="points" value="40.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5582-7a1b-e477-10d5" name="Skaarac the Bloodborn" hidden="true" collective="false" type="unit">
+    <selectionEntry id="5582-7a1b-e477-10d5" name="Skaarac the Bloodborn" hidden="false" collective="false" type="unit">
       <profiles>
         <profile id="4340-39c9-2c1a-e2f5" name="Skaarac the Bloodborn" hidden="false" profileTypeId="1960-ca8e-67ce-2014" profileTypeName="01 Unit">
           <profiles/>
@@ -14236,51 +15435,6 @@
             <characteristic name="Variable 2" characteristicTypeId="4cdd-1e03-530f-0ff7" value="10&quot;"/>
             <characteristic name="Variable 3" characteristicTypeId="b1ea-56be-ba52-16e9" value="4+"/>
             <characteristic name="Variable 4" characteristicTypeId="ad26-bf56-95c4-80f1" value="2D6"/>
-          </characteristics>
-        </profile>
-        <profile id="1453-6018-ce56-7382" name="Burning Blood" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="03 Weapon">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Missle"/>
-            <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="8&quot;"/>
-            <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="1"/>
-            <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="3+"/>
-            <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="*"/>
-            <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-"/>
-            <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="D6"/>
-          </characteristics>
-        </profile>
-        <profile id="2817-9d6e-a45a-52bd" name="Brutal Blades" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="03 Weapon">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
-            <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="2&quot;"/>
-            <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="*"/>
-            <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="3+"/>
-            <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
-            <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-2"/>
-            <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="2"/>
-          </characteristics>
-        </profile>
-        <profile id="53fe-9222-e9c3-6600" name="Skaarac the Bloodborn" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="03 Weapon">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
-            <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
-            <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="6"/>
-            <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="4+"/>
-            <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
-            <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-1"/>
-            <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
           </characteristics>
         </profile>
         <profile id="df50-a483-52ae-b672" name="Towering Horror" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="08 Ability (Unit)">
@@ -14380,25 +15534,139 @@
       <rules/>
       <infoLinks/>
       <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries>
-        <selectionEntry id="229c-1fee-ad94-fb1f" name="Skaarac the Bloodborn" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4b33-9186-975a-e548" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="754d-2b01-1bea-b4c4" name="New CategoryLink" hidden="false" targetId="7cdd-80ea-cbeb-8e16" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="e2be-0305-6769-b8d3" name="New CategoryLink" hidden="false" targetId="f22b-976f-fc38-366a" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="46ee-c177-66be-dbb4" name="New CategoryLink" hidden="false" targetId="1959-9f6a-3056-913a" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="56a5-b001-5cc0-613d" name="New CategoryLink" hidden="false" targetId="4e0e-664d-51ea-0929" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="bcc2-ee2a-74a0-ec84" name="New CategoryLink" hidden="false" targetId="0d42-43fb-57b1-0841" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="341b-b6ed-adbb-45ae" name="Burning Blood" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="cb63-b56b-b37d-6de1" name="Burning Blood" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="03 Weapon">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Missle"/>
+                <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="8&quot;"/>
+                <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="1"/>
+                <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="3+"/>
+                <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="*"/>
+                <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-"/>
+                <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="D6"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c134-cfbe-59eb-78bc" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="86be-0390-5c3b-c19c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af0b-1d6d-6612-4552" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1072-535a-8501-fb53" type="max"/>
           </constraints>
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="500.0"/>
-          </costs>
+          <costs/>
+        </selectionEntry>
+        <selectionEntry id="b220-25df-9a9e-fcc2" name="Brutal Blades" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="40a9-daae-f616-95eb" name="Brutal Blades" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="03 Weapon">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="2&quot;"/>
+                <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="*"/>
+                <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="3+"/>
+                <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+                <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-2"/>
+                <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="2"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f00d-f726-d19d-1ccf" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6fd-087a-6463-3b7a" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs/>
+        </selectionEntry>
+        <selectionEntry id="0fb6-605f-11e0-bad7" name="Thunderous Hooves" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="f37d-34b5-6489-0132" name="Thunderous Hooves" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="03 Weapon">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
+                <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="6"/>
+                <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="4+"/>
+                <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+                <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-1"/>
+                <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70e9-d0a5-408b-5b05" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f6b-3251-69b7-a483" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs/>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>
@@ -14413,8 +15681,1643 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="500.0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry id="3c49-5d28-4581-6b78" name="Chaos Spawn" book="" hidden="false" collective="false" type="unit">
+      <profiles>
+        <profile id="575a-68e7-5729-3923" name="Chaos Spawn" hidden="false" profileTypeId="1960-ca8e-67ce-2014" profileTypeName="Unit">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Move" characteristicTypeId="8655-6213-2824-1752" value="2D6&quot;"/>
+            <characteristic name="Wounds" characteristicTypeId="cd0e-fea6-411f-904d" value="5"/>
+            <characteristic name="Bravery" characteristicTypeId="0c85-bf79-836b-759e" value="10"/>
+            <characteristic name="Save" characteristicTypeId="f8dd-4f2a-8543-4f36" value="5+"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers>
+        <modifier type="decrement" field="points" value="50">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="3c49-5d28-4581-6b78" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a611-1b5b-4658-45e3" type="greaterThan"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+        <modifier type="increment" field="points" value="50">
+          <repeats>
+            <repeat field="selections" scope="3c49-5d28-4581-6b78" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a611-1b5b-4658-45e3" repeats="1" roundUp="false"/>
+          </repeats>
+          <conditions/>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="1785-3525-bd18-daba" name="New CategoryLink" hidden="false" targetId="7cdd-80ea-cbeb-8e16" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="2223-6351-3d72-0366" name="New CategoryLink" hidden="false" targetId="a934-6d15-9932-b7ea" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="e64f-ca1a-53d9-20c4" name="New CategoryLink" hidden="false" targetId="4ba7-618a-4e30-2e0c" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="cba7-d4e9-03cd-6101" name="New CategoryLink" hidden="false" targetId="1c84-df70-ead8-d11c" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="a611-1b5b-4658-45e3" name="Chaos Spawn" hidden="false" collective="false" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0130-c3b9-04ba-406b" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d2b5-718d-7e08-10bd" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2031-550d-e4bb-eeab" name="Cursed of the Dark Gods : KHORNE" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="d273-91d5-0392-64e7" name="Cursed of the Dark Gods (KHORNE)" book="Grand Alliance: Chaos" page="45" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="Unit Abilities">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="If you wish, when setting up this unit, you can pick one of the following keywords to assign to this unit for the duration of the battle: KHORNE [...]"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c970-3c16-edcc-a5b4" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bfa3-f536-9a51-785b" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="3459-63e1-0d47-ed06" name="New CategoryLink" hidden="false" targetId="f22b-976f-fc38-366a" primary="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </categoryLink>
+          </categoryLinks>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs/>
+        </selectionEntry>
+        <selectionEntry id="872b-2968-2e7b-934a" name="Freakish Mutations" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="e18b-0ad0-1d79-63a0" name="Freakish Mutations" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
+                <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="2D6"/>
+                <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="4+"/>
+                <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="4+"/>
+                <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-"/>
+                <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
+              </characteristics>
+            </profile>
+            <profile id="a6bf-03de-3fba-a796" name="Writhing Tentacles" book="" page="" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="Unit Abilities">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="If you roll a double when determining the number of attacks made by a Chaos Spawn&apos;s Freakish Mutations, resolve those attacks with a To Hit and To Wound characteristic of 3+ instead of 4+."/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ec1-ef46-840f-e422" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35f7-494c-f108-2c9c" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="50.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="05ed-b451-22d2-d2ab" name="Soul Grinder (of Khorne)" hidden="false" collective="false" type="unit">
+      <profiles>
+        <profile id="7d39-2d98-78b0-7bdf" name="Summon Soul Grinder" hidden="false" profileTypeId="2e81-5e22-c6e1-73cb" profileTypeName="05 Spell">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Casting Value" characteristicTypeId="2508-b604-1258-a920" value="10"/>
+            <characteristic name="Description" characteristicTypeId="76ff-781d-b8e6-5f27" value="Chaos Wizards know the Summon Soul Grinder spell, in addition to any others they know.  If successfully cast, you can set up a Soul Grinder within 16&quot; of the caster and more than 9&quot; from any enemy models. The unit is added to your army but cannot move in the following movement phase."/>
+          </characteristics>
+        </profile>
+        <profile id="da3c-8db5-5269-6177" name="Soul Grinder (of Khorne)" hidden="false" profileTypeId="1960-ca8e-67ce-2014" profileTypeName="Unit">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Move" characteristicTypeId="8655-6213-2824-1752" value="*"/>
+            <characteristic name="Wounds" characteristicTypeId="cd0e-fea6-411f-904d" value="16"/>
+            <characteristic name="Bravery" characteristicTypeId="0c85-bf79-836b-759e" value="10"/>
+            <characteristic name="Save" characteristicTypeId="f8dd-4f2a-8543-4f36" value="4+"/>
+          </characteristics>
+        </profile>
+        <profile id="6b34-c4c5-288f-f785" name="Implacable Advance" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="Unit Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="A Soul Grinder can shoot even if it ran in the movement phase."/>
+          </characteristics>
+        </profile>
+        <profile id="69ed-8374-88bb-c21f" name="Caught by the Claw" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="Unit Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="Each time a Hellforged Claw attack hits a HERO or a MONSTER, you and your opponent both secretly use a dice to select a number and hide it underneath your hand. Reveal the dice on the count of three; if they are the same, the model grabbed by the claw suffers 6 mortal wounds instead of resolving the damage normally."/>
+          </characteristics>
+        </profile>
+        <profile id="481b-b7e6-9c60-11da" name="00-03" hidden="false" profileTypeId="9c58-8858-0964-2b7d" profileTypeName="Soul Grinder Wound Table">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Move" characteristicTypeId="b0a4-7abe-3239-c92a" value="12&quot;"/>
+            <characteristic name="Harvester Cannon" characteristicTypeId="ebc9-9350-e12b-84a9" value="D6"/>
+            <characteristic name="Piston-driven Legs" characteristicTypeId="1394-0752-952b-55e7" value="6"/>
+          </characteristics>
+        </profile>
+        <profile id="2fcc-5854-2641-8757" name="04-06" hidden="false" profileTypeId="9c58-8858-0964-2b7d" profileTypeName="Soul Grinder Wound Table">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Move" characteristicTypeId="b0a4-7abe-3239-c92a" value="10&quot;"/>
+            <characteristic name="Harvester Cannon" characteristicTypeId="ebc9-9350-e12b-84a9" value="D6"/>
+            <characteristic name="Piston-driven Legs" characteristicTypeId="1394-0752-952b-55e7" value="5"/>
+          </characteristics>
+        </profile>
+        <profile id="060e-f0bb-53f6-87d2" name="07-10" hidden="false" profileTypeId="9c58-8858-0964-2b7d" profileTypeName="Soul Grinder Wound Table">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Move" characteristicTypeId="b0a4-7abe-3239-c92a" value="8&quot;"/>
+            <characteristic name="Harvester Cannon" characteristicTypeId="ebc9-9350-e12b-84a9" value="D3"/>
+            <characteristic name="Piston-driven Legs" characteristicTypeId="1394-0752-952b-55e7" value="4"/>
+          </characteristics>
+        </profile>
+        <profile id="0530-79b2-68f9-42e4" name="11-13" hidden="false" profileTypeId="9c58-8858-0964-2b7d" profileTypeName="Soul Grinder Wound Table">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Move" characteristicTypeId="b0a4-7abe-3239-c92a" value="7&quot;"/>
+            <characteristic name="Harvester Cannon" characteristicTypeId="ebc9-9350-e12b-84a9" value="D3"/>
+            <characteristic name="Piston-driven Legs" characteristicTypeId="1394-0752-952b-55e7" value="3"/>
+          </characteristics>
+        </profile>
+        <profile id="167d-3135-3715-2e4e" name="14+" hidden="false" profileTypeId="9c58-8858-0964-2b7d" profileTypeName="Soul Grinder Wound Table">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Move" characteristicTypeId="b0a4-7abe-3239-c92a" value="6&quot;"/>
+            <characteristic name="Harvester Cannon" characteristicTypeId="ebc9-9350-e12b-84a9" value="1"/>
+            <characteristic name="Piston-driven Legs" characteristicTypeId="1394-0752-952b-55e7" value="2"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="abc3-3ce5-59a9-d415" name="New CategoryLink" hidden="false" targetId="7cdd-80ea-cbeb-8e16" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="a70b-e687-9f59-61b3" name="New CategoryLink" hidden="false" targetId="1418-9a68-9f9e-e9a7" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="4582-093d-2ddf-c0e3" name="New CategoryLink" hidden="false" targetId="1959-9f6a-3056-913a" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="9618-42d4-f00b-4dc9" name="New CategoryLink" hidden="false" targetId="a154-9fce-7de2-439f" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="eff7-323e-f6b1-2b15" name="Harvester Cannon" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="cef5-ed61-4010-ae63" name="Harvester Cannon" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="03 Weapon">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Missile"/>
+                <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="16&quot;"/>
+                <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="*"/>
+                <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="4+"/>
+                <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+                <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-1"/>
+                <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aac5-57f4-b96f-ef2e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ae4-bee5-5923-8204" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ccfb-3d8f-bccb-bf02" name="Phlegm Bombardment" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="37cc-1ede-c533-bed7" name="Phlegm Bombardment" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="03 Weapon">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Missile"/>
+                <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="20&quot;"/>
+                <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="1"/>
+                <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="4+"/>
+                <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+                <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-2"/>
+                <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="3"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8fd9-2898-ea27-9639" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b02-93cd-ca84-881a" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a0e1-056f-a008-bb22" name="Hellforged Claw" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="5a73-4777-7cc9-88fe" name="Hellforged Claw" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="03 Weapon">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="2&quot;"/>
+                <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="1"/>
+                <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="4+"/>
+                <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+                <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-2"/>
+                <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="D6"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="407a-bfeb-37ea-9a91" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c363-8617-688f-1314" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2d70-7945-cee8-31b6" name="Piston-driven Legs" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="ef06-3db7-b4ba-3642" name="Piston-driven Legs" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="03 Weapon">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
+                <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="*"/>
+                <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="4+"/>
+                <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+                <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-1"/>
+                <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8112-86ab-95f9-651e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="793a-7d43-5061-b28b" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="aacf-6e1c-0bbc-9856" name="Demon Engine of the Dark Gods : KHORNE" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="7cee-a10d-74ad-9c57" name="Demon Engine of the Dark Gods : KHORNE" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="Unit Abilities">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="If you wish, when setting up a Soul Grinder, you can pick any one of the following keywords to apply to this unit for the duration of the battle: KHORNE [...]"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed7c-6978-0701-15dd" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f102-10ca-5b99-4bec" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="4def-0a31-075b-e9dd" name="New CategoryLink" hidden="false" targetId="f22b-976f-fc38-366a" primary="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </categoryLink>
+          </categoryLinks>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="1baa-51d6-669f-5b55" name="Blade or Talon" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4fa5-3145-8da1-b944" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d3c1-3799-903a-2a2d" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="e97f-724b-91c4-b585" name="Warpmetal Blade" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="27be-55c7-a503-512b" name="Warpmetal Blade" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="03 Weapon">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                    <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="2&quot;"/>
+                    <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="2"/>
+                    <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="4+"/>
+                    <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+                    <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-2"/>
+                    <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="3"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="652f-2f9d-1c6e-8bb2" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6fc2-81a7-78a2-7f94" name="Daemonbone Talon" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="b2eb-71d2-1323-725d" name="Daemonbone Talon" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="03 Weapon">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                    <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="2&quot;"/>
+                    <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="4"/>
+                    <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="3+"/>
+                    <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+                    <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-1"/>
+                    <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="D3"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01e2-b1ae-e3cf-16dd" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="280.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="83fa-dff7-c115-8f42" name="Gigantic Chaos Spawn of Khorne" book="Tamurkhan&apos;s Horde: Warscroll Battalion" hidden="false" collective="false" type="unit">
+      <profiles>
+        <profile id="036b-cae9-112e-18b5" name="Gigantic Chaos Spawn (of Khorne)" hidden="false" profileTypeId="1960-ca8e-67ce-2014" profileTypeName="Unit">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Move" characteristicTypeId="8655-6213-2824-1752" value="*"/>
+            <characteristic name="Wounds" characteristicTypeId="cd0e-fea6-411f-904d" value="12"/>
+            <characteristic name="Bravery" characteristicTypeId="0c85-bf79-836b-759e" value="10"/>
+            <characteristic name="Save" characteristicTypeId="f8dd-4f2a-8543-4f36" value="5+"/>
+          </characteristics>
+        </profile>
+        <profile id="100f-3399-5155-eba1" name="Writhing Tentacles &amp; Snapping Claws" book="" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="Unit Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="If you roll a double when determining the number of attacks made by a Gigantic Chaos Spawn’s Freakish Mutations, resolve those attacks with a To Hit characteristic of 3+ rather than a 4+."/>
+          </characteristics>
+        </profile>
+        <profile id="eec2-79b0-2859-d5a7" name="3" hidden="false" profileTypeId="b6a2-008f-9e59-df68" profileTypeName="Plaything of the Gods">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effect" characteristicTypeId="0152-6755-50dd-c13d" value="The Gigantic Chaos Spawn heals D3 wounds."/>
+          </characteristics>
+        </profile>
+        <profile id="218d-28fb-9dc0-be3f" name="4" hidden="false" profileTypeId="b6a2-008f-9e59-df68" profileTypeName="Plaything of the Gods">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effect" characteristicTypeId="0152-6755-50dd-c13d" value="The Gigantic Chaos Spawn may re-roll hit rolls of 1 this turn."/>
+          </characteristics>
+        </profile>
+        <profile id="5a06-eb7e-38d6-d2d3" name="5" hidden="false" profileTypeId="b6a2-008f-9e59-df68" profileTypeName="Plaything of the Gods">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effect" characteristicTypeId="0152-6755-50dd-c13d" value="The Gigantic Chaos Spawn may unbind a single spell this turn as if it were a wizard."/>
+          </characteristics>
+        </profile>
+        <profile id="2034-e545-570a-a136" name="6" hidden="false" profileTypeId="b6a2-008f-9e59-df68" profileTypeName="Plaything of the Gods">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effect" characteristicTypeId="0152-6755-50dd-c13d" value="The Gigantic Chaos Spawn immediately restores all wounds it has previously lost in the game and may re-roll all wound rolls this turn."/>
+          </characteristics>
+        </profile>
+        <profile id="35e1-d886-9d4a-091b" name="-" hidden="false" profileTypeId="b6a2-008f-9e59-df68" profileTypeName="Plaything of the Gods">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effect" characteristicTypeId="0152-6755-50dd-c13d" value="During your hero phase you may roll for fresh mutations to afflict your Gigantic Chaos Spawn."/>
+          </characteristics>
+        </profile>
+        <profile id="646b-076f-82c0-5c08" name="1" hidden="false" profileTypeId="b6a2-008f-9e59-df68" profileTypeName="Plaything of the Gods">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effect" characteristicTypeId="0152-6755-50dd-c13d" value="The Gigantic Chaos Spawn suffers a single mortal wound."/>
+          </characteristics>
+        </profile>
+        <profile id="7cc2-2b5f-b44a-1cbe" name="00-02" hidden="false" profileTypeId="65ac-ba71-6bc2-4365" profileTypeName="Gigantic Chaos Spawn Wound Table">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Move" characteristicTypeId="4a7e-f7c8-6c21-acad" value="3D6&quot;"/>
+            <characteristic name="Crushing Jaws" characteristicTypeId="8ea1-0116-40b5-1b41" value="-2"/>
+          </characteristics>
+        </profile>
+        <profile id="33eb-9e44-5f66-fa7f" name="03-04" hidden="false" profileTypeId="65ac-ba71-6bc2-4365" profileTypeName="Gigantic Chaos Spawn Wound Table">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Move" characteristicTypeId="4a7e-f7c8-6c21-acad" value="2D6&quot;"/>
+            <characteristic name="Crushing Jaws" characteristicTypeId="8ea1-0116-40b5-1b41" value="-2"/>
+          </characteristics>
+        </profile>
+        <profile id="1194-899e-620d-ba10" name="05-07" hidden="false" profileTypeId="65ac-ba71-6bc2-4365" profileTypeName="Gigantic Chaos Spawn Wound Table">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Move" characteristicTypeId="4a7e-f7c8-6c21-acad" value="2D6&quot;"/>
+            <characteristic name="Crushing Jaws" characteristicTypeId="8ea1-0116-40b5-1b41" value="-1"/>
+          </characteristics>
+        </profile>
+        <profile id="6d31-c8d3-d0cd-d9f0" name="08-09" hidden="false" profileTypeId="65ac-ba71-6bc2-4365" profileTypeName="Gigantic Chaos Spawn Wound Table">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Move" characteristicTypeId="4a7e-f7c8-6c21-acad" value="D6&quot;"/>
+            <characteristic name="Crushing Jaws" characteristicTypeId="8ea1-0116-40b5-1b41" value="-1"/>
+          </characteristics>
+        </profile>
+        <profile id="ffdd-40b7-3626-8170" name="10+" hidden="false" profileTypeId="65ac-ba71-6bc2-4365" profileTypeName="Gigantic Chaos Spawn Wound Table">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Move" characteristicTypeId="4a7e-f7c8-6c21-acad" value="D6&quot;"/>
+            <characteristic name="Crushing Jaws" characteristicTypeId="8ea1-0116-40b5-1b41" value="-"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="9962-f667-ab51-1754" name="New CategoryLink" hidden="false" targetId="7cdd-80ea-cbeb-8e16" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="3c33-ca51-5455-1c9d" name="New CategoryLink" hidden="false" targetId="1959-9f6a-3056-913a" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="970b-107e-ebb9-e034" name="New CategoryLink" hidden="false" targetId="37de-a6c9-b8c0-610e" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="2a57-ab84-94ba-474c" name="Freakish Mutations" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="1b7b-81af-48d9-87ba" name="Freakish Mutations" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="03 Weapon">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="2&quot;"/>
+                <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="2D6"/>
+                <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="4+"/>
+                <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+                <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-"/>
+                <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f5b8-3b7e-8eb9-95a4" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7650-11cc-e1c7-d08f" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7155-7885-043e-e5ee" name="Slavering Maws" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="d57e-9a48-0056-8edb" name="Slavering Maws" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="03 Weapon">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
+                <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="D6"/>
+                <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="4+"/>
+                <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+                <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="*"/>
+                <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="D3"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d021-f65f-601b-532b" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="138a-8759-162c-20cc" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="98a9-51d5-5553-8038" name="Cursed of the Dark Gods : KHORNE" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="136e-938e-9da7-3a7d" name="Cursed of the Dark Gods : KHORNE" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="Unit Abilities">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="If you wish, when setting up this unit, you can pick one of the following keywords to assign to this unit for the duration of the battle: KHORNE [...]"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5328-27be-a9a1-095f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d52d-90a3-a8a2-b093" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="f9c0-c27e-0186-e098" name="New CategoryLink" hidden="false" targetId="f22b-976f-fc38-366a" primary="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </categoryLink>
+          </categoryLinks>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs/>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="180.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8ce7-8f12-7675-5e3d" name="Daemon Prince (of Khorne)" hidden="false" collective="false" type="unit">
+      <profiles>
+        <profile id="ccb8-0cff-6537-b13a" name="Magic: Summon Daemon Prince" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="Unit Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="CHAOS WIZARDS know the Summon Daemon Prince spell, in addition to any others they know."/>
+          </characteristics>
+        </profile>
+        <profile id="743e-9a11-6590-ce6f" name="Daemon Prince of Khorne" hidden="false" profileTypeId="1960-ca8e-67ce-2014" profileTypeName="Unit">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="8655-6213-2824-1752" value="12">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fc99-863f-0096-fc65" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Move" characteristicTypeId="8655-6213-2824-1752" value="8"/>
+            <characteristic name="Wounds" characteristicTypeId="cd0e-fea6-411f-904d" value="8"/>
+            <characteristic name="Bravery" characteristicTypeId="0c85-bf79-836b-759e" value="10"/>
+            <characteristic name="Save" characteristicTypeId="f8dd-4f2a-8543-4f36" value="4+"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="7162-d179-1f9c-465b" name="New CategoryLink" hidden="false" targetId="7cdd-80ea-cbeb-8e16" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="33c2-e4bc-d6d3-b6aa" name="New CategoryLink" hidden="false" targetId="1418-9a68-9f9e-e9a7" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="5fa2-4bef-8f0f-df38" name="New CategoryLink" hidden="false" targetId="1959-9f6a-3056-913a" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="339a-eb03-26ed-49e7" name="New CategoryLink" hidden="false" targetId="4e0e-664d-51ea-0929" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="9c96-2cb5-ac9c-985f" name="New CategoryLink" hidden="false" targetId="9156-9f50-b935-6006" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="f980-fa03-3970-a645" name="Malefic Talons" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="f58c-45ed-3fee-807e" name="Malefic Talons" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
+                <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="3"/>
+                <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="4+ (3+)"/>
+                <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+                <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-"/>
+                <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="2"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9eb1-2b03-7d8a-1f70" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7bd5-5147-977f-6193" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2245-5e7e-aaa6-1380" name="Summon Daemon Prince" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="0d8d-48fe-cbf3-ea09" name="Summon Daemon Prince" hidden="false" profileTypeId="2e81-5e22-c6e1-73cb" profileTypeName="Spell">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Casting Value" characteristicTypeId="2508-b604-1258-a920" value="8"/>
+                <characteristic name="Description" characteristicTypeId="76ff-781d-b8e6-5f27" value="If successfully cast, you can set up a Daemon Prince within 16&quot; of the summoner and more than 9&quot; from any enemy models. The model is added to your army but cannot move in the following movement phase."/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f36-e9c2-60cd-7cd6" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b8ef-ad1e-a1d0-11a8" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="fc99-863f-0096-fc65" name="Wings" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="a6dc-6c87-7c49-d07f" name="Fly" hidden="false" targetId="8e0c-cbe4-27be-8a30" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0185-e912-3299-a5e6" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9651-78cf-8060-92a9" name="Immortal Champion: KHORNE" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="8889-d93c-3667-987c" name="Immortal Champion: KHORNE" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="Unit Abilities">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="Immortal Champion: When you set up this model, you can declare that it is dedicated to Khorne [...] when you do replace its Curse Soul-eater ability with [...] KHORNE Daemon Prince [...] You can add 1 to all hit rolls made for a Khorne Daemon Prince."/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ff1-8a39-b7e1-02a3" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41b6-8fe0-0fb1-5ce1" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="ad2e-952e-f12b-f6df" name="New CategoryLink" hidden="false" targetId="f22b-976f-fc38-366a" primary="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </categoryLink>
+          </categoryLinks>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="fd1a-503b-c5f6-026a" name="Weapon choice" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0329-3a40-2d11-00a8" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0535-eb35-2a5e-327b" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="c83b-371a-aa94-22dc" name="Hellforged Sword" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="0779-489d-52aa-fa7c" name="Hellforged Sword" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                    <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="2&quot;"/>
+                    <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="4"/>
+                    <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="3+ (2+)"/>
+                    <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+                    <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-1"/>
+                    <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="D3"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="48be-d179-b598-8400" name="Daemonic Axe" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="0ed3-af37-1f66-cfcc" name="Daemonic Axe" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                    <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="2&quot;"/>
+                    <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="4"/>
+                    <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="4+ (3+)"/>
+                    <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+                    <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-2"/>
+                    <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="D3"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="b13a-ed33-daa7-b0aa" name="General" hidden="false" targetId="7ab9-de0a-88c2-4fd1" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="5d71-7cb9-cbe4-66e0" name="Artefacts" hidden="false" targetId="0740-e91a-e615-4ac9" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="72d9-448a-23d2-eb8d" name="Command Traits" hidden="false" targetId="0879-c394-8274-958b" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="160.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6549-dda6-35e3-8010" name="Furies (of Khorne)" hidden="false" collective="false" type="unit">
+      <profiles>
+        <profile id="adc7-2a6b-f003-5655" name="Furies" hidden="false" profileTypeId="1960-ca8e-67ce-2014" profileTypeName="Unit">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Move" characteristicTypeId="8655-6213-2824-1752" value="12&quot;"/>
+            <characteristic name="Wounds" characteristicTypeId="cd0e-fea6-411f-904d" value="1"/>
+            <characteristic name="Bravery" characteristicTypeId="0c85-bf79-836b-759e" value="10"/>
+            <characteristic name="Save" characteristicTypeId="f8dd-4f2a-8543-4f36" value="5+"/>
+          </characteristics>
+        </profile>
+        <profile id="ad9f-9f63-3fec-5e52" name="Shadows of the Dark Gods : KHORNE" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="Unit Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="If you wish, when setting up this unit, you can pick one of the following keywords to apply to this unit for the duration of the battle: KHORNE [...]"/>
+          </characteristics>
+        </profile>
+        <profile id="6e5d-aed4-0236-22fc" name="Prey Upon Terror" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="Unit Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="Roll a dice every time an enemy unit fails a battleshock test within 12&quot; of any Furies. On a roll of 4 or more an additional model from the same unit is pounced upon and devoured by the Furies."/>
+          </characteristics>
+        </profile>
+        <profile id="f80f-9893-eae1-a7e6" name="Hooked Claws" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+            <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
+            <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="2"/>
+            <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="4+"/>
+            <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="4+"/>
+            <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-"/>
+            <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="95a3-74e4-d119-fcaf" name="Fly" hidden="false" targetId="8e0c-cbe4-27be-8a30" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers>
+        <modifier type="decrement" field="points" value="60">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="6549-dda6-35e3-8010" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a354-0bfa-e69e-19b0" type="greaterThan"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+        <modifier type="increment" field="points" value="60">
+          <repeats>
+            <repeat field="selections" scope="6549-dda6-35e3-8010" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a354-0bfa-e69e-19b0" repeats="1" roundUp="false"/>
+          </repeats>
+          <conditions/>
+          <conditionGroups/>
+        </modifier>
+        <modifier type="decrement" field="points" value="40">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="6549-dda6-35e3-8010" value="6.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a354-0bfa-e69e-19b0" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="b2e1-b01c-b872-b894" name="New CategoryLink" hidden="false" targetId="7cdd-80ea-cbeb-8e16" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="8058-6c81-efc7-7941" name="New CategoryLink" hidden="false" targetId="1418-9a68-9f9e-e9a7" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="3bdb-985d-f16f-ac11" name="New CategoryLink" hidden="false" targetId="0adb-3e44-760d-015f" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="9f21-8768-33fb-a8b0" name="New CategoryLink" hidden="false" targetId="f22b-976f-fc38-366a" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="a354-0bfa-e69e-19b0" name="5 Furies" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9bf9-08b8-e596-dc00" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a02a-b98f-7e0b-33bf" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="60.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="de8c-b9b6-51fb-6c9a" name="Mazrall the Butcher, Daemon Prince of Khorne" hidden="false" collective="false" type="unit">
+      <profiles>
+        <profile id="e971-f660-d316-cd0b" name="Bloody Charge" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="Unit Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="After this unit completes a charge move, roll a dice for each enemy unit within 1&quot;. On a roll of a 4 or more, that unit suffers D3 mortal wounds."/>
+          </characteristics>
+        </profile>
+        <profile id="9251-2daf-7fa4-580d" name="Mazrall the Butcher, Daemon Prince of Khorne" hidden="false" profileTypeId="1960-ca8e-67ce-2014" profileTypeName="Unit">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Move" characteristicTypeId="8655-6213-2824-1752" value="*"/>
+            <characteristic name="Wounds" characteristicTypeId="cd0e-fea6-411f-904d" value="12"/>
+            <characteristic name="Bravery" characteristicTypeId="0c85-bf79-836b-759e" value="10"/>
+            <characteristic name="Save" characteristicTypeId="f8dd-4f2a-8543-4f36" value="4+"/>
+          </characteristics>
+        </profile>
+        <profile id="ca07-6e47-b109-c3be" name="Harrow Meat&apos;s Hunger" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="Unit Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="If Harrow Meat slays any models in the combat phase, you can add 1 to the attacks Harrow Meat makes for the rest of battle, starting from the next combat phase in which it is used. This effect is cumulative."/>
+          </characteristics>
+        </profile>
+        <profile id="f98d-ddad-14e5-a5c1" name="The Ancyte Shield" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="Unit Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="You may re-roll failed saves for Mazarall the Butcher. In addition Mazarall the Butcher may unbind one spell per turn as if he were a Wizard."/>
+          </characteristics>
+        </profile>
+        <profile id="dbb1-ffdf-3fbe-3b34" name="The Butcher&apos;s Due" hidden="false" profileTypeId="f71f-b0a4-730e-ced3" profileTypeName="Command Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Command Ability Details" characteristicTypeId="1b71-4c83-4e8c-093f" value=" If this model is your general and uses this ability, choose a single unit with the Khorne keyword within 12&quot; of Mazarall. Until your next hero phase, the selected unit may re-roll all wound rolls of 1.
+"/>
+          </characteristics>
+        </profile>
+        <profile id="2374-6430-cfb9-c12a" name="00-02" hidden="false" profileTypeId="9850-0517-4974-24ba" profileTypeName="Mazrall Wounds Suffered">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Move" characteristicTypeId="03ed-1cd2-0d05-559d" value="12&quot;"/>
+            <characteristic name="Harrow Meat" characteristicTypeId="2b90-338b-0385-ad6f" value="-2"/>
+            <characteristic name="Ancyte&apos;s Shield Blades" characteristicTypeId="a7b0-c2ce-697b-fba1" value="D6"/>
+          </characteristics>
+        </profile>
+        <profile id="f8b9-835a-8c5a-0f5a" name="10+" hidden="false" profileTypeId="9850-0517-4974-24ba" profileTypeName="Mazrall Wounds Suffered">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Move" characteristicTypeId="03ed-1cd2-0d05-559d" value="6&quot;"/>
+            <characteristic name="Harrow Meat" characteristicTypeId="2b90-338b-0385-ad6f" value="-"/>
+            <characteristic name="Ancyte&apos;s Shield Blades" characteristicTypeId="a7b0-c2ce-697b-fba1" value="1"/>
+          </characteristics>
+        </profile>
+        <profile id="e2a8-ac5e-6450-8e60" name="08-09" hidden="false" profileTypeId="9850-0517-4974-24ba" profileTypeName="Mazrall Wounds Suffered">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Move" characteristicTypeId="03ed-1cd2-0d05-559d" value="8&quot;"/>
+            <characteristic name="Harrow Meat" characteristicTypeId="2b90-338b-0385-ad6f" value="-1"/>
+            <characteristic name="Ancyte&apos;s Shield Blades" characteristicTypeId="a7b0-c2ce-697b-fba1" value="1"/>
+          </characteristics>
+        </profile>
+        <profile id="da3d-5544-63c3-806f" name="03-04" hidden="false" profileTypeId="9850-0517-4974-24ba" profileTypeName="Mazrall Wounds Suffered">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Move" characteristicTypeId="03ed-1cd2-0d05-559d" value="10&quot;"/>
+            <characteristic name="Harrow Meat" characteristicTypeId="2b90-338b-0385-ad6f" value="-2"/>
+            <characteristic name="Ancyte&apos;s Shield Blades" characteristicTypeId="a7b0-c2ce-697b-fba1" value="D3"/>
+          </characteristics>
+        </profile>
+        <profile id="0c20-e096-b3fd-34dc" name="05-07" hidden="false" profileTypeId="9850-0517-4974-24ba" profileTypeName="Mazrall Wounds Suffered">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Move" characteristicTypeId="03ed-1cd2-0d05-559d" value="8&quot;"/>
+            <characteristic name="Harrow Meat" characteristicTypeId="2b90-338b-0385-ad6f" value="-1"/>
+            <characteristic name="Ancyte&apos;s Shield Blades" characteristicTypeId="a7b0-c2ce-697b-fba1" value="D3"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="77ea-b808-0f17-2232" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="4f41-17ab-d212-8385" name="New CategoryLink" hidden="false" targetId="7cdd-80ea-cbeb-8e16" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="d2b3-f2e6-7bf9-58ab" name="New CategoryLink" hidden="false" targetId="f22b-976f-fc38-366a" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="cad8-75e9-90ea-fee6" name="New CategoryLink" hidden="false" targetId="1418-9a68-9f9e-e9a7" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="53f2-7bce-898b-9986" name="New CategoryLink" hidden="false" targetId="1959-9f6a-3056-913a" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="8293-3cac-43e6-a000" name="New CategoryLink" hidden="false" targetId="4e0e-664d-51ea-0929" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="9f81-659a-994e-224c" name="New CategoryLink" hidden="false" targetId="0124-e1e8-c2e7-ef6b" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="a27d-8c9b-6731-0c08" name="Ancyte&apos;s Shield Blades" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="165b-24a6-e41b-f5a2" name="Ancyte&apos;s Shield Blades" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
+                <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="*"/>
+                <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="4+"/>
+                <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+                <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-1"/>
+                <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a83e-fed6-2ceb-58f5" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0fc3-a0b2-7083-77f8" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="81de-7184-fde2-1451" name="Harrow Meat" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="ef7c-5623-4e09-eacf" name="Harrow Meat" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="2&quot;"/>
+                <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="4"/>
+                <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="3+"/>
+                <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+                <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="*"/>
+                <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="3"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b4dd-da21-4228-5520" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab8c-8330-8a60-546d" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="ebab-ae98-27a3-efad" name="General" hidden="false" targetId="7ab9-de0a-88c2-4fd1" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="360.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7e93-92f2-50b5-2185" name="Battalion: Khorne Bloodbound Murderband (Open Play)" book="Start Collecting: Khorne Bloodbound" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="8b95-3f15-effe-5943" name="Murderous Blessings" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="In your hero phase, a Murderband&apos;s Slaughterpriest can pray for a Murderous Blessing in addition to using his Bloodfuelled Prayers.  If he oes so, roll a dice. If you roll a 3 or more, until your next hero phase you can re-roll failed wound rolls made for him and other units from his Murderband that are within 8&quot;. On a 1, however, he suffers a mortal wound."/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="5d17-321b-b27a-295b" name="1 Slaughterpriest" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="76da-de0a-1ae6-2a53" name="1 unit of Blood Warriors" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="9ed6-23bb-7b25-610d" name="1 unit of Mighty Skullcrushers" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs/>
+    </selectionEntry>
+    <selectionEntry id="61d9-ceff-02a4-d364" name="Battalion: Khorne Bloodbound Slaughterstorm (Open Play)" book="Battalion Set: Khorne Bloodbound Slaughterstorm" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="2ea4-e468-d275-49b7" name="Fuelled by Blood" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="In your hero phase, pick one unit from this battalion that is within 8&quot; of Skarr Bloodwrath and within 3&quot; of an enemy unit. The unit you pick can immediately attack as if it were the combat phase."/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="1e1e-b8fd-7ba5-8478" name="Skaar Bloodwrath" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="d1d2-4504-b87c-1ed4" name="1 Aspiring Deathbringer with Goreaxe and Skullhammer" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="54f0-076b-b780-2222" name="1 unit of Blood Warriors" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="7bda-c787-9e58-2f5e" name="1 unit of Bloodreavers" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="1bd6-cc4a-d52c-2a24" name="1 unit of Wrathmongers" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6905-8ed8-ba98-301a" name="1 unit of Mighty Skullcrushers" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs/>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>

--- a/Chaos - Khorne.cat
+++ b/Chaos - Khorne.cat
@@ -1887,7 +1887,7 @@
         <cost name="pts" costTypeId="points" value="80.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="a7fd-9b56-eaff-f352" name="Blood Host of Khorne" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="a7fd-9b56-eaff-f352" name="Battalion: Blood Host of Khorne" hidden="false" collective="false" type="upgrade">
       <profiles>
         <profile id="70a3-36f5-392f-9838" name="Cometh the Slaughter" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>
@@ -1922,14 +1922,30 @@
       <modifiers/>
       <constraints/>
       <categoryLinks/>
-      <selectionEntries/>
+      <selectionEntries>
+        <selectionEntry id="ab94-af9d-4cb4-2275" name="Blood Host of Khorne" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="117e-7f71-73ed-a7d8" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5380-156b-305d-692a" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="220.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="220.0"/>
-      </costs>
+      <costs/>
     </selectionEntry>
-    <selectionEntry id="cb7a-2a30-c407-d701" name="Blood Hunt" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="cb7a-2a30-c407-d701" name="Battalion: Blood Hunt" hidden="false" collective="false" type="upgrade">
       <profiles>
         <profile id="0e3b-7e75-ac42-7e61" name="Blood Mark" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>
@@ -1982,12 +1998,28 @@
       <modifiers/>
       <constraints/>
       <categoryLinks/>
-      <selectionEntries/>
+      <selectionEntries>
+        <selectionEntry id="9b6e-3e7d-1668-ecf8" name="Blood Hunt" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b4c7-d12e-eaab-412e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7d3-f350-ac72-a84f" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="130.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="130.0"/>
-      </costs>
+      <costs/>
     </selectionEntry>
     <selectionEntry id="d39a-4082-0c4c-b899" name="Blood Throne" hidden="false" collective="false" type="unit">
       <profiles>
@@ -2785,7 +2817,7 @@
         <cost name="pts" costTypeId="points" value="100.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="a584-3218-b0cd-294f" name="Bloodbound Warband" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="a584-3218-b0cd-294f" name="Battalion: Bloodbound Warband" hidden="false" collective="false" type="upgrade">
       <profiles>
         <profile id="c2c3-dad0-05b9-8e67" name="Bloodrain" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>
@@ -2865,14 +2897,30 @@
       <modifiers/>
       <constraints/>
       <categoryLinks/>
-      <selectionEntries/>
+      <selectionEntries>
+        <selectionEntry id="8df4-6b64-d9d9-4e10" name="Bloodbound Warband" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bbe3-a197-d364-9aa5" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f088-8bef-4d25-2afc" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="220.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="220.0"/>
-      </costs>
+      <costs/>
     </selectionEntry>
-    <selectionEntry id="45b7-db81-23e4-78c8" name="Bloodbound Warhorde" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="45b7-db81-23e4-78c8" name="Battalion: Bloodbound Warhorde" hidden="false" collective="false" type="upgrade">
       <profiles>
         <profile id="1607-c161-654f-b836" name="-" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
           <profiles/>
@@ -2938,12 +2986,28 @@
       <modifiers/>
       <constraints/>
       <categoryLinks/>
-      <selectionEntries/>
+      <selectionEntries>
+        <selectionEntry id="66e9-01d2-8690-5173" name="Bloodbound Warhorde" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4af3-bc67-1ed6-5f6f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc44-2e15-fbdb-b9fc" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="220.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="220.0"/>
-      </costs>
+      <costs/>
     </selectionEntry>
     <selectionEntry id="e52f-0fd9-6fe1-5c89" name="Bloodcrushers" hidden="false" collective="false" type="unit">
       <profiles>
@@ -3207,7 +3271,7 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d28c-99c1-fb9b-7755" name="Bloodforged" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="d28c-99c1-fb9b-7755" name="Battalion: Bloodforged" hidden="false" collective="false" type="upgrade">
       <profiles>
         <profile id="26ae-945c-99e8-8efb" name="Blood Aegis" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>
@@ -3269,12 +3333,28 @@
       <modifiers/>
       <constraints/>
       <categoryLinks/>
-      <selectionEntries/>
+      <selectionEntries>
+        <selectionEntry id="dbee-e34d-f405-db64" name="Bloodforged" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba2b-04cf-f964-2ebe" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc14-0727-0566-0a2c" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="140.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="140.0"/>
-      </costs>
+      <costs/>
     </selectionEntry>
     <selectionEntry id="3012-ad18-c49d-24c2" name="Bloodletters" hidden="false" collective="false" type="unit">
       <profiles>
@@ -4903,7 +4983,7 @@
         <cost name="pts" costTypeId="points" value="260.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="80d0-e602-f091-6279" name="Bloodthunder Stampede" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="80d0-e602-f091-6279" name="Battalion: Bloodthunder Stampede" hidden="false" collective="false" type="upgrade">
       <profiles>
         <profile id="c0a0-0a02-efd5-7391" name="Avalanche of Brass" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>
@@ -4965,14 +5045,30 @@
       <modifiers/>
       <constraints/>
       <categoryLinks/>
-      <selectionEntries/>
+      <selectionEntries>
+        <selectionEntry id="2750-7732-39a9-a617" name="Bloodthunder Stampede" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96fb-ffd3-ba92-942f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1ae-4429-fdcf-05fc" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="180.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="180.0"/>
-      </costs>
+      <costs/>
     </selectionEntry>
-    <selectionEntry id="54ed-273a-ff0d-b1d0" name="Brass Stampede" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="54ed-273a-ff0d-b1d0" name="Battalion: Brass Stampede" hidden="false" collective="false" type="upgrade">
       <profiles>
         <profile id="f8b6-9860-19f5-b766" name="Avalanche of Brass" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>
@@ -5034,14 +5130,30 @@
       <modifiers/>
       <constraints/>
       <categoryLinks/>
-      <selectionEntries/>
+      <selectionEntries>
+        <selectionEntry id="613d-7b8d-4f97-d94a" name="Brass Stampede" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5116-140c-7fd6-6607" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d522-2489-32cd-0693" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="180.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="180.0"/>
-      </costs>
+      <costs/>
     </selectionEntry>
-    <selectionEntry id="a765-6bbb-3d30-5dda" name="Charnel Host" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="a765-6bbb-3d30-5dda" name="Battalion: Charnel Host" hidden="false" collective="false" type="upgrade">
       <profiles>
         <profile id="abb5-e04d-d149-2643" name="Daemon Commander" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>
@@ -5110,7 +5222,7 @@
         <cost name="pts" costTypeId="points" value="140.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="4871-f8d1-52f4-c5e0" name="Council of Blood" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="4871-f8d1-52f4-c5e0" name="Battalion: Council of Blood" hidden="false" collective="false" type="upgrade">
       <profiles>
         <profile id="072b-d1c0-987a-961d" name="Fierce Rivals" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>
@@ -5216,7 +5328,7 @@
         <cost name="pts" costTypeId="points" value="160.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="ed0a-8b27-5e9c-2d74" name="Dark Feast" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="ed0a-8b27-5e9c-2d74" name="Battalion: Dark Feast" hidden="false" collective="false" type="upgrade">
       <profiles>
         <profile id="bb71-2cc1-422a-af51" name="Feeding Frenzy" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>
@@ -6079,7 +6191,7 @@
         <cost name="pts" costTypeId="points" value="60.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b9b7-ea01-585d-aed2" name="Gore Pilgrims" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="b9b7-ea01-585d-aed2" name="Battalion: Gore Pilgrims" hidden="false" collective="false" type="upgrade">
       <profiles>
         <profile id="7727-c343-a095-7ad5" name="Acolytes of Khorne" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>
@@ -6157,7 +6269,7 @@
         <cost name="pts" costTypeId="points" value="180.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="38b0-9eab-8717-1264" name="Gorethunder Cohort" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="38b0-9eab-8717-1264" name="Battalion: Gorethunder Cohort" hidden="false" collective="false" type="upgrade">
       <profiles>
         <profile id="9b8a-f4e2-dc8d-4d31" name="The Cannons of Khorne" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>
@@ -7459,7 +7571,7 @@
         <cost name="pts" costTypeId="points" value="140.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="3e97-a678-8853-12df" name="Murderhost" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="3e97-a678-8853-12df" name="Battalion: Murderhost" hidden="false" collective="false" type="upgrade">
       <profiles>
         <profile id="0f63-4651-665b-a98f" name="Insatiable Bloodlust" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>
@@ -7510,7 +7622,7 @@
         <cost name="pts" costTypeId="points" value="120.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c470-a112-03b6-9129" name="Red Headsmen" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="c470-a112-03b6-9129" name="Battalion: Red Headsmen" hidden="false" collective="false" type="upgrade">
       <profiles>
         <profile id="3975-f7a6-d4c1-4221" name="Slay the Worthy" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>
@@ -8891,7 +9003,7 @@
         <cost name="pts" costTypeId="points" value="180.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="a5f8-e838-f2a2-2441" name="Skullseeker Host" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="a5f8-e838-f2a2-2441" name="Battalion: Skullseeker Host" hidden="false" collective="false" type="upgrade">
       <profiles>
         <profile id="ea01-c7ab-3521-e6d5" name="Giant Killers" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>
@@ -8969,7 +9081,7 @@
         <cost name="pts" costTypeId="points" value="140.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="3258-9691-5f0d-19e0" name="Skulltake" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="3258-9691-5f0d-19e0" name="Battalion: Skulltake" hidden="false" collective="false" type="upgrade">
       <profiles>
         <profile id="e4e5-022e-87f2-6a65" name="Reaping Strikes" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>
@@ -9189,7 +9301,7 @@
         <cost name="pts" costTypeId="points" value="100.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8e7c-60f9-b0c3-fbc5" name="The Bloodlords" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="8e7c-60f9-b0c3-fbc5" name="Battalion: The Bloodlords" hidden="false" collective="false" type="upgrade">
       <profiles>
         <profile id="2e36-0b8f-305a-b31a" name="Blood Host of Khorne, Murderhost, Bloodthunder Stampede, Council of Blood, Blood Hunt, Gorethunder Cohort, Charnel Host, Skullseeker Host" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
           <profiles/>
@@ -9271,7 +9383,7 @@
         <cost name="pts" costTypeId="points" value="140.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="f7da-d7af-dfa7-865d" name="The Gorechosen" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="f7da-d7af-dfa7-865d" name="Battalion: The Gorechosen" hidden="false" collective="false" type="upgrade">
       <profiles>
         <profile id="22d1-3b2b-f675-3b10" name="Eternal Contest" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>
@@ -9331,7 +9443,7 @@
         <cost name="pts" costTypeId="points" value="150.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0cb6-312b-58a5-927a" name="The Goretide" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="0cb6-312b-58a5-927a" name="Battalion: The Goretide" hidden="false" collective="false" type="upgrade">
       <profiles>
         <profile id="dc55-c5a8-416c-2f18" name="Aqshy&apos;s Bane" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>
@@ -9440,7 +9552,7 @@
         <cost name="pts" costTypeId="points" value="140.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7f72-a078-1db0-e0b8" name="The Reapers of Vengeance" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="7f72-a078-1db0-e0b8" name="Battalion: The Reapers of Vengeance" hidden="false" collective="false" type="upgrade">
       <profiles>
         <profile id="0baa-efbf-00df-e47e" name="Khorne&apos;s Vengeance Made Manifest" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>
@@ -9531,7 +9643,7 @@
         <cost name="pts" costTypeId="points" value="140.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="4b62-5ef4-4293-14a9" name="The Skullfiend Tribe" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="4b62-5ef4-4293-14a9" name="Battalion: The Skullfiend Tribe" hidden="false" collective="false" type="upgrade">
       <profiles>
         <profile id="a25f-f6e5-0372-af4b" name="Skull Hunters" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>
@@ -9631,7 +9743,7 @@
         <cost name="pts" costTypeId="points" value="120.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7901-eafc-3534-afe8" name="Slaughterborn" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="7901-eafc-3534-afe8" name="Battalion: Slaughterborn" hidden="false" collective="false" type="upgrade">
       <profiles>
         <profile id="6a5e-a7ea-3c5d-7b62" name="Hungry for Glory" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>

--- a/Chaos - Khorne.cat
+++ b/Chaos - Khorne.cat
@@ -357,7 +357,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="4a03-e9ac-d013-88bc" name="Blood Host of Khorne" hidden="false" targetId="a7fd-9b56-eaff-f352" type="selectionEntry">
+    <entryLink id="4a03-e9ac-d013-88bc" name="Battalion: Blood Host of Khorne" hidden="false" targetId="a7fd-9b56-eaff-f352" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -373,7 +373,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="da63-e9ea-d27d-c920" name="Blood Hunt" hidden="false" targetId="cb7a-2a30-c407-d701" type="selectionEntry">
+    <entryLink id="da63-e9ea-d27d-c920" name="Battalion: Blood Hunt" hidden="false" targetId="cb7a-2a30-c407-d701" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -467,7 +467,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="6981-396f-f0b1-ac6a" name="Bloodbound Warband" hidden="false" targetId="a584-3218-b0cd-294f" type="selectionEntry">
+    <entryLink id="6981-396f-f0b1-ac6a" name="Battalion: Bloodbound Warband" hidden="false" targetId="a584-3218-b0cd-294f" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -591,7 +591,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="6cf2-dbe1-e67d-f510" name="Bloodforged" hidden="false" targetId="d28c-99c1-fb9b-7755" type="selectionEntry">
+    <entryLink id="6cf2-dbe1-e67d-f510" name="Battalion: Bloodforged" hidden="false" targetId="d28c-99c1-fb9b-7755" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -825,7 +825,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="f3a2-9d22-cd33-e17a" name="Bloodthunder Stampede" hidden="false" targetId="80d0-e602-f091-6279" type="selectionEntry">
+    <entryLink id="f3a2-9d22-cd33-e17a" name="Battalion: Bloodthunder Stampede" hidden="false" targetId="80d0-e602-f091-6279" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -841,7 +841,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="8161-3a22-b9f6-f065" name="Brass Stampede" hidden="false" targetId="54ed-273a-ff0d-b1d0" type="selectionEntry">
+    <entryLink id="8161-3a22-b9f6-f065" name="Battalion: Brass Stampede" hidden="false" targetId="54ed-273a-ff0d-b1d0" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -857,7 +857,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="0b95-23b9-2a60-4005" name="Charnel Host" hidden="false" targetId="a765-6bbb-3d30-5dda" type="selectionEntry">
+    <entryLink id="0b95-23b9-2a60-4005" name="Battalion: Charnel Host" hidden="false" targetId="a765-6bbb-3d30-5dda" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -873,7 +873,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="fc4f-9226-a4c3-8910" name="Council of Blood" hidden="false" targetId="4871-f8d1-52f4-c5e0" type="selectionEntry">
+    <entryLink id="fc4f-9226-a4c3-8910" name="Battalion: Council of Blood" hidden="false" targetId="4871-f8d1-52f4-c5e0" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -905,7 +905,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="22ad-c256-6f96-6af7" name="Dark Feast" hidden="false" targetId="ed0a-8b27-5e9c-2d74" type="selectionEntry">
+    <entryLink id="22ad-c256-6f96-6af7" name="Battalion: Dark Feast" hidden="false" targetId="ed0a-8b27-5e9c-2d74" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -1013,7 +1013,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="bc28-8568-5395-6d23" name="Gore Pilgrims" hidden="false" targetId="b9b7-ea01-585d-aed2" type="selectionEntry">
+    <entryLink id="bc28-8568-5395-6d23" name="Battalion: Gore Pilgrims" hidden="false" targetId="b9b7-ea01-585d-aed2" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -1029,7 +1029,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="d517-17eb-30a6-1c21" name="Gorethunder Cohort" hidden="false" targetId="38b0-9eab-8717-1264" type="selectionEntry">
+    <entryLink id="d517-17eb-30a6-1c21" name="Battalion: Gorethunder Cohort" hidden="false" targetId="38b0-9eab-8717-1264" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -1125,7 +1125,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="9785-da50-1738-7eac" name="Murderhost" hidden="false" targetId="3e97-a678-8853-12df" type="selectionEntry">
+    <entryLink id="9785-da50-1738-7eac" name="Battalion: Murderhost" hidden="false" targetId="3e97-a678-8853-12df" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -1201,7 +1201,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="20e5-fe93-e44e-084d" name="Red Headsmen" hidden="false" targetId="c470-a112-03b6-9129" type="selectionEntry">
+    <entryLink id="20e5-fe93-e44e-084d" name="Battalion: Red Headsmen" hidden="false" targetId="c470-a112-03b6-9129" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -1320,7 +1320,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="a86b-87aa-75fc-4c01" name="Skullseeker Host" hidden="false" targetId="a5f8-e838-f2a2-2441" type="selectionEntry">
+    <entryLink id="a86b-87aa-75fc-4c01" name="Battalion: Skullseeker Host" hidden="false" targetId="a5f8-e838-f2a2-2441" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -1336,7 +1336,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="5403-673f-a92c-7b05" name="Skulltake" hidden="false" targetId="3258-9691-5f0d-19e0" type="selectionEntry">
+    <entryLink id="5403-673f-a92c-7b05" name="Battalion: Skulltake" hidden="false" targetId="3258-9691-5f0d-19e0" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -1368,7 +1368,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="bf2f-7b96-174f-50c1" name="Slaughterborn" hidden="false" targetId="7901-eafc-3534-afe8" type="selectionEntry">
+    <entryLink id="bf2f-7b96-174f-50c1" name="Battalion: Slaughterborn" hidden="false" targetId="7901-eafc-3534-afe8" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -1432,7 +1432,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="2fd1-cf92-acf2-4544" name="The Gorechosen" hidden="false" targetId="f7da-d7af-dfa7-865d" type="selectionEntry">
+    <entryLink id="2fd1-cf92-acf2-4544" name="Battalion: The Gorechosen" hidden="false" targetId="f7da-d7af-dfa7-865d" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -1677,7 +1677,14 @@
         <modifier type="set" field="points" value="100">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="57cc-05f8-a255-d1b9" type="equalTo"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="57cc-05f8-a255-d1b9" type="greaterThan"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+        <modifier type="append" field="name" value="with Goreaxe and Skullhammer">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="57cc-05f8-a255-d1b9" type="greaterThan"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -1849,7 +1856,7 @@
               <selectionEntryGroups/>
               <entryLinks/>
               <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
+                <cost name="pts" costTypeId="points" value="20.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1898,24 +1905,6 @@
             <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="In each of your hero phases, pick D3 units from the Blood Host of Khorne that are within 3&quot; of the enemy. All models in the units that you pick can immediately pile in and attack with one of their melee weapons. Increase the number of units that can attack from D3 to D6 if there are sixteen or more units in the battalion at the start of the hero phase."/>
           </characteristics>
         </profile>
-        <profile id="b965-cc23-d516-c493" name="BLOODTHIRSTER" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1"/>
-          </characteristics>
-        </profile>
-        <profile id="117d-afdc-8a95-8b3f" name="BLOODLETTER HERO, BLOODTHIRSTER, Bloodletters, Bloodcrushers, Skull Cannons, Flesh Hounds" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="7 or more units in any combination."/>
-          </characteristics>
-        </profile>
       </profiles>
       <rules/>
       <infoLinks/>
@@ -1941,7 +1930,564 @@
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="978a-4aed-b391-c1ba" name="1x BLOODTHIRSTER" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e2f-23d8-9b29-cccf" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8bb4-8978-c86f-b6bc" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="7c9b-cdad-9cbf-4109" name="Wrath of Khorne Bloodthirster" hidden="false" targetId="510a-95e2-773f-81a9" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="b2ce-220a-27af-411a" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="7ced-0713-aba7-50c2" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="8488-50b6-a0ab-cbe6" name="Bloodthirster of Insensate Rage" hidden="false" targetId="8886-dbc9-97d5-ddad" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="c287-c96d-d26b-70d7" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="8a29-3323-a119-a93c" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="4e47-4f1f-e24d-e918" name="Bloodthirster of Unfettered Fury" hidden="false" targetId="a59e-d6c6-24cb-cf41" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="5b97-57ae-d8ab-3030" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="2290-20a1-ee7d-9cad" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="3ef9-8398-b252-273c" name="Exalted Greater Daemon of Khorne" hidden="false" targetId="e137-a705-cb6c-a10f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1e1-a5e3-6f87-608b" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="0c39-ad0f-f876-6621" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="76c4-7816-d000-8a3f" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="35c5-178e-3bbd-27bc" name="Skarbrand" hidden="false" targetId="580c-ab5a-f469-2866" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb47-ba13-a9a3-063d" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="2bf9-06fc-fa89-886a" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="cd3c-f11f-2beb-355b" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="9d04-2296-91e5-1a97" name="7 or more units in any combination" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7937-4ec6-55a1-ca4d" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="6c5a-8aae-0f3b-f3b6" name="BLOODLETTER HERO" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="574e-abae-4aba-816a" name="Skullmaster, Herald of Khorne" hidden="false" targetId="3f73-0a16-9b36-ae7a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks>
+                    <categoryLink id="be58-1b4a-6a9b-dced" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+                <entryLink id="9677-795b-7ce3-33c3" name="Skulltaker" hidden="false" targetId="d0d5-c7ce-b8ef-4805" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cfc5-81c9-c4a4-e2a3" type="max"/>
+                  </constraints>
+                  <categoryLinks>
+                    <categoryLink id="ec6b-477f-e58f-170b" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+                <entryLink id="0da7-1e6c-c787-b78b" name="Bloodmaster, Herald of Khorne" hidden="false" targetId="049f-9f7d-343e-c78c" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks>
+                    <categoryLink id="2b34-ee14-86d5-100c" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+                <entryLink id="7565-4b14-fbfa-2050" name="Blood Throne" hidden="false" targetId="d39a-4082-0c4c-b899" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks>
+                    <categoryLink id="403e-dfaf-f69a-d65a" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="acc6-5cb9-b1d3-0b49" name="BLOODTHIRSTER" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="6165-7c84-ffe4-03bc" name="Wrath of Khorne Bloodthirster" hidden="false" targetId="510a-95e2-773f-81a9" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks>
+                    <categoryLink id="9312-37f8-e712-d610" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                    <categoryLink id="c42a-b55f-0edd-6296" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+                <entryLink id="a7ba-5043-6a22-b3e4" name="Bloodthirster of Insensate Rage" hidden="false" targetId="8886-dbc9-97d5-ddad" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks>
+                    <categoryLink id="f250-8d62-1f9a-31cb" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                    <categoryLink id="0b6c-aedc-634f-14c5" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+                <entryLink id="dbce-4e73-df93-c492" name="Bloodthirster of Unfettered Fury" hidden="false" targetId="a59e-d6c6-24cb-cf41" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks>
+                    <categoryLink id="1a7c-641b-900d-6e32" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                    <categoryLink id="1285-6b15-9850-d501" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+                <entryLink id="4ac1-ec09-860f-7576" name="Exalted Greater Daemon of Khorne" hidden="false" targetId="e137-a705-cb6c-a10f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f7a5-c501-313f-e274" type="max"/>
+                  </constraints>
+                  <categoryLinks>
+                    <categoryLink id="8871-0590-78bd-cdee" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                    <categoryLink id="8fb9-61b2-0536-5352" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+                <entryLink id="f414-689f-6402-73bc" name="Skarbrand" hidden="false" targetId="580c-ab5a-f469-2866" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac44-8f72-1c9a-9653" type="max"/>
+                  </constraints>
+                  <categoryLinks>
+                    <categoryLink id="0454-b8f2-fc95-cdd4" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                    <categoryLink id="2203-dce2-adac-4d0f" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="e5c9-b51f-00d9-b1ea" name="Bloodcrushers" hidden="false" targetId="e52f-0fd9-6fe1-5c89" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9517-e07e-e189-6699" type="equalTo"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0472-ec32-ce10-0540" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="044c-1ad4-b8e6-ec80" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="ec5c-7aad-7918-fd0b" name="Bloodcrushers" hidden="false" targetId="e52f-0fd9-6fe1-5c89" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0472-ec32-ce10-0540" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9517-e07e-e189-6699" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="6e8b-e2aa-607c-6a06" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="dc04-a9ce-e1c0-91b2" name="Flesh Hounds" hidden="false" targetId="3fd9-43de-d22c-48a0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0472-ec32-ce10-0540" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a41-d215-35d9-3a00" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="8575-10ed-c75f-461d" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="81b7-6f1c-c438-4c9f" name="Flesh Hounds" hidden="false" targetId="3fd9-43de-d22c-48a0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a41-d215-35d9-3a00" type="equalTo"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0472-ec32-ce10-0540" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="b03f-b46f-0ff1-e678" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="1e9e-cd9b-39c4-f96e" name="Skull Cannons" hidden="false" targetId="2163-0d0c-6837-de92" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="9d59-1ff8-bef2-32d6" name="New CategoryLink" hidden="false" targetId="1d26-07fc-6a66-d73e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="7af3-0ece-d9d0-e6a2" name="Bloodletters" hidden="false" targetId="3012-ad18-c49d-24c2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="24b0-1412-de01-9bef" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="2f82-36b1-a3cb-6ab0" name="Bloodletters" hidden="false" targetId="3012-ad18-c49d-24c2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="notInstanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="e90d-8ae1-79fe-0f54" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks/>
       <costs/>
     </selectionEntry>
@@ -1963,33 +2509,6 @@
           <modifiers/>
           <characteristics>
             <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Add 1 to any wound rolls you make for models from a Blood Hunt when attacking an enemy HERO. If a Blood Hunt contained the maximum number of units at the start of the battle, then you can re-roll all failed wound rolls you make for models from the battalion when attacking an enemy HERO."/>
-          </characteristics>
-        </profile>
-        <profile id="08bd-6d1c-147c-2283" name="-" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="A Blood Hunt consists of the following units:"/>
-          </characteristics>
-        </profile>
-        <profile id="0246-a264-0bb1-358b" name="Wrath of Khorne Bloodthirster/Karanak" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5"/>
-          </characteristics>
-        </profile>
-        <profile id="9a16-86f6-2403-c970" name="Flesh Hounds/Bloodcrushers" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="3-8 units in any combination."/>
           </characteristics>
         </profile>
       </profiles>
@@ -2017,7 +2536,197 @@
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="61e9-1ef2-ddca-4df8" name="1 Wrath or Khorne Bloodthirster or Karanak " hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="48af-6a79-8828-9f6f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8d71-35bf-cdfb-52ef" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="bddf-2b08-4e0d-3d16" name="Wrath of Khorne Bloodthirster" hidden="false" targetId="510a-95e2-773f-81a9" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="3950-d882-f499-49aa" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="2aee-6273-8f7e-8356" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="f0aa-650b-ddb9-cfaf" name="Karanak" hidden="false" targetId="6578-af62-39ff-f9f2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="27c3-2265-ece0-9c79" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6790-a3ca-0a2c-cd74" name="3-8 units in any combination" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="908c-90c4-1366-ce0a" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ab15-2933-ff7d-a9cd" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="0689-c09b-a871-50c7" name="Bloodcrushers" hidden="false" targetId="e52f-0fd9-6fe1-5c89" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0472-ec32-ce10-0540" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9517-e07e-e189-6699" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="3831-e7f4-486c-a9b7" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="bae2-ddd2-6971-96a3" name="Bloodcrushers" hidden="false" targetId="e52f-0fd9-6fe1-5c89" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9517-e07e-e189-6699" type="equalTo"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0472-ec32-ce10-0540" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="4102-08a1-6367-f5f3" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="46bd-85c8-89e7-3e80" name="Flesh Hounds" hidden="false" targetId="3fd9-43de-d22c-48a0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a41-d215-35d9-3a00" type="equalTo"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0472-ec32-ce10-0540" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="f9f3-b981-eda0-5b1a" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="cd26-ede9-b863-9f04" name="Flesh Hounds" hidden="false" targetId="3fd9-43de-d22c-48a0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0472-ec32-ce10-0540" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a41-d215-35d9-3a00" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="d9ef-85c3-65d4-443a" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks/>
       <costs/>
     </selectionEntry>
@@ -2727,21 +3436,6 @@
           <selectionEntries>
             <selectionEntry id="554b-39c8-fcb5-c0ed" name="Goreaxe and Gorefist" hidden="false" collective="false" type="upgrade">
               <profiles>
-                <profile id="3d9c-bea7-6f12-86af" name="Goreaxe" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="03 Weapon">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <characteristics>
-                    <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
-                    <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
-                    <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="2"/>
-                    <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="3+"/>
-                    <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="4+"/>
-                    <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-"/>
-                    <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
-                  </characteristics>
-                </profile>
                 <profile id="00d4-fb47-87f9-e61d" name="Gorefists" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="08 Ability (Unit)">
                   <profiles/>
                   <rules/>
@@ -2753,7 +3447,14 @@
                 </profile>
               </profiles>
               <rules/>
-              <infoLinks/>
+              <infoLinks>
+                <infoLink id="3c25-74c3-17eb-ef69" name="Goreaxe" hidden="false" targetId="1ebc-6dfb-5777-dfab" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
               <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9720-3e37-4e6a-6300" type="max"/>
@@ -2777,24 +3478,16 @@
                     <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="You can re-roll hit rolls of 1 for models armed with more than one Goreaxe."/>
                   </characteristics>
                 </profile>
-                <profile id="cfe4-3c4d-e5e7-6b44" name="Goreaxe" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="03 Weapon">
+              </profiles>
+              <rules/>
+              <infoLinks>
+                <infoLink id="f830-3c5e-9d34-b0bb" name="Goreaxe" hidden="false" targetId="1ebc-6dfb-5777-dfab" type="profile">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
-                  <characteristics>
-                    <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
-                    <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
-                    <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="2"/>
-                    <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="3+"/>
-                    <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="4+"/>
-                    <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-"/>
-                    <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <rules/>
-              <infoLinks/>
+                </infoLink>
+              </infoLinks>
               <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d433-eb74-bf51-7823" type="max"/>
@@ -2837,60 +3530,6 @@
             <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="When units in a Bloodbound Warband make attacks in any turn that they charged, add 1 to the Attacks characteristic of all melee weapons they use. If the Bloodbound Warband contained the maximum number of units at the start of the battle, then you can also re-roll failed wound rolls of 1 for units from this battalion in the combat phase of any turn in which the unit charged."/>
           </characteristics>
         </profile>
-        <profile id="6382-620f-c45b-f5e4" name="-" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="A Bloodbound Warband consists of the following units:"/>
-          </characteristics>
-        </profile>
-        <profile id="c3ce-3636-40b1-cc0f" name="ASPIRING DEATHBRINGER" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1"/>
-          </characteristics>
-        </profile>
-        <profile id="9cd2-d613-07e7-14a2" name="Bloodsecrator" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1"/>
-          </characteristics>
-        </profile>
-        <profile id="993d-b163-22c3-0ae1" name="Blood Warriors" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="3 units"/>
-          </characteristics>
-        </profile>
-        <profile id="60b6-fc22-d6b1-2960" name="Bloodreavers" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1-2 units"/>
-          </characteristics>
-        </profile>
-        <profile id="a68b-654c-4049-27a6" name="Skullreapers" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5"/>
-          </characteristics>
-        </profile>
       </profiles>
       <rules/>
       <infoLinks/>
@@ -2916,58 +3555,260 @@
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="25b7-3946-9872-4f60" name="1 ASPIRING DEATHBRINGER" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fca3-4349-ffdc-d294" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="df40-2843-ce03-4468" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="41b3-ec93-d5cc-f573" name="Aspiring Deathbringer" hidden="false" targetId="c098-9c13-471b-7fc8" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="6196-30c2-8834-c1f3" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="9a25-4ce0-8ce0-7c52" name="1 Bloodsecrator" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4e88-cf95-ad66-9bc1" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9c08-07c2-3783-614e" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="bd1a-0966-0979-a829" name="Bloodsecrator" hidden="false" targetId="56be-4ba7-aa8b-81d6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="cf4e-6e1b-c2a3-7293" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="3ff6-dd05-bec2-30c3" name="3 units of Blood Warriors" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a1b7-725b-29a7-3d51" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cc3d-45b6-d5d8-2f57" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="f15e-5123-6bdc-1e8b" name="Blood Warriors" hidden="false" targetId="9361-fa26-31b7-4a10" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="notInstanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="f057-46e4-d344-b96a" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="a558-e0cd-13dc-9137" name="Blood Warriors" hidden="false" targetId="9361-fa26-31b7-4a10" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="6855-8b95-442d-9647" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="f1b0-5e41-b158-9caf" name="1-2 units of Bloodreavers" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0c4a-0055-7fb1-fa83" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c622-e1b5-d2f8-6789" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="9b36-828d-ea75-902f" name="Bloodreavers" hidden="false" targetId="78be-9de2-98c0-1b84" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="97b2-bba2-b047-a0ef" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="76ea-9c8b-914f-c77c" name="Bloodreavers" hidden="false" targetId="78be-9de2-98c0-1b84" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="notInstanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="f301-1559-4bc1-5127" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="15d2-3a45-4ad9-f687" name="1 unit of Skullreapers" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ff7c-b807-9901-7848" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7d1a-3070-28c2-3b1a" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="24d8-073f-ea71-ed45" name="Skullreapers" hidden="false" targetId="be0c-d1b0-5f46-48c4" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="6ddd-0fc0-9959-be3d" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks/>
       <costs/>
     </selectionEntry>
     <selectionEntry id="45b7-db81-23e4-78c8" name="Battalion: Bloodbound Warhorde" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="1607-c161-654f-b836" name="-" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="A Bloodbound Warhorde consists of the following warscroll battalions:"/>
-          </characteristics>
-        </profile>
-        <profile id="eccf-4b29-2e4a-8e50" name="Mighty Lord of Khorne, Lord of Khorne on Juggernaut, Skarr Bloodwrath or Valkia the Bloody" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1"/>
-          </characteristics>
-        </profile>
-        <profile id="7e01-7cb9-67db-71c1" name="The Gorechosen" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1"/>
-          </characteristics>
-        </profile>
-        <profile id="cd69-8989-02e6-de10" name="Bloodbound Warband" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1"/>
-          </characteristics>
-        </profile>
-        <profile id="5301-8ad5-fac7-107a" name="Bloodbound Warband, Bloodforged, Brass Stampede, Dark Feast, Gore Pilgrims, Red Headsmen, Slaughterborn, Skulltake" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="3-7 warcrolls battalions in any combination."/>
-          </characteristics>
-        </profile>
-      </profiles>
+      <profiles/>
       <rules/>
       <infoLinks>
         <infoLink id="6578-6a54-bf84-9b95" name="Khorne Cares Not From Whence The Blood Flows" hidden="false" targetId="1e59-b134-d86a-40da" type="profile">
@@ -3005,7 +3846,292 @@
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="8e6e-7816-4a42-b181" name="1 Mighty Lord of Khorne, Lord of Khorne on Juggernaut, Skarr Bloodwrath or Valkia the Bloody" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f48b-9b67-7d77-6bbc" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c731-8348-29aa-94c4" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="556b-2b71-0617-31c9" name="Mighty Lord of Khorne" hidden="false" targetId="50ba-f44c-8f95-a084" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="f12f-620d-728e-8d73" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="50f6-e6aa-dedb-9d7c" name="Lord of Khorne on Juggernaut" hidden="false" targetId="f423-90c7-d450-d22b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="e52f-d037-5798-cb92" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="b25a-1102-07b5-8881" name="Skarr Bloodwrath" hidden="false" targetId="be72-b584-fc3e-decc" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="7ce4-8b1f-ee93-effe" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="d78d-1900-4e14-a379" name="Valkia the Bloody" hidden="false" targetId="c8c7-4d19-2acc-1c0c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="e4cc-7d34-b99b-014b" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="4713-0df6-50c3-1511" name="The Gorechosen" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="782f-b2a0-e512-5110" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d685-bc6a-7a65-f7c1" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="77ba-26a6-86a0-f200" name="Battalion: The Gorechosen" hidden="false" targetId="f7da-d7af-dfa7-865d" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="9ea8-9261-5f41-9ce2" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="0e53-12ef-62a6-9cdc" name="1 Bloodbound Warband" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fb62-e209-90ff-9a68" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="499b-743d-2ec3-74ff" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="b690-185d-17d4-cb59" name="Battalion: Bloodbound Warband" hidden="false" targetId="a584-3218-b0cd-294f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="1324-2553-d5eb-3e46" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="1fc5-61a4-d9d3-5568" name="3-7 other warscroll battalions" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="04bc-2bcb-6679-06e0" type="max"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3365-4d22-7585-ccce" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="06fd-7c2d-e538-87d1" name="Battalion: Bloodbound Warband" hidden="false" targetId="a584-3218-b0cd-294f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="5066-9398-4b14-54a8" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="2fe1-3d12-d8a0-de0c" name="Battalion: Bloodforged" hidden="false" targetId="d28c-99c1-fb9b-7755" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="a9be-69bc-1657-a05a" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="f581-8307-335f-c514" name="Battalion: Brass Stampede" hidden="false" targetId="54ed-273a-ff0d-b1d0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="d856-5ce0-7ba5-4bee" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="fae6-d8fa-5a4a-dd0e" name="Battalion: Dark Feast" hidden="false" targetId="ed0a-8b27-5e9c-2d74" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="38e1-4fea-09a8-d10e" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="d971-ab73-edfd-11b1" name="Battalion: Gore Pilgrims" hidden="false" targetId="b9b7-ea01-585d-aed2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="b889-fa78-6aa0-b9dc" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="e1f5-9daf-5e72-9201" name="Battalion: Red Headsmen" hidden="false" targetId="c470-a112-03b6-9129" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="73e2-640d-d096-88d4" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="d060-a1b3-4d4a-4430" name="Battalion: Slaughterborn" hidden="false" targetId="7901-eafc-3534-afe8" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="f780-8b91-01b0-9c76" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="1f2a-aff9-6f22-db56" name="Battalion: Skulltake" hidden="false" targetId="3258-9691-5f0d-19e0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="4e63-f883-1918-9629" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks/>
       <costs/>
     </selectionEntry>
@@ -5012,33 +6138,6 @@
             <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="If a unit uses its Murderous Charge ability within 3&quot; of another unit in the Bloodthunder Stampede, you do not need to roll a dice - it automatically inflicts D3 mortal wounds (or D6 if the Bloodcrusher unit includes 6 or more models) as the enemy is trampled to a bloody pulp."/>
           </characteristics>
         </profile>
-        <profile id="5c14-bfb1-a0fa-c0ab" name="-" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="A Bloodthunder Stampede consists of the following units:"/>
-          </characteristics>
-        </profile>
-        <profile id="915c-18c6-f0e0-27d1" name="Skullmaster, Herald of Khorne" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1"/>
-          </characteristics>
-        </profile>
-        <profile id="49b8-10c9-fcb5-cd8f" name="Bloodcrushers" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5"/>
-          </characteristics>
-        </profile>
       </profiles>
       <rules/>
       <infoLinks/>
@@ -5064,7 +6163,114 @@
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="3661-2c71-69e4-8d14" name="1 Skullmaster, Herald of Khorne" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a43-56be-f163-bd95" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98de-639c-58b0-b11b" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="272f-3407-1867-acd5" name="Skullmaster, Herald of Khorne" hidden="false" targetId="3f73-0a16-9b36-ae7a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="6fd0-84cd-2e6e-101b" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="992b-f989-911f-4468" name="3-8 units of Bloodcrushers" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d869-97e8-7606-8c39" type="min"/>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6739-61ec-3515-9511" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="c546-c026-4090-cbb2" name="Bloodcrushers" hidden="false" targetId="e52f-0fd9-6fe1-5c89" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9517-e07e-e189-6699" type="equalTo"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0472-ec32-ce10-0540" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="34bb-c24d-f773-f7f5" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="8766-d44c-141e-22e4" name="Bloodcrushers" hidden="false" targetId="e52f-0fd9-6fe1-5c89" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0472-ec32-ce10-0540" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9517-e07e-e189-6699" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="457a-fc90-543c-3f7f" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks/>
       <costs/>
     </selectionEntry>
@@ -5215,12 +6421,175 @@
       <modifiers/>
       <constraints/>
       <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
+      <selectionEntries>
+        <selectionEntry id="b04d-8477-9101-3658" name="Charnel Host" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43d5-c311-c738-6ba1" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7cf-76ed-52ad-d701" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="140.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="d34c-8286-5a5d-7171" name="1x Bloodthirster of Unfettered Fury" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3373-1879-e63c-2c09" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="63b5-d60d-e5c5-3e92" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="f56c-f0ea-5787-3fa1" name="Bloodthirster of Unfettered Fury" hidden="false" targetId="a59e-d6c6-24cb-cf41" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="a327-e644-a651-f73c" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="acc2-91f4-b080-5415" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="c1fe-408c-66f6-fc8c" name="1 Bloodmaster, Herald of Khorne" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01b3-914c-ab5a-67db" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f4ba-0108-025a-ccd3" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="be53-3b62-0342-9c55" name="Bloodmaster, Herald of Khorne" hidden="false" targetId="049f-9f7d-343e-c78c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="3599-2cee-d537-6fc0" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="0cfe-e7e7-a735-773a" name="3-8 Units of Bloodletters" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ead8-b73e-6fe6-8ec3" type="min"/>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91c2-d634-0a48-2f57" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="b060-faba-158e-a8c8" name="Bloodletters" hidden="false" targetId="3012-ad18-c49d-24c2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="be58-22ae-badb-9f65" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="27c0-c2fe-5821-0cc9" name="Bloodletters" hidden="false" targetId="3012-ad18-c49d-24c2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="notInstanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="8aa2-e6fa-1242-37cf" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="140.0"/>
-      </costs>
+      <costs/>
     </selectionEntry>
     <selectionEntry id="4871-f8d1-52f4-c5e0" name="Battalion: Council of Blood" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -5266,43 +6635,166 @@
       <modifiers/>
       <constraints/>
       <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
+      <selectionEntries>
+        <selectionEntry id="5566-ef84-bdeb-5cb5" name="Council of Blood" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4586-e031-a25b-28f4" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5fc-46bd-4745-8062" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="110.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="83bb-344c-1721-3c9d" name="3 BLOODTHIRSTERS" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94f5-5799-54db-5d14" type="max"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4827-7ee7-e13a-d05d" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="1a85-35c0-7cdb-8867" name="Wrath of Khorne Bloodthirster" hidden="false" targetId="510a-95e2-773f-81a9" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="9fd2-f24d-53ca-b705" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="3788-6955-56aa-e8ed" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="5a66-d6ed-be08-43c0" name="Bloodthirster of Insensate Rage" hidden="false" targetId="8886-dbc9-97d5-ddad" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="5583-2160-0162-8fd7" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="48c3-c6a3-8c89-9186" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="35a0-1db9-c35c-6b85" name="Bloodthirster of Unfettered Fury" hidden="false" targetId="a59e-d6c6-24cb-cf41" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="3d45-cbe9-0b6b-36e7" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="41dd-44e2-df97-618e" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="a34d-9bfc-88bb-83a4" name="Exalted Greater Daemon of Khorne" hidden="false" targetId="e137-a705-cb6c-a10f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f32a-df3e-42f7-549a" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="3377-2981-06e1-e987" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="7702-c3af-333c-f75a" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="c632-3467-251b-0b6f" name="Skarbrand" hidden="false" targetId="580c-ab5a-f469-2866" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="efec-33cd-7748-bd5d" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="bf59-5d2a-c3e4-7b11" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="0aa3-8b2a-e231-aea3" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="110.0"/>
-      </costs>
+      <costs/>
     </selectionEntry>
-    <selectionEntry id="502c-6a0a-4fc2-5bcc" name="Daemon Legion of Khorne" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="5e09-9cea-875a-52f9" name="-" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="A Daemon Legion of Khorne consists of the following warscroll battalions."/>
-          </characteristics>
-        </profile>
-        <profile id="8358-1ed7-6bcd-2cc5" name="Bloodhost of Khorne" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1"/>
-          </characteristics>
-        </profile>
-        <profile id="3570-1e77-b10b-47f8" name="Murderhost, Bloodthunder Stampede, Council of Blood, Blood Hunt, Gorethunder Cohort, Charnel Host, Skullseeker Host" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="3-8 warscroll battalions chosen in any combination."/>
-          </characteristics>
-        </profile>
-      </profiles>
+    <selectionEntry id="502c-6a0a-4fc2-5bcc" name="Battalion: Daemon Legion of Khorne" hidden="false" collective="false" type="upgrade">
+      <profiles/>
       <rules/>
       <infoLinks>
         <infoLink id="b450-0000-ec40-95e5" name="Khorne Cares Not From Whence The Blood Flows" hidden="false" targetId="1e59-b134-d86a-40da" type="profile">
@@ -5321,12 +6813,187 @@
       <modifiers/>
       <constraints/>
       <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
+      <selectionEntries>
+        <selectionEntry id="7504-6989-83b6-06ad" name="Daemon Legion of Khorne" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="caef-1aa3-f2ef-e07a" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c1f-7041-8dc1-601a" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="160.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="e8da-a18f-5d59-4801" name="1 Blood Host of Khorne" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2c6d-729b-fb78-ccef" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="60e5-cc4b-49b9-680f" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="a72f-4b26-9719-c16f" name="Battalion: Blood Host of Khorne" hidden="false" targetId="a7fd-9b56-eaff-f352" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="4736-5060-6d74-39d8" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="7734-261a-0a30-cfad" name="3-8 other warscroll battalions" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a051-b542-830c-83a7" type="max"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d255-964c-5992-3819" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="08d7-7db5-7c24-c38e" name="Battalion: Murderhost" hidden="false" targetId="3e97-a678-8853-12df" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="c9eb-6819-0f5d-fbdb" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="a4c6-6bf4-3fe5-2cf4" name="Battalion: Bloodthunder Stampede" hidden="false" targetId="80d0-e602-f091-6279" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="b2e6-09a8-e9fa-d934" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="3c83-3495-93d6-a916" name="Battalion: Council of Blood" hidden="false" targetId="4871-f8d1-52f4-c5e0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="d7e3-81ac-6a30-e067" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="5e47-84ca-265f-bf90" name="Battalion: Blood Hunt" hidden="false" targetId="cb7a-2a30-c407-d701" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="23b7-fb67-2001-adf9" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="3a1e-f685-ebbf-e200" name="Battalion: Gorethunder Cohort" hidden="false" targetId="38b0-9eab-8717-1264" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="01e3-5f31-b48c-b579" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="c69f-a01b-12e4-54e7" name="Battalion: Charnel Host" hidden="false" targetId="a765-6bbb-3d30-5dda" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="8df9-5651-4873-30a8" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="bd81-02ec-1c2b-d36a" name="Battalion: Skullseeker Host" hidden="false" targetId="a5f8-e838-f2a2-2441" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="829a-5a44-e5c4-1d98" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="160.0"/>
-      </costs>
+      <costs/>
     </selectionEntry>
     <selectionEntry id="ed0a-8b27-5e9c-2d74" name="Battalion: Dark Feast" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -5390,12 +7057,28 @@
       <modifiers/>
       <constraints/>
       <categoryLinks/>
-      <selectionEntries/>
+      <selectionEntries>
+        <selectionEntry id="2ec3-47f1-33f5-7779" name="Dark Feast" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e7ef-532f-2297-ea74" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f27-3189-246a-3cac" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="200.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="200.0"/>
-      </costs>
+      <costs/>
     </selectionEntry>
     <selectionEntry id="e888-8eef-c485-8b83" name="Exalted Deathbringer" hidden="false" collective="false" type="unit">
       <profiles>
@@ -5432,7 +7115,15 @@
       </profiles>
       <rules/>
       <infoLinks/>
-      <modifiers/>
+      <modifiers>
+        <modifier type="append" field="name" value="with Impaling Spear">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bb32-8c3a-845d-6be4" type="greaterThan"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
       <constraints/>
       <categoryLinks>
         <categoryLink id="9581-ab50-396d-9e20" name="New CategoryLink" hidden="false" targetId="7cdd-80ea-cbeb-8e16" primary="false">
@@ -6262,12 +7953,28 @@
       <modifiers/>
       <constraints/>
       <categoryLinks/>
-      <selectionEntries/>
+      <selectionEntries>
+        <selectionEntry id="068d-890f-0349-f200" name="Gore Pilgrims" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc74-e0cb-5268-e2bc" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8223-aded-a3d8-e0f9" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="180.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="180.0"/>
-      </costs>
+      <costs/>
     </selectionEntry>
     <selectionEntry id="38b0-9eab-8717-1264" name="Battalion: Gorethunder Cohort" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -6313,12 +8020,91 @@
       <modifiers/>
       <constraints/>
       <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
+      <selectionEntries>
+        <selectionEntry id="365f-f1c8-1660-9578" name="Gorethunder Cohort" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7219-9101-7d50-7c1f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45cb-4152-3104-04ef" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="110.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="7e2b-3b07-f40c-50e4" name="1 Blood Throne" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b5d-8610-3733-35ab" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e4c-db82-c891-6514" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="a2dd-b60b-9fbd-4372" name="Blood Throne" hidden="false" targetId="d39a-4082-0c4c-b899" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="3510-5313-79ab-0214" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="b353-2efa-eb67-38be" name="3-8 units of Skull Cannons" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bbd8-f1ba-9516-7654" type="min"/>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="60b1-3f2c-c16b-8a42" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="c95e-d96a-dec4-bdef" name="Skull Cannons" hidden="false" targetId="2163-0d0c-6837-de92" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="e9fe-dc7f-dc1e-6f8b" name="New CategoryLink" hidden="false" targetId="1d26-07fc-6a66-d73e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="110.0"/>
-      </costs>
+      <costs/>
     </selectionEntry>
     <selectionEntry id="6578-af62-39ff-f9f2" name="Karanak" hidden="false" collective="false" type="unit">
       <profiles>
@@ -7441,7 +9227,6 @@
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a50c-c7ea-ee0d-347f" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ff1-8d35-c91c-fd84" type="max"/>
           </constraints>
           <categoryLinks/>
@@ -7468,7 +9253,6 @@
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03a9-bacf-844f-e340" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8af0-d780-7887-8efe" type="max"/>
           </constraints>
           <categoryLinks/>
@@ -7582,45 +9366,329 @@
             <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="After set-up, but before the battel begins, roll 2D6. Each unit from this battalion within 8&quot; of the battalion&apos;s BLOODLETTER HERO and more than 3&quot; from any enemy units can move a distance in inches equal to the roll. The units cannot run, or move within 3&quot; of an enemy unit, and the distance to the HERO must be measured before any of the moves are made. If the Murderhost contained the maximum number of units at the start of the battle, you can use this ability again at the start of each of your hero phases as well as after set-up."/>
           </characteristics>
         </profile>
-        <profile id="1c1b-03d3-a7ae-cc9d" name="-" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="A Murderhost consists of the following units:"/>
-          </characteristics>
-        </profile>
-        <profile id="4a82-6dbe-fada-ada7" name="BLOODLETTER HERO" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1"/>
-          </characteristics>
-        </profile>
-        <profile id="5b13-460e-2a36-d7df" name="Bloodletters, Flesh Hounds, Bloodcrushers, Skull Cannons" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="3-8 units in any combination"/>
-          </characteristics>
-        </profile>
       </profiles>
       <rules/>
       <infoLinks/>
       <modifiers/>
       <constraints/>
       <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
+      <selectionEntries>
+        <selectionEntry id="3f7a-4faa-7e85-aa94" name="Murderhost" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ff1-4a3c-3550-f53c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="89d7-b570-a5f3-dc1f" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="120.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="697e-faaf-d5c4-9387" name="1 BLOODLETTER HERO" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7478-5233-3964-bbab" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b65-4dd3-c9d0-f0cc" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="c68d-bf9e-0334-7100" name="Skullmaster, Herald of Khorne" hidden="false" targetId="3f73-0a16-9b36-ae7a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="3b36-3627-f7b7-a989" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="f6cc-c7ee-30e5-4f47" name="Skulltaker" hidden="false" targetId="d0d5-c7ce-b8ef-4805" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f02-5142-97da-0aed" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="9488-0955-2908-33f4" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="19ee-dffa-b428-9a04" name="Bloodmaster, Herald of Khorne" hidden="false" targetId="049f-9f7d-343e-c78c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="8e94-e5a9-a900-6c82" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="8849-9874-a04f-b4e7" name="Blood Throne" hidden="false" targetId="d39a-4082-0c4c-b899" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="b5a8-5e69-a9f0-30d7" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="610e-bf62-610e-e2d4" name="3-8 units in any combination from the following" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4421-f0cf-f867-2391" type="min"/>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa47-8882-43e2-5ae4" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="67c0-2778-f71f-1ab1" name="Bloodcrushers" hidden="false" targetId="e52f-0fd9-6fe1-5c89" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9517-e07e-e189-6699" type="equalTo"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0472-ec32-ce10-0540" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="8664-8254-9228-cf09" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="245d-93cc-daf7-938d" name="Bloodcrushers" hidden="false" targetId="e52f-0fd9-6fe1-5c89" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0472-ec32-ce10-0540" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9517-e07e-e189-6699" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="9cae-ba81-b907-72a8" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="0cc5-53aa-a4a4-71e8" name="Flesh Hounds" hidden="false" targetId="3fd9-43de-d22c-48a0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0472-ec32-ce10-0540" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a41-d215-35d9-3a00" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="42c2-347f-69a8-bfdd" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="e449-8177-7207-2a70" name="Flesh Hounds" hidden="false" targetId="3fd9-43de-d22c-48a0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a41-d215-35d9-3a00" type="equalTo"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0472-ec32-ce10-0540" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="48e3-f5e6-8b70-ffe0" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="e47d-d215-f18c-0a3d" name="Skull Cannons" hidden="false" targetId="2163-0d0c-6837-de92" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="b35f-504c-8624-5f80" name="New CategoryLink" hidden="false" targetId="1d26-07fc-6a66-d73e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="1601-729d-7757-3820" name="Bloodletters" hidden="false" targetId="3012-ad18-c49d-24c2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="27ab-a5c9-b4ce-a88c" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="53ff-8169-f53e-d0a4" name="Bloodletters" hidden="false" targetId="3012-ad18-c49d-24c2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="notInstanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="c51e-7573-484a-0455" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="120.0"/>
-      </costs>
+      <costs/>
     </selectionEntry>
     <selectionEntry id="c470-a112-03b6-9129" name="Battalion: Red Headsmen" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -7684,12 +9752,28 @@
       <modifiers/>
       <constraints/>
       <categoryLinks/>
-      <selectionEntries/>
+      <selectionEntries>
+        <selectionEntry id="f347-be49-9169-5b9d" name="Red Headsmen" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d248-6c36-c1c0-c5ea" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="daeb-2e9f-df5f-caa9" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="160.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="160.0"/>
-      </costs>
+      <costs/>
     </selectionEntry>
     <selectionEntry id="6067-346b-d05a-72dc" name="Scyla Anfingrimm" hidden="false" collective="false" type="unit">
       <profiles>
@@ -9074,12 +11158,204 @@
       <modifiers/>
       <constraints/>
       <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
+      <selectionEntries>
+        <selectionEntry id="5251-030d-4ced-3b59" name="Skullseeker Host" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d96d-86bf-8511-90c6" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8cc8-7547-6329-5d96" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="140.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="9347-b2e7-0390-7baf" name="2-5 units of Bloodcrushers" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84e0-ebaf-d4c9-9953" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="67fd-1f00-855f-8b16" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="e5d6-8718-659b-7256" name="Bloodcrushers" hidden="false" targetId="e52f-0fd9-6fe1-5c89" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9517-e07e-e189-6699" type="equalTo"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0472-ec32-ce10-0540" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="b1f4-fdd9-c5e4-f483" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="cab0-3447-e349-aa32" name="Bloodcrushers" hidden="false" targetId="e52f-0fd9-6fe1-5c89" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0472-ec32-ce10-0540" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9517-e07e-e189-6699" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="6e70-e0ce-c332-5f77" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="ba05-a503-c7c6-5bbc" name="1-3 units of Skull Cannons" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4503-ee81-e0de-9a84" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c6b-823f-241d-0b9a" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="5eb1-0d72-f082-e133" name="Skull Cannons" hidden="false" targetId="2163-0d0c-6837-de92" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="a678-8dc6-58a0-4308" name="New CategoryLink" hidden="false" targetId="1d26-07fc-6a66-d73e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="d753-a433-90eb-9f5e" name="1 Bloodmaster, Herald of Khorne" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39e4-a48c-5f6d-4bda" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df09-1803-bde9-50d4" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="3c96-4cf1-e17c-802a" name="Bloodmaster, Herald of Khorne" hidden="false" targetId="049f-9f7d-343e-c78c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="e592-c1d3-e905-5d5e" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="acbd-bfc6-7086-b56d" name="1x Bloodthirster of Insensate Rage" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5cc-4913-f9ac-fa8c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="493b-c5d7-6a75-c7fa" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="63c4-a508-fc15-df51" name="Bloodthirster of Insensate Rage" hidden="false" targetId="8886-dbc9-97d5-ddad" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="2827-3a47-6d59-eb5a" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="0c85-1839-7a06-3d41" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="140.0"/>
-      </costs>
+      <costs/>
     </selectionEntry>
     <selectionEntry id="3258-9691-5f0d-19e0" name="Battalion: Skulltake" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -9152,12 +11428,28 @@
       <modifiers/>
       <constraints/>
       <categoryLinks/>
-      <selectionEntries/>
+      <selectionEntries>
+        <selectionEntry id="983e-b451-90ab-7539" name="Skulltake" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1701-a6bd-ced7-39e6" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d21-154f-2d95-715f" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="200.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="200.0"/>
-      </costs>
+      <costs/>
     </selectionEntry>
     <selectionEntry id="d0d5-c7ce-b8ef-4805" name="Skulltaker" hidden="false" collective="false" type="unit">
       <profiles>
@@ -9376,12 +11668,28 @@
       <modifiers/>
       <constraints/>
       <categoryLinks/>
-      <selectionEntries/>
+      <selectionEntries>
+        <selectionEntry id="8af1-b211-518d-c5a6" name="The Bloodlords" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f0d-030c-446e-39b6" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ac5-3667-9719-52b6" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="140.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="140.0"/>
-      </costs>
+      <costs/>
     </selectionEntry>
     <selectionEntry id="f7da-d7af-dfa7-865d" name="Battalion: The Gorechosen" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -9436,12 +11744,28 @@
       <modifiers/>
       <constraints/>
       <categoryLinks/>
-      <selectionEntries/>
+      <selectionEntries>
+        <selectionEntry id="fac2-4d40-637d-6eb9" name="The Gorechosen" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea70-9a46-371f-284c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1db8-481a-a273-bd42" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="150.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="150.0"/>
-      </costs>
+      <costs/>
     </selectionEntry>
     <selectionEntry id="0cb6-312b-58a5-927a" name="Battalion: The Goretide" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -9545,12 +11869,28 @@
       <modifiers/>
       <constraints/>
       <categoryLinks/>
-      <selectionEntries/>
+      <selectionEntries>
+        <selectionEntry id="e013-ed8f-890e-3550" name="The Goretide" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f959-ecf1-1886-38ce" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9693-a2b5-752e-3973" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="140.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="140.0"/>
-      </costs>
+      <costs/>
     </selectionEntry>
     <selectionEntry id="7f72-a078-1db0-e0b8" name="Battalion: The Reapers of Vengeance" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -9636,12 +11976,28 @@
       <modifiers/>
       <constraints/>
       <categoryLinks/>
-      <selectionEntries/>
+      <selectionEntries>
+        <selectionEntry id="31ac-9c0c-d616-5e34" name="The Reapers of Vengeance" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ae7-c58a-da84-19a4" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a7c-8950-6557-4d06" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="140.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="140.0"/>
-      </costs>
+      <costs/>
     </selectionEntry>
     <selectionEntry id="4b62-5ef4-4293-14a9" name="Battalion: The Skullfiend Tribe" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -9736,7 +12092,25 @@
       <modifiers/>
       <constraints/>
       <categoryLinks/>
-      <selectionEntries/>
+      <selectionEntries>
+        <selectionEntry id="440f-69b6-ac26-ca7b" name="The Skullfiend Tribe" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80e2-bc92-7b2e-33a8" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6550-aba6-ea06-f18f" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="120.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups/>
       <entryLinks/>
       <costs>
@@ -9796,12 +12170,28 @@
       <modifiers/>
       <constraints/>
       <categoryLinks/>
-      <selectionEntries/>
+      <selectionEntries>
+        <selectionEntry id="d0de-3d70-4738-33e8" name="Slaughterborn" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a36d-2d50-03bb-1cfc" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="428d-5be9-0ecf-464d" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="180.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="180.0"/>
-      </costs>
+      <costs/>
     </selectionEntry>
     <selectionEntry id="29f7-0f99-f720-3119" name="Slaughterbrute of Khorne" hidden="false" collective="false" type="unit">
       <profiles>
@@ -11249,7 +13639,7 @@
       </infoLinks>
       <modifiers/>
       <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="af7c-67c8-29e9-a5ec" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="af7c-67c8-29e9-a5ec" type="max"/>
       </constraints>
       <categoryLinks>
         <categoryLink id="501e-f68c-ee09-6f72" name="New CategoryLink" hidden="false" targetId="246f-c9a0-65ab-f616" primary="false">
@@ -11511,38 +13901,7 @@
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="200c-6e6a-6931-3ce6" name="Magore Redhand" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="3ce1-951d-d1b5-87b3" name="Magore&apos;s Belly Maw" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
-                <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
-                <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="1"/>
-                <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="4+"/>
-                <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
-                <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-1"/>
-                <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="D3"/>
-              </characteristics>
-            </profile>
-            <profile id="f043-b7af-078a-a8cd" name="Daemonic Axe" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
-                <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
-                <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="3"/>
-                <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="3+"/>
-                <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
-                <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-1"/>
-                <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
-              </characteristics>
-            </profile>
-          </profiles>
+          <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
@@ -11551,7 +13910,54 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7641-7c59-c5ad-e19d" type="max"/>
           </constraints>
           <categoryLinks/>
-          <selectionEntries/>
+          <selectionEntries>
+            <selectionEntry id="8ea7-e73a-7d02-6127" name="Daemonic Axe and Belly Maw" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="3839-ed37-7aad-298f" name="Daemonic Axe" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                    <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
+                    <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="3"/>
+                    <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="3+"/>
+                    <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+                    <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-1"/>
+                    <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
+                  </characteristics>
+                </profile>
+                <profile id="daf5-ba7c-e3ef-6f80" name="Magore&apos;s Belly Maw" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                    <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
+                    <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="1"/>
+                    <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="4+"/>
+                    <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+                    <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-1"/>
+                    <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="D3"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="63a3-8578-cb97-b2c7" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bdff-8eeb-b2c3-2cef" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs/>
+            </selectionEntry>
+          </selectionEntries>
           <selectionEntryGroups/>
           <entryLinks/>
           <costs>
@@ -11559,32 +13965,7 @@
           </costs>
         </selectionEntry>
         <selectionEntry id="52ed-0f0b-c106-70f9" name="Ghartok Flayskull" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="50e6-8132-13d9-12bc" name="Goreaxe" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
-                <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
-                <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="2"/>
-                <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="3+"/>
-                <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="4+"/>
-                <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-"/>
-                <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
-              </characteristics>
-            </profile>
-            <profile id="8601-b55c-4c43-2cb8" name="Gorefists" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="Unit Abilities">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="If the save roll for an attack that targets a unit with any Gorefists is 4+ (after re-rolls and modifiers are applied), and the attacking unit is within 1&quot; of the target unit, roll a dice. On a 6, the attacking unit suffers 1 mortal wound after all of its attacks have been resolved."/>
-              </characteristics>
-            </profile>
-          </profiles>
+          <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
@@ -11593,7 +13974,38 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="133f-7e57-e3f0-2bb3" type="max"/>
           </constraints>
           <categoryLinks/>
-          <selectionEntries/>
+          <selectionEntries>
+            <selectionEntry id="3d6b-aeae-1bad-0334" name="Goreaxe and Gorefist" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="2b36-05a9-5247-b34e" name="Goreaxe" hidden="false" targetId="1ebc-6dfb-5777-dfab" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="e157-ab39-b19a-d30b" name="Gorefists (Magore&apos;s Fiends)" hidden="false" targetId="5a14-a300-fa5d-02b2" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4113-1859-bfad-3804" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1160-72af-5177-6033" type="min"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
           <selectionEntryGroups/>
           <entryLinks/>
           <costs>
@@ -11601,32 +14013,7 @@
           </costs>
         </selectionEntry>
         <selectionEntry id="1760-d06b-0453-5ebf" name="Zharkus the Bloodsighted" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="8f69-95c1-b6e1-b519" name="Goreaxe" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
-                <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
-                <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="2"/>
-                <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="3+"/>
-                <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="4+"/>
-                <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-"/>
-                <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
-              </characteristics>
-            </profile>
-            <profile id="fe4c-67fa-e682-43de" name="Gorefists" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="Unit Abilities">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="If the save roll for an attack that targets a unit with any Gorefists is 4+ (after re-rolls and modifiers are applied), and the attacking unit is within 1&quot; of the target unit, roll a dice. On a 6, the attacking unit suffers 1 mortal wound after all of its attacks have been resolved."/>
-              </characteristics>
-            </profile>
-          </profiles>
+          <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
@@ -11635,7 +14022,38 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5761-3599-5218-f250" type="max"/>
           </constraints>
           <categoryLinks/>
-          <selectionEntries/>
+          <selectionEntries>
+            <selectionEntry id="4672-c427-688e-8782" name="Goreaxe and Gorefist" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="7741-93c9-4600-065c" name="Goreaxe" hidden="false" targetId="1ebc-6dfb-5777-dfab" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="8e24-55dd-2216-560d" name="Gorefists (Magore&apos;s Fiends)" hidden="false" targetId="5a14-a300-fa5d-02b2" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="043a-0dc0-e58a-84fd" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="407c-1755-7bc6-615b" type="min"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
           <selectionEntryGroups/>
           <entryLinks/>
           <costs>
@@ -11661,21 +14079,6 @@
             <characteristic name="Wounds" characteristicTypeId="cd0e-fea6-411f-904d" value="2"/>
             <characteristic name="Bravery" characteristicTypeId="0c85-bf79-836b-759e" value="10"/>
             <characteristic name="Save" characteristicTypeId="f8dd-4f2a-8543-4f36" value="5+"/>
-          </characteristics>
-        </profile>
-        <profile id="0f38-2959-fbb0-abbe" name="Blood-dark Claws" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
-            <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
-            <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="4"/>
-            <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="3+"/>
-            <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="4+"/>
-            <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-"/>
-            <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
           </characteristics>
         </profile>
         <profile id="a9a9-c08a-9bcf-4f27" name="Collar of Khorne" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="Unit Abilities">
@@ -11758,7 +14161,39 @@
           <constraints/>
         </categoryLink>
       </categoryLinks>
-      <selectionEntries/>
+      <selectionEntries>
+        <selectionEntry id="fc13-ea35-5e1a-2ae7" name="Blood-dark Claws" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="5baa-d555-0cea-f552" name="Blood-dark Claws" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
+                <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="4"/>
+                <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="3+"/>
+                <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="4+"/>
+                <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-"/>
+                <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="986e-6eaa-b40b-c47e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="994f-ee84-1080-f3d4" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs/>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups/>
       <entryLinks/>
       <costs>
@@ -13687,6 +16122,30 @@
       <modifiers/>
       <characteristics>
         <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="You immediately gain 1 Blood Tithe point at the start of each of your hero phases."/>
+      </characteristics>
+    </profile>
+    <profile id="5a14-a300-fa5d-02b2" name="Gorefists" book="Magore&apos;s Fiends" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="Unit Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="If the save roll for an attack that targets a unit with any Gorefists is 4+ (after re-rolls and modifiers are applied), and the attacking unit is within 1&quot; of the target unit, roll a dice. On a 6, the attacking unit suffers 1 mortal wound after all of its attacks have been resolved."/>
+      </characteristics>
+    </profile>
+    <profile id="1ebc-6dfb-5777-dfab" name="Goreaxe" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+        <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
+        <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="2"/>
+        <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="3+"/>
+        <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="4+"/>
+        <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-"/>
+        <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/Chaos - Khorne.cat
+++ b/Chaos - Khorne.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cac4-1eec-d548-b34d" name="Chaos - Khorne" book="Chaos Battletome Blade of Khorne" revision="8" battleScribeVersion="2.01" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="19" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="cac4-1eec-d548-b34d" name="Chaos - Khorne" book="Chaos Battletome Blade of Khorne" revision="9" battleScribeVersion="2.01" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="19" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -963,7 +963,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="c437-801f-2604-d25d" name="Daemon Legion of Khorne" hidden="false" targetId="502c-6a0a-4fc2-5bcc" type="selectionEntry">
+    <entryLink id="c437-801f-2604-d25d" name="Battalion: Daemon Legion of Khorne" hidden="false" targetId="502c-6a0a-4fc2-5bcc" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -1797,6 +1797,118 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
+    <entryLink id="998d-f80c-337e-a974" name="Battalion: Khorne Bloodbound Slaughterstorm (Open Play)" hidden="false" targetId="61d9-ceff-02a4-d364" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="8fc6-ecc7-b554-d85f" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="52c6-21b0-f723-015f" name="Battalion: Daemon Cohort of Khorne (Open Play)" hidden="false" targetId="a9bc-7cff-e9fd-4425" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="0d8f-1ae3-d183-16ab" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="1221-aaa2-e961-dce1" name="Soul Grinder (of Khorne)" hidden="false" targetId="05ed-b451-22d2-d2ab" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="a449-736d-f78b-ba90" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="42d8-a359-90ec-95f7" name="Battalion: Khorne Bloodbound Murderband (Open Play)" hidden="false" targetId="7e93-92f2-50b5-2185" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="324e-5223-f174-096e" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="85bb-fd8e-2611-8937" name="Battalion: Bloodmarked Warband (BLOODBOUND)" hidden="false" targetId="c148-96c9-13fa-ae62" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="b7e5-e637-4c09-1457" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="2edd-afe1-6bdd-6fd8" name="Battalion: Skall&apos;uk&apos;s Slaughterband (Open Play)" hidden="false" targetId="4029-82e5-afde-0d4f" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="e98e-388d-6bc9-cc02" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="ea5a-c7d5-39a3-f17a" name="Battalion: Goreblade Warband (Open Play) [Starter Set Battalion]" hidden="false" targetId="bcdb-55cb-80d1-c1b4" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="f0d0-518f-9ce2-d686" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+    </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="7ab9-de0a-88c2-4fd1" name="General" hidden="false" collective="false" type="upgrade">
@@ -1982,7 +2094,15 @@
               </profiles>
               <rules/>
               <infoLinks/>
-              <modifiers/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="61d9-ceff-02a4-d364" type="instanceOf"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="852e-8cba-a1d0-bc46" type="max"/>
               </constraints>
@@ -2770,7 +2890,15 @@
               <profiles/>
               <rules/>
               <infoLinks/>
-              <modifiers/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b1c3-247f-3f2b-c657" type="instanceOf"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
               <constraints/>
               <categoryLinks>
                 <categoryLink id="27c3-2265-ece0-9c79" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
@@ -2790,7 +2918,7 @@
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="908c-90c4-1366-ce0a" type="min"/>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="908c-90c4-1366-ce0a" type="max"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ab15-2933-ff7d-a9cd" type="min"/>
           </constraints>
           <categoryLinks/>
@@ -2875,6 +3003,13 @@
                     </conditionGroup>
                   </conditionGroups>
                 </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b1c3-247f-3f2b-c657" type="instanceOf"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
               </modifiers>
               <constraints/>
               <categoryLinks>
@@ -2904,6 +3039,13 @@
                       <conditionGroups/>
                     </conditionGroup>
                   </conditionGroups>
+                </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b1c3-247f-3f2b-c657" type="instanceOf"/>
+                  </conditions>
+                  <conditionGroups/>
                 </modifier>
               </modifiers>
               <constraints/>
@@ -5261,7 +5403,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="The leder of this unit is a Chieftain. A Chieftain makes 2 attacks rather than 1."/>
+            <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="The laeder of this unit is a Chieftain. A Chieftain makes 2 attacks rather than 1."/>
           </characteristics>
         </profile>
         <profile id="5190-b17d-b718-5294" name="Frenzied Devotion" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="08 Ability (Unit)">
@@ -6665,14 +6807,14 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="c8dd-ee6a-71e9-6872" name="Mighty Lord of Khorne" hidden="false" targetId="50ba-f44c-8f95-a084" type="selectionEntry">
+            <entryLink id="a6f0-7ce6-ab66-c968" name="Lord of Khorne on Juggernaut" hidden="false" targetId="f423-90c7-d450-d22b" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints/>
               <categoryLinks>
-                <categoryLink id="0994-7bc0-c9ac-578d" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                <categoryLink id="1339-b9ca-d0b4-d30d" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -6782,42 +6924,6 @@
           <modifiers/>
           <characteristics>
             <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="In each of your hero phases, you can pile in and attack with any units from a Charnel Host that are within 3&quot; of an enemy unit and within 8&quot; of their battalion&apos;s Bloodthirster of Unfettered Fury."/>
-          </characteristics>
-        </profile>
-        <profile id="b1b2-0367-611a-b0a4" name="-" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="A Charnel Host consists of the following units:"/>
-          </characteristics>
-        </profile>
-        <profile id="139d-98ce-84f5-f17b" name="Bloodthirster of Unfettered Fury" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5"/>
-          </characteristics>
-        </profile>
-        <profile id="4ca9-0304-f6f0-d5d0" name="Bloodmaster, Herald of Khorne" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1"/>
-          </characteristics>
-        </profile>
-        <profile id="37f4-67f2-a031-dfa7" name="Bloodletters" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="3-8 units"/>
           </characteristics>
         </profile>
       </profiles>
@@ -7018,24 +7124,6 @@
             <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Each BLOODTHIRSTER from a Council of Blood can use the command ability on its warscroll in each of your hero phases, even if they are not your army&apos;s general."/>
           </characteristics>
         </profile>
-        <profile id="3592-eccb-1fa3-c13a" name="-" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="A Council of Blood consists of the following units:"/>
-          </characteristics>
-        </profile>
-        <profile id="2265-2616-2227-66c2" name="BLOODTHIRSTERS" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="3-8 models"/>
-          </characteristics>
-        </profile>
       </profiles>
       <rules/>
       <infoLinks/>
@@ -7062,7 +7150,7 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="83bb-344c-1721-3c9d" name="3 BLOODTHIRSTERS" hidden="false" collective="false">
+        <selectionEntryGroup id="83bb-344c-1721-3c9d" name="3-8 BLOODTHIRSTERS" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -8053,7 +8141,8 @@
       <infoLinks/>
       <modifiers/>
       <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1f72-4aac-a5bc-9cd1" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1f72-4aac-a5bc-9cd1" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82b4-ed5c-f567-1248" type="max"/>
       </constraints>
       <categoryLinks>
         <categoryLink id="7359-18f4-70a4-4a0a" name="New CategoryLink" hidden="false" targetId="7cdd-80ea-cbeb-8e16" primary="false">
@@ -8819,6 +8908,7 @@
       <modifiers/>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1458-76bd-d2d6-c1e4" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9989-6ac6-4fd5-66a1" type="max"/>
       </constraints>
       <categoryLinks>
         <categoryLink id="db19-1920-a68a-1677" name="New CategoryLink" hidden="false" targetId="7cdd-80ea-cbeb-8e16" primary="false">
@@ -9186,6 +9276,7 @@
       <modifiers/>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4224-6a6a-ccf3-2e42" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30d4-3cef-2a3d-ad15" type="max"/>
       </constraints>
       <categoryLinks>
         <categoryLink id="4950-0ed3-8b13-fcca" name="New CategoryLink" hidden="false" targetId="7cdd-80ea-cbeb-8e16" primary="false">
@@ -10230,6 +10321,13 @@
                     </conditionGroup>
                   </conditionGroups>
                 </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea80-f24a-71aa-b159" type="instanceOf"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
               </modifiers>
               <constraints/>
               <categoryLinks>
@@ -10260,6 +10358,13 @@
                     </conditionGroup>
                   </conditionGroups>
                 </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea80-f24a-71aa-b159" type="instanceOf"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
               </modifiers>
               <constraints/>
               <categoryLinks>
@@ -10276,7 +10381,15 @@
               <profiles/>
               <rules/>
               <infoLinks/>
-              <modifiers/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea80-f24a-71aa-b159" type="instanceOf"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
               <constraints/>
               <categoryLinks>
                 <categoryLink id="b35f-504c-8624-5f80" name="New CategoryLink" hidden="false" targetId="1d26-07fc-6a66-d73e" primary="true">
@@ -10596,6 +10709,7 @@
       <modifiers/>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1e21-4d96-031a-c079" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d61-d64b-fcb6-dcbe" type="max"/>
       </constraints>
       <categoryLinks>
         <categoryLink id="ed1d-cee6-5d0f-fa74" name="New CategoryLink" hidden="false" targetId="7cdd-80ea-cbeb-8e16" primary="false">
@@ -10809,6 +10923,7 @@
       <modifiers/>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7a20-6e2a-f4e3-2764" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b0a2-54d6-a7d0-1cf7" type="max"/>
       </constraints>
       <categoryLinks>
         <categoryLink id="fc58-a56e-d1c2-fae4" name="New CategoryLink" hidden="false" targetId="7cdd-80ea-cbeb-8e16" primary="false">
@@ -11064,6 +11179,7 @@
       <modifiers/>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bce7-962e-8b94-dc78" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1cb5-64a5-d197-c405" type="max"/>
       </constraints>
       <categoryLinks>
         <categoryLink id="2a0a-ca0a-dd06-5359" name="New CategoryLink" hidden="false" targetId="7cdd-80ea-cbeb-8e16" primary="false">
@@ -12044,7 +12160,7 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="acbd-bfc6-7086-b56d" name="1x Bloodthirster of Insensate Rage" hidden="false" collective="false">
+        <selectionEntryGroup id="acbd-bfc6-7086-b56d" name="1 Bloodthirster of Insensate Rage" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -12138,7 +12254,15 @@
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="increment" field="5cfb-178f-ec53-7b4d" value="1">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c4f4-d49b-b53d-d2e6" type="instanceOf"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5cfb-178f-ec53-7b4d" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6a3-6619-92f8-a292" type="max"/>
@@ -12410,6 +12534,7 @@
       <modifiers/>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9bc4-bc0c-1a68-4af1" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a8b-dea5-a6e8-47b1" type="max"/>
       </constraints>
       <categoryLinks>
         <categoryLink id="bfe9-19cc-321c-e3c0" name="New CategoryLink" hidden="false" targetId="7cdd-80ea-cbeb-8e16" primary="false">
@@ -12516,24 +12641,6 @@
     </selectionEntry>
     <selectionEntry id="8e7c-60f9-b0c3-fbc5" name="Battalion: The Bloodlords" hidden="false" collective="false" type="upgrade">
       <profiles>
-        <profile id="2e36-0b8f-305a-b31a" name="Blood Host of Khorne, Murderhost, Bloodthunder Stampede, Council of Blood, Blood Hunt, Gorethunder Cohort, Charnel Host, Skullseeker Host" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="3-8 warscroll battalions in any combination."/>
-          </characteristics>
-        </profile>
-        <profile id="1168-d982-3a45-61e7" name="KHORNE DAEMON units or warscroll battalions" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="Any number"/>
-          </characteristics>
-        </profile>
         <profile id="7e12-1bd4-247b-f82f" name="-" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>
           <rules/>
@@ -12559,15 +12666,6 @@
           <modifiers/>
           <characteristics>
             <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="If any units of Bloodletters and/or Bloodcrushers from the Bloodlords are within 3&quot; of an enemy unit and within 8&quot; of any of the battalion&apos;s BLOODLETTER HEROES at the start of your hero phase, they can immediately pile in and each model in the unit can make a single attack with one of their melee weapons."/>
-          </characteristics>
-        </profile>
-        <profile id="86f3-16f9-0001-c65c" name="Murderhost battalion" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1 (must contain 1 BLOODLETTER HERO and 3-8 units of Bloodletters and Blood Crushers only)"/>
           </characteristics>
         </profile>
       </profiles>
@@ -12608,8 +12706,192 @@
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
-      <entryLinks/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="545b-ddd3-2c8c-8839" name="3-8 warscroll battalions chosen in any combination from the following list" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="feee-b7ef-c749-8b4f" type="min"/>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad39-53fa-0d8d-8e82" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="364c-0700-4c9f-0080" name="Battalion: Blood Host of Khorne" hidden="false" targetId="a7fd-9b56-eaff-f352" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="8c88-6451-d3f1-5789" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="ff96-2bb3-a605-0520" name="Battalion: Murderhost" hidden="false" targetId="3e97-a678-8853-12df" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="bd6c-79b4-f971-3f69" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="9322-c6c1-2899-9aea" name="Battalion: Bloodthunder Stampede" hidden="false" targetId="80d0-e602-f091-6279" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="e5d0-415f-9ab3-f0a8" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="1e83-6a54-d7b7-2fbe" name="Battalion: Council of Blood" hidden="false" targetId="4871-f8d1-52f4-c5e0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="cb90-417c-2df3-8346" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="409f-6f03-c88d-bf6f" name="Battalion: Blood Hunt" hidden="false" targetId="cb7a-2a30-c407-d701" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="c6d6-81f1-ad63-bfbb" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="7af0-e97f-0bc5-4647" name="Battalion: Gorethunder Cohort" hidden="false" targetId="38b0-9eab-8717-1264" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="d0b6-be1d-77b1-d5a7" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="a637-b839-e3ea-d57b" name="Battalion: Charnel Host" hidden="false" targetId="a765-6bbb-3d30-5dda" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="ad64-016c-534e-531f" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="4cf7-7f90-9d2f-ac42" name="Battalion: Skullseeker Host" hidden="false" targetId="a5f8-e838-f2a2-2441" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="898e-23ee-335e-0edc" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="ea80-f24a-71aa-b159" name="1 Murderhost battalion (must have 1 BLOODLETTER HERO and 3-8 units of Bloodletters and Bloodcrushers only)" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02ae-5757-9769-04c1" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7172-f36a-833e-8a1a" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="c556-e189-46a0-d6fe" name="Battalion: Murderhost" hidden="false" targetId="3e97-a678-8853-12df" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="e3db-7c0c-09d6-c272" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="d3af-30c7-9b92-7553" name="Any number of additional KHORNE DAEMON units of Warscroll Battalions" hidden="false" targetId="4026-5e0f-ea39-9ada" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
@@ -12872,24 +13154,6 @@
             <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="In each of your hero phases, roll a D6. You can move each Goretide unit up to the number rolled in inches. You cannot retreat or run as part of this move, but can use it to charge the enemy."/>
           </characteristics>
         </profile>
-        <profile id="ef6b-9fce-571c-056f" name="-" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="The Goretide consists of the following battalions and units:"/>
-          </characteristics>
-        </profile>
-        <profile id="5702-e94b-76fd-76b7" name="Mighty Lord of Khorne/Khorgos Khul" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1. This unit must be included."/>
-          </characteristics>
-        </profile>
         <profile id="89d3-f546-3337-585a" name="Slaughterborn battalion" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
           <profiles/>
           <rules/>
@@ -12897,33 +13161,6 @@
           <modifiers/>
           <characteristics>
             <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1 (must contain 3 units of Blood Warriors) This battalion must be included."/>
-          </characteristics>
-        </profile>
-        <profile id="28d2-9ed7-cf84-07d2" name="Gorechosen battalion" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="0-1 (this battalion is optional)"/>
-          </characteristics>
-        </profile>
-        <profile id="4f16-7956-0099-3079" name="Bloodbound Warband, Bloodforged, Brass Stampede, Dark Feast, Gore Pilgrims, Skulltake, Red Headsmen" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="3-7 warscroll battalions in any combination. (These are optional)"/>
-          </characteristics>
-        </profile>
-        <profile id="ab32-e5da-f50b-70bf" name="KHORNE BLOODBOUND units or warscroll battalions" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="Any number (These are optional)"/>
           </characteristics>
         </profile>
         <profile id="93e6-ace4-a778-eb4c" name="-" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
@@ -12942,13 +13179,41 @@
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="0cb6-312b-58a5-927a" value="7.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4236-d648-023e-ddd1" type="lessThan"/>
+                    <condition field="selections" scope="0cb6-312b-58a5-927a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c706-7e15-4753-e157" type="lessThan"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
         </infoLink>
         <infoLink id="7ef1-e476-52a4-538b" name="The Blood God&apos;s Scorn" hidden="false" targetId="6967-3d69-b8ab-31c6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="0cb6-312b-58a5-927a" value="7.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4236-d648-023e-ddd1" type="lessThan"/>
+                    <condition field="selections" scope="0cb6-312b-58a5-927a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c706-7e15-4753-e157" type="lessThan"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
         </infoLink>
       </infoLinks>
       <modifiers/>
@@ -12973,7 +13238,273 @@
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="beb8-109a-32ff-5ddc" name="Optional Choices:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="4236-d648-023e-ddd1" name="3-7 other warscroll battalions" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="3dc5-27cf-6120-be60" value="3">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4236-d648-023e-ddd1" type="greaterThan"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d99d-440b-84f4-b745" type="max"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3dc5-27cf-6120-be60" type="min"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="cc6d-0444-87f6-19bf" name="Battalion: Bloodbound Warband" hidden="false" targetId="a584-3218-b0cd-294f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks>
+                    <categoryLink id="4816-1cb3-251d-5f9a" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+                <entryLink id="719e-c2f5-581a-f547" name="Battalion: Bloodforged" hidden="false" targetId="d28c-99c1-fb9b-7755" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks>
+                    <categoryLink id="5cb3-1fe2-b04e-e7f9" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+                <entryLink id="0a15-6539-4d3a-c7cc" name="Battalion: Brass Stampede" hidden="false" targetId="54ed-273a-ff0d-b1d0" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks>
+                    <categoryLink id="7291-4b41-5127-f253" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+                <entryLink id="61c0-4d8a-fe16-5481" name="Battalion: Dark Feast" hidden="false" targetId="ed0a-8b27-5e9c-2d74" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks>
+                    <categoryLink id="03c8-f00b-12b9-16e3" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+                <entryLink id="1e3d-4c11-a907-4f32" name="Battalion: Gore Pilgrims" hidden="false" targetId="b9b7-ea01-585d-aed2" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks>
+                    <categoryLink id="95cc-8a21-3062-b936" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+                <entryLink id="2902-c623-0428-7380" name="Battalion: Red Headsmen" hidden="false" targetId="c470-a112-03b6-9129" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks>
+                    <categoryLink id="783c-1d93-5b67-b453" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+                <entryLink id="5c5c-7eda-c96e-9d01" name="Battalion: Skulltake" hidden="false" targetId="3258-9691-5f0d-19e0" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks>
+                    <categoryLink id="c4cf-dced-8f34-8fc6" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="c706-7e15-4753-e157" name="0-1 Gorechosen" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d8be-4d2e-6bde-c3e4" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="569a-d2c0-884f-608e" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="6846-a873-2f1f-0f39" name="Battalion: The Gorechosen" hidden="false" targetId="f7da-d7af-dfa7-865d" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks>
+                    <categoryLink id="5bd6-10cd-530a-fa65" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="fbb8-d135-602b-111e" name="Any number of additional KHORNE BLOODBOUND units or Warscroll Battalions" hidden="false" targetId="7fe7-81b3-4c7e-9fae" type="selectionEntryGroup">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="9c98-efd2-9087-514a" name="1 Mighty Lord of Khorne" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a008-5118-0822-b2be" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3bb7-ffbd-c8fb-76ec" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="d862-9eb5-ff7b-380f" name="Mighty Lord of Khorne" hidden="false" targetId="50ba-f44c-8f95-a084" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="71e2-650e-7d5b-7072" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="03f5-5811-e364-8e0f" name="Khorgos Khull" hidden="false" targetId="595a-599f-1b18-246c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="7067-d548-e19d-4c77" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="2395-00d5-150a-cdc2" name="1 Slaughterborn battalion (Must have 3 units of Blood Warriors)" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bd6f-1b4d-85e7-9d94" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4851-d5b0-a5c8-389a" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="9874-c58d-1df9-5f1b" name="Battalion: Slaughterborn" hidden="false" targetId="7901-eafc-3534-afe8" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="0f50-db43-6904-f6c9" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="0.0"/>
@@ -12997,42 +13528,6 @@
           <modifiers/>
           <characteristics>
             <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Units of Blood Crushers from the Reapers of Vengeance inflict D3 mortal wounds as a result of their Murderous Charge ability on a roll of 2+ instead of 4+."/>
-          </characteristics>
-        </profile>
-        <profile id="96ef-50ce-7890-3e66" name="-" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="The Reapers of Vengeance must contain the following:"/>
-          </characteristics>
-        </profile>
-        <profile id="0e8b-25f6-f85e-a12b" name="Blood Hunt battalion" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1 (must contain a Wrath of Khorne Bloodthirster and units of Blood Crushers only)"/>
-          </characteristics>
-        </profile>
-        <profile id="e9c9-e82a-ba4f-bb55" name="Blood Host of Khorne, Murderhost, Bloodthunder Stampede, Council of Blood, Blood Hunt, Gorethunder Cohort, Charnel Host, Skullseeker Host" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="3-8 warscroll battalions in any combination."/>
-          </characteristics>
-        </profile>
-        <profile id="81a2-9afb-5fc0-5352" name="KHORNE DAEMON units or warscroll battalions" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="Any number"/>
           </characteristics>
         </profile>
         <profile id="4aa8-9a61-5d0a-e513" name="-" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
@@ -13082,8 +13577,192 @@
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
-      <entryLinks/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="f9fa-0323-b82c-6941" name="3-8 warscroll battalions chosen in any combination from the following list" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6469-693a-f913-6b03" type="min"/>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58d5-b308-5325-a102" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="1ca1-8c75-7bdf-35a0" name="Battalion: Blood Host of Khorne" hidden="false" targetId="a7fd-9b56-eaff-f352" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="1edd-3e9e-b2d2-4a59" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="cb45-a094-76a0-16e4" name="Battalion: Murderhost" hidden="false" targetId="3e97-a678-8853-12df" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="a1c9-c4f2-3037-7d2a" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="f1df-2d01-cd63-2e2d" name="Battalion: Bloodthunder Stampede" hidden="false" targetId="80d0-e602-f091-6279" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="419b-100f-afef-e630" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="12ec-e3a2-2447-0065" name="Battalion: Council of Blood" hidden="false" targetId="4871-f8d1-52f4-c5e0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="3dbf-5b3e-f3ac-9110" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="906f-1322-b158-51d9" name="Battalion: Blood Hunt" hidden="false" targetId="cb7a-2a30-c407-d701" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="7933-c487-5119-4424" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="870d-6a6a-07ac-e1fc" name="Battalion: Gorethunder Cohort" hidden="false" targetId="38b0-9eab-8717-1264" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="ffcd-070c-ab70-bc9f" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="46f0-9b8a-ed39-4953" name="Battalion: Charnel Host" hidden="false" targetId="a765-6bbb-3d30-5dda" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="8ee7-6745-176c-7713" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="3fca-2b9f-3b40-2b3b" name="Battalion: Skullseeker Host" hidden="false" targetId="a5f8-e838-f2a2-2441" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="9c14-2d22-237b-7588" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="b1c3-247f-3f2b-c657" name="1 Blood Hunt battalion (must have a Wrath of Khorne Bloodthirster and Bloodcrushers only)" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5499-a3a5-584f-a1a6" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3931-6c37-1047-afc3" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="86e6-4186-2da0-dc2a" name="Battalion: Blood Hunt" hidden="false" targetId="cb7a-2a30-c407-d701" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="6eb0-9caf-fe81-3d11" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="8b04-41c2-4669-ce20" name="Any number of additional KHORNE DAEMON units of Warscroll Battalions" hidden="false" targetId="4026-5e0f-ea39-9ada" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
@@ -13097,60 +13776,6 @@
           <modifiers/>
           <characteristics>
             <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="If any units from the Skullfiend Tribe are within 3&quot; of any enemy HEROES or MONSTERS at the start of your hero phase, they can immediately pile in and each model in that unit can make a single attack against one such unit with one of their melee weapons."/>
-          </characteristics>
-        </profile>
-        <profile id="c64b-1588-0f21-c8c5" name="-" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5"/>
-          </characteristics>
-        </profile>
-        <profile id="b382-136e-5897-9b27" name="Lord of Khorne on Juggernaut" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1. This unit must be included."/>
-          </characteristics>
-        </profile>
-        <profile id="bf34-407f-3969-18d2" name="Skulltake battalion" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1. This battalion must be included."/>
-          </characteristics>
-        </profile>
-        <profile id="4e14-0ec0-34e0-bcbe" name="Gorechosen battalion" book="" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="0-1 (This battalion is optional)."/>
-          </characteristics>
-        </profile>
-        <profile id="954b-1829-b710-5466" name="Bloodbound Warband, Bloodforged, Brass Stampede, Dark Feast, Gore Pilgrims, Skulltake, Red Headsmen" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="3-7 warscroll battalions in any combination. (These are optional)"/>
-          </characteristics>
-        </profile>
-        <profile id="697f-1f31-ba45-3092" name="KHORNE BLOODBOUND units or warscroll battalions" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="Any number (These are optional)"/>
           </characteristics>
         </profile>
         <profile id="bc75-0823-b0d5-fab1" name="-" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
@@ -13169,13 +13794,41 @@
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="4b62-5ef4-4293-14a9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="47a3-8732-9dd8-94d6" type="lessThan"/>
+                    <condition field="selections" scope="4b62-5ef4-4293-14a9" value="7.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1bbb-9632-ae37-ca88" type="lessThan"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
         </infoLink>
         <infoLink id="500a-7c25-95c3-bf8a" name="The Blood God&apos;s Scorn" hidden="false" targetId="6967-3d69-b8ab-31c6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="4b62-5ef4-4293-14a9" value="7.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1bbb-9632-ae37-ca88" type="lessThan"/>
+                    <condition field="selections" scope="4b62-5ef4-4293-14a9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="47a3-8732-9dd8-94d6" type="lessThan"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
         </infoLink>
       </infoLinks>
       <modifiers/>
@@ -13200,7 +13853,275 @@
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="47cf-c69f-32b3-7f49" name="Optional Choices:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a94a-b608-c846-e4b0" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="1bbb-9632-ae37-ca88" name="3-7 other warscroll battalions" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="7c1f-a298-c12d-0716" value="3">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1bbb-9632-ae37-ca88" type="greaterThan"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9299-1a29-786c-4a2f" type="max"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7c1f-a298-c12d-0716" type="min"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="2c3b-910c-19c1-a948" name="Battalion: Bloodbound Warband" hidden="false" targetId="a584-3218-b0cd-294f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks>
+                    <categoryLink id="278b-db04-d1f2-7d74" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+                <entryLink id="ec7f-7681-259b-68d8" name="Battalion: Bloodforged" hidden="false" targetId="d28c-99c1-fb9b-7755" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks>
+                    <categoryLink id="bc37-1eac-fec5-80f6" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+                <entryLink id="7a2e-9c22-ab57-77aa" name="Battalion: Brass Stampede" hidden="false" targetId="54ed-273a-ff0d-b1d0" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks>
+                    <categoryLink id="d92a-c595-d9c0-9215" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+                <entryLink id="d184-5911-fe02-0473" name="Battalion: Dark Feast" hidden="false" targetId="ed0a-8b27-5e9c-2d74" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks>
+                    <categoryLink id="6927-5863-22f0-9c39" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+                <entryLink id="8c78-ea9c-c00e-7d6a" name="Battalion: Gore Pilgrims" hidden="false" targetId="b9b7-ea01-585d-aed2" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks>
+                    <categoryLink id="8176-ccc4-b5de-159c" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+                <entryLink id="077b-ec16-3685-0fd9" name="Battalion: Red Headsmen" hidden="false" targetId="c470-a112-03b6-9129" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks>
+                    <categoryLink id="aedd-e773-6a3b-2548" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+                <entryLink id="502c-6b6a-bb7d-d13d" name="Battalion: Skulltake" hidden="false" targetId="3258-9691-5f0d-19e0" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks>
+                    <categoryLink id="c352-d7f3-3987-b875" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+                <entryLink id="182b-3f78-29ec-1aba" name="Battalion: Slaughterborn" hidden="false" targetId="7901-eafc-3534-afe8" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks>
+                    <categoryLink id="0cc8-6133-05df-d131" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="47a3-8732-9dd8-94d6" name="0-1 Gorechosen" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3743-bd6c-95d4-9dac" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2656-926a-ba8e-31b4" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="f981-8758-8010-5179" name="Battalion: The Gorechosen" hidden="false" targetId="f7da-d7af-dfa7-865d" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks>
+                    <categoryLink id="9bbb-70f2-a1f6-a6aa" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="191b-8fe2-9670-25a8" name="Any number of additional KHORNE BLOODBOUND units of warscroll battalions" hidden="false" targetId="7fe7-81b3-4c7e-9fae" type="selectionEntryGroup">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6b9d-6095-e3ba-31d5" name="1 Lord of Khorne on Juggernaut" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7ba1-51fe-0399-446d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c84b-b821-0b13-8efd" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="a7f2-828c-405f-5bdc" name="Lord of Khorne on Juggernaut" hidden="false" targetId="f423-90c7-d450-d22b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="69fb-c919-d8fc-3215" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="c4f4-d49b-b53d-d2e6" name="1 Skulltake battalion (Must have 3 units of Skullreapers)" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="97c1-892c-e06f-7fbf" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="24bb-111c-162e-a7b1" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="cc35-1634-d040-0d79" name="Battalion: Skulltake" hidden="false" targetId="3258-9691-5f0d-19e0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="fdd8-f101-b8f0-9d65" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="120.0"/>
@@ -13278,10 +14199,18 @@
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="9523-95b0-b529-1128" value="3">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2395-00d5-150a-cdc2" type="instanceOf"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9523-95b0-b529-1128" type="min"/>
-            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e179-9597-3e39-d9ae" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9523-95b0-b529-1128" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e179-9597-3e39-d9ae" type="max"/>
           </constraints>
           <categoryLinks/>
           <selectionEntries/>
@@ -13921,6 +14850,7 @@
       <modifiers/>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4ae3-287a-8bd9-ce00" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fac6-09df-b012-3e40" type="max"/>
       </constraints>
       <categoryLinks>
         <categoryLink id="a300-982d-7f01-9bd7" name="New CategoryLink" hidden="false" targetId="7cdd-80ea-cbeb-8e16" primary="false">
@@ -14835,6 +15765,7 @@
       <modifiers/>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="af7c-67c8-29e9-a5ec" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6aa3-4243-a390-d758" type="max"/>
       </constraints>
       <categoryLinks>
         <categoryLink id="501e-f68c-ee09-6f72" name="New CategoryLink" hidden="false" targetId="246f-c9a0-65ab-f616" primary="false">
@@ -15049,6 +15980,7 @@
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7d2d-5857-68d2-e667" type="max"/>
         <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="72cd-b7b7-b6a8-d1ad" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a6fb-2573-cd24-8e11" type="max"/>
       </constraints>
       <categoryLinks>
         <categoryLink id="3104-a9d6-b9c3-2e61" name="New CategoryLink" hidden="false" targetId="28cc-5c0c-ed3e-fa91" primary="false">
@@ -15320,6 +16252,7 @@
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="72ec-1b9b-9861-49c3" type="max"/>
         <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7ccf-a946-837f-b079" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="901b-5163-6b0f-f9e4" type="max"/>
       </constraints>
       <categoryLinks>
         <categoryLink id="e8db-5e9c-340c-8c56" name="New CategoryLink" hidden="false" targetId="7cdd-80ea-cbeb-8e16" primary="false">
@@ -15536,6 +16469,7 @@
       <modifiers/>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4b33-9186-975a-e548" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="883c-6a94-3c18-defb" type="max"/>
       </constraints>
       <categoryLinks>
         <categoryLink id="754d-2b01-1bea-b4c4" name="New CategoryLink" hidden="false" targetId="7cdd-80ea-cbeb-8e16" primary="false">
@@ -15604,7 +16538,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="b220-25df-9a9e-fcc2" name="Brutal Blades" hidden="false" collective="false" type="upgrade">
           <profiles>
@@ -15635,7 +16571,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="0fb6-605f-11e0-bad7" name="Thunderous Hooves" hidden="false" collective="false" type="upgrade">
           <profiles>
@@ -15666,7 +16604,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>
@@ -15797,7 +16737,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="872b-2968-2e7b-934a" name="Freakish Mutations" hidden="false" collective="false" type="upgrade">
           <profiles>
@@ -16488,7 +17430,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>
@@ -16981,8 +17925,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Command Ability Details" characteristicTypeId="1b71-4c83-4e8c-093f" value=" If this model is your general and uses this ability, choose a single unit with the Khorne keyword within 12&quot; of Mazarall. Until your next hero phase, the selected unit may re-roll all wound rolls of 1.
-"/>
+            <characteristic name="Command Ability Details" characteristicTypeId="1b71-4c83-4e8c-093f" value=" If this model is your general and uses this ability, choose a single unit with the Khorne keyword within 12&quot; of Mazarall. Until your next hero phase, the selected unit may re-roll all wound rolls of 1. "/>
           </characteristics>
         </profile>
         <profile id="2374-6430-cfb9-c12a" name="00-02" hidden="false" profileTypeId="9850-0517-4974-24ba" profileTypeName="Mazrall Wounds Suffered">
@@ -17046,6 +17989,7 @@
       <modifiers/>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="77ea-b808-0f17-2232" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="222f-fedf-b3b0-3f2f" type="max"/>
       </constraints>
       <categoryLinks>
         <categoryLink id="4f41-17ab-d212-8385" name="New CategoryLink" hidden="false" targetId="7cdd-80ea-cbeb-8e16" primary="false">
@@ -17198,37 +18142,189 @@
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f482-174f-d4f0-431c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d66-5e9e-c4e0-d7e4" type="max"/>
+          </constraints>
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups/>
-          <entryLinks/>
+          <entryLinks>
+            <entryLink id="9f32-19e3-8142-e561" name="Slaughterpriest" hidden="false" targetId="b805-6a44-d7ec-92e0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="9ae0-7854-fc20-179d" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="76da-de0a-1ae6-2a53" name="1 unit of Blood Warriors" hidden="false" collective="false">
+        <selectionEntryGroup id="3a3f-953d-e004-88c9" name="1 unit of Blood Warriors" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1b5-84c3-bcee-d002" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="039f-3043-96db-9347" type="max"/>
+          </constraints>
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups/>
-          <entryLinks/>
+          <entryLinks>
+            <entryLink id="65d5-0b12-b47a-9a68" name="Blood Warriors" hidden="false" targetId="9361-fa26-31b7-4a10" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="notInstanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="e542-6d4f-3140-6dcb" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="ae60-1b23-653d-999d" name="Blood Warriors" hidden="false" targetId="9361-fa26-31b7-4a10" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="4fa4-f350-5263-734f" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="9ed6-23bb-7b25-610d" name="1 unit of Mighty Skullcrushers" hidden="false" collective="false">
+        <selectionEntryGroup id="ff26-9956-5bc6-a34b" name="1 unit of Mighty Skullcrushers" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b2f-ba4f-e64d-7905" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b71c-60ef-8872-a5be" type="max"/>
+          </constraints>
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups/>
-          <entryLinks/>
+          <entryLinks>
+            <entryLink id="845e-601d-f2b3-66fb" name="Mighty Skullcrushers" hidden="false" targetId="f22b-7afb-d696-5145" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0472-ec32-ce10-0540" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8918-313c-dfeb-b3cc" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="5552-d393-71fb-86b3" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="56d9-ee0b-b344-5176" name="Mighty Skullcrushers" hidden="false" targetId="f22b-7afb-d696-5145" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8918-313c-dfeb-b3cc" type="equalTo"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0472-ec32-ce10-0540" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="70d5-1443-8204-bb87" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="61d9-ceff-02a4-d364" name="Battalion: Khorne Bloodbound Slaughterstorm (Open Play)" book="Battalion Set: Khorne Bloodbound Slaughterstorm" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -17254,66 +18350,2023 @@
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7270-626a-6d91-f9b8" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82e0-ab2c-5cb3-9e0b" type="min"/>
+          </constraints>
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups/>
-          <entryLinks/>
+          <entryLinks>
+            <entryLink id="08ec-4fac-63fb-5ac0" name="Skarr Bloodwrath" hidden="false" targetId="be72-b584-fc3e-decc" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="9e41-03d2-6e11-730b" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="d1d2-4504-b87c-1ed4" name="1 Aspiring Deathbringer with Goreaxe and Skullhammer" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9fba-295e-e800-2dae" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a88-e18e-330e-e0b7" type="max"/>
+          </constraints>
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="54f0-076b-b780-2222" name="1 unit of Blood Warriors" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="7bda-c787-9e58-2f5e" name="1 unit of Bloodreavers" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
+          <entryLinks>
+            <entryLink id="7939-679b-95ea-8896" name="Aspiring Deathbringer" hidden="false" targetId="c098-9c13-471b-7fc8" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="03de-b273-369c-2697" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="1bd6-cc4a-d52c-2a24" name="1 unit of Wrathmongers" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="36de-ced0-e5f6-7a52" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22b1-8846-9674-2ea5" type="max"/>
+          </constraints>
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups/>
-          <entryLinks/>
+          <entryLinks>
+            <entryLink id="0c68-3719-6183-a0d5" name="Wrathmongers" hidden="false" targetId="4fc6-7808-d334-a716" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="925f-8409-88a3-e2a8" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="6905-8ed8-ba98-301a" name="1 unit of Mighty Skullcrushers" hidden="false" collective="false">
+        <selectionEntryGroup id="d7df-5261-8a66-443f" name="1 unit of Mighty Skullcrushers" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f02f-26a8-8571-52ac" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6aec-04f8-74f2-1aa0" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="1e8b-bae6-b514-c425" name="Mighty Skullcrushers" hidden="false" targetId="f22b-7afb-d696-5145" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0472-ec32-ce10-0540" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8918-313c-dfeb-b3cc" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="73c1-a0d0-43c1-3a13" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="d92a-630a-e3bf-a830" name="Mighty Skullcrushers" hidden="false" targetId="f22b-7afb-d696-5145" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8918-313c-dfeb-b3cc" type="equalTo"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0472-ec32-ce10-0540" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="ef49-3783-1196-39e5" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="1d24-3191-1080-3b7d" name="1 unit of Bloodreavers" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b95c-74c7-359d-d5ec" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5b8-f7da-9d4c-dcb3" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="cbf9-9a8a-1b97-0e81" name="Bloodreavers" hidden="false" targetId="78be-9de2-98c0-1b84" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="d4d8-0be8-04bf-c5ab" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="2c0c-1a59-3501-f4b1" name="Bloodreavers" hidden="false" targetId="78be-9de2-98c0-1b84" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="notInstanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="8baf-2b07-72a5-ff8e" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="7d9d-68e2-1ff5-b798" name="1 unit of Blood Warriors" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23dd-a64b-7c4b-1179" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5637-1ece-eabe-a10a" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="ca6d-3a70-5496-0a08" name="Blood Warriors" hidden="false" targetId="9361-fa26-31b7-4a10" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="notInstanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="d2dd-99f7-a375-88b4" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="dc6f-2de8-fdec-6f0c" name="Blood Warriors" hidden="false" targetId="9361-fa26-31b7-4a10" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="2543-006f-4e72-fc4c" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a9bc-7cff-e9fd-4425" name="Battalion: Daemon Cohort of Khorne (Open Play)" book="Warscroll Compendium: Daemons of Chaos (2015)" hidden="false" collective="false" type="unit">
+      <profiles>
+        <profile id="8631-9ae9-0547-21fe" name="Blood for the Blood God" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="You can add 1 to any wound roll made in the combat phase for a model in a Daemon Cohort of Khorne if its unit charged that turn."/>
+          </characteristics>
+        </profile>
+        <profile id="6dc1-bdc3-2d43-c354" name="Skulls for the Skull Throne" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Roll a dice at the end of the combat phase for each unit in this battalion that wiped out an enemy unit during that phase; on a 6, that unit can immediately pile in and attack again."/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="a278-438b-fb3f-ea97" name="1 Bloodthirster of Insensate Rage, Bloodthirster of Unfettered Fury, Wrath of Khorne Bloodthirster or Khorne Daemon Prince" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="175c-6883-727e-4083" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c67a-57dc-3da7-e9f0" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="206a-a0af-1274-dab8" name="Bloodthirster of Insensate Rage" hidden="false" targetId="8886-dbc9-97d5-ddad" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="da58-b236-201e-3454" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="254e-4841-81f1-ef66" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="90ba-8e23-a138-e44f" name="Bloodthirster of Unfettered Fury" hidden="false" targetId="a59e-d6c6-24cb-cf41" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="220a-98ff-cdac-73bb" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="aaf7-72aa-6fcc-0657" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="a6b5-c5e4-3db0-f3cc" name="Wrath of Khorne Bloodthirster" hidden="false" targetId="510a-95e2-773f-81a9" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="2f9a-8d73-0f01-7182" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="ff5a-1114-dd45-c9f9" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="7b23-e5e3-c48b-5e9c" name="Daemon Prince (of Khorne)" hidden="false" targetId="8ce7-8f12-7675-5e3d" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="330e-b74c-f827-cc8e" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="e5ea-691a-fd99-02e0" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="872f-9a80-735f-6831" name="1 Blood Throne of Khorne, Herald of Khorne or Herald of Khorne on Juggernaut" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e388-9bba-84ac-dedb" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2028-15e5-337f-44dc" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="7755-f5a8-a764-8ad8" name="Blood Throne" hidden="false" targetId="d39a-4082-0c4c-b899" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="8af6-0475-2883-a28b" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="dc44-07fa-c1d2-dcd7" name="Bloodmaster, Herald of Khorne" hidden="false" targetId="049f-9f7d-343e-c78c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="6b8d-2571-7361-9834" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="364e-d916-5e24-f616" name="Skullmaster, Herald of Khorne" hidden="false" targetId="3f73-0a16-9b36-ae7a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="2f60-44e2-1dac-ceef" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="8a48-425a-dd2e-f16c" name="3 units of Bloodletters of Khorne" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c63f-dd08-078a-45b9" type="max"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8947-00ef-edfd-3da6" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="b606-a50c-2b68-ca51" name="Bloodletters" hidden="false" targetId="3012-ad18-c49d-24c2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="notInstanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="fc0d-df7e-fd6d-efc4" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="0698-491c-b75c-b5fc" name="Bloodletters" hidden="false" targetId="3012-ad18-c49d-24c2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="f4ac-84d4-c622-ea7b" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="d0fc-6d3a-63c6-3dfc" name="1 unit of Flesh Hounds, Skull Cannons of Khorne or Bloodcrushers of Khorne" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5d17-efce-ef9a-5e24" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="12da-b305-80c8-5f32" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="474d-0cb7-1890-8e45" name="Bloodcrushers" hidden="false" targetId="e52f-0fd9-6fe1-5c89" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0472-ec32-ce10-0540" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9517-e07e-e189-6699" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="5a49-62ff-bc79-75b9" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="e5be-aa2d-3948-c216" name="Bloodcrushers" hidden="false" targetId="e52f-0fd9-6fe1-5c89" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9517-e07e-e189-6699" type="equalTo"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0472-ec32-ce10-0540" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="91eb-f9c1-7fff-dd2a" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="baf7-cddd-d86e-b1c4" name="Skull Cannons" hidden="false" targetId="2163-0d0c-6837-de92" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="b92e-897c-2e6a-60c4" name="New CategoryLink" hidden="false" targetId="1d26-07fc-6a66-d73e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="ea2a-3512-b3da-5f0e" name="Flesh Hounds" hidden="false" targetId="3fd9-43de-d22c-48a0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0472-ec32-ce10-0540" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a41-d215-35d9-3a00" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="a93b-3f3a-fb51-720d" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="6804-8287-0b3c-9bb9" name="Flesh Hounds" hidden="false" targetId="3fd9-43de-d22c-48a0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a41-d215-35d9-3a00" type="equalTo"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0472-ec32-ce10-0540" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="d2eb-de05-821c-fa96" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs/>
+    </selectionEntry>
+    <selectionEntry id="c148-96c9-13fa-ae62" name="Battalion: Bloodmarked Warband" book="Battletome: Everchosen" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries>
+        <selectionEntry id="6463-ca3b-28c0-64b7" name="Bloodmarked Warband" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="fc41-d804-cfd5-fe82" name="Blood Rage" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="If any HERO from a Bloodmarked Warband slays an enemy model in the combat phase, then all other units from that warband within 16&quot; become filled with an unstoppable blood rage. Add 1 to the Attacks of any melee weapons used by those units for the rest of the combat phase."/>
+              </characteristics>
+            </profile>
+            <profile id="1ec9-b952-9fe1-cf8f" name="Brand of the Blood God" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="[...] If the number of models in a unit from a Bloodmarked Warband is a multiple of 8 when it is first set up, you can re-roll wound rolls of 1 for the unit for the duration of the battle."/>
+              </characteristics>
+            </profile>
+            <profile id="c17e-d143-482e-4f8c" name="Raised to Greatness" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="If a HERO from this warband is slain, pick another model in the warband that is not a HERO. That model adds 1 to the Attacks of all its melee weapons, becomes a HERO, and is treated as a separate unit for the rest of the Battle."/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="531d-4889-e20b-a6ca" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6268-e672-915e-36d7" type="max"/>
+          </constraints>
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="100.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2832-0dbc-cdcc-7675" name="1 MORTAL KHORNE HERO" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a34e-d111-389e-2f4e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ef4-c9aa-b78b-1454" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="021a-446d-74e5-bd9a" name="Aspiring Deathbringer" hidden="false" targetId="c098-9c13-471b-7fc8" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="503f-8101-e333-4586" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="d7eb-d1e5-14ab-d1dd" name="Slaughterpriest" hidden="false" targetId="b805-6a44-d7ec-92e0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="d6f2-fe14-0729-eadc" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="a906-60f2-7eaa-1769" name="Exalted Deathbringer" hidden="false" targetId="e888-8eef-c485-8b83" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="fbc5-331e-655b-068c" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="66f3-7444-ca73-cc7b" name="Bloodsecrator" hidden="false" targetId="56be-4ba7-aa8b-81d6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="2014-b62d-c0b8-2925" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="3c18-4af2-fa75-7a3b" name="Skullgrinder" hidden="false" targetId="e167-7729-8c8b-bf26" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="1ad0-6df7-4b19-5242" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="c725-3d09-20a7-56ce" name="Bloodstoker" hidden="false" targetId="7ee0-2ba0-c052-200a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="2871-03ae-6717-ba60" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="3532-f13f-17bd-7084" name="Mighty Lord of Khorne" hidden="false" targetId="50ba-f44c-8f95-a084" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="122d-c2eb-5554-bcef" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="52ad-d783-6443-6ed9" name="Skarr Bloodwrath" hidden="false" targetId="be72-b584-fc3e-decc" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="d390-23f3-f4b6-811a" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="db64-5f4c-1b46-d338" name="Valkia the Bloody" hidden="false" targetId="c8c7-4d19-2acc-1c0c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="f9f9-bbf9-6b54-b0c9" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="4a3e-93cf-fe6e-28d4" name="Lord of Khorne on Juggernaut" hidden="false" targetId="f423-90c7-d450-d22b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="35a6-760a-c41e-26bc" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="2977-238e-579c-7ff8" name="Khorgos Khull" hidden="false" targetId="595a-599f-1b18-246c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="183f-c6c1-4b79-fddf" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="19a9-5991-af24-2aa6" name="Scyla Anfingrimm" hidden="false" targetId="6067-346b-d05a-72dc" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="e283-75a2-2852-426f" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="48b8-688a-1ad1-32f5" name="8 MORTAL KHORNE UNITS" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1af1-ba66-28d0-b929" type="min"/>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97ab-facb-f644-134e" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="3f57-da2c-4268-0d4c" name="Aspiring Deathbringer" hidden="false" targetId="c098-9c13-471b-7fc8" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="aa40-45c1-7672-1da2" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="be62-1f28-c5c5-43ee" name="Slaughterpriest" hidden="false" targetId="b805-6a44-d7ec-92e0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="ef21-e0c4-9934-8a50" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="6922-1792-e870-55c3" name="Exalted Deathbringer" hidden="false" targetId="e888-8eef-c485-8b83" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="e7d1-44b6-4969-b0ce" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="94d6-998b-a6d0-3a12" name="Bloodsecrator" hidden="false" targetId="56be-4ba7-aa8b-81d6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="481a-b6f0-a992-b5e2" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="d7ce-e99c-17d3-498a" name="Skullgrinder" hidden="false" targetId="e167-7729-8c8b-bf26" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="469f-faa3-6791-5219" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="9ad1-688b-f6d0-bc79" name="Bloodstoker" hidden="false" targetId="7ee0-2ba0-c052-200a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="6002-8157-1c6d-fa9c" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="26a7-5c38-0e58-b6f1" name="Mighty Lord of Khorne" hidden="false" targetId="50ba-f44c-8f95-a084" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="64ac-8971-49e1-5d3a" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="91c1-9b35-434a-6baa" name="Skarr Bloodwrath" hidden="false" targetId="be72-b584-fc3e-decc" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="245a-82f6-0949-49ff" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="a272-6df5-c9db-7b8c" name="Valkia the Bloody" hidden="false" targetId="c8c7-4d19-2acc-1c0c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="7eec-121b-ad94-55db" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="321d-abd5-e067-bd1c" name="Lord of Khorne on Juggernaut" hidden="false" targetId="f423-90c7-d450-d22b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="5e25-ae6d-5058-9b5a" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="de5d-f543-462b-0451" name="Khorgos Khull" hidden="false" targetId="595a-599f-1b18-246c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="204a-2c98-803d-ff5f" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="dd10-efd7-8661-5878" name="Blood Warriors" hidden="false" targetId="9361-fa26-31b7-4a10" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="notInstanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="47d3-781b-0d3b-4959" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="98ac-9426-1a3b-433d" name="Blood Warriors" hidden="false" targetId="9361-fa26-31b7-4a10" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="d8ad-616f-3d82-2f7e" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="526d-f08e-56ca-88ee" name="Bloodreavers" hidden="false" targetId="78be-9de2-98c0-1b84" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="a7a5-ac6e-8bf3-30e5" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="682a-3f5e-15c4-a79a" name="Bloodreavers" hidden="false" targetId="78be-9de2-98c0-1b84" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="notInstanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="0507-7a04-6f7e-b8ab" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="03e2-d1fb-0abd-efa1" name="Skullreapers" hidden="false" targetId="be0c-d1b0-5f46-48c4" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="979b-bf6d-90eb-8e5c" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="eb60-1e02-c044-e5ce" name="Wrathmongers" hidden="false" targetId="4fc6-7808-d334-a716" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="f164-bc9a-42bb-095d" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="de70-2c7b-4af1-e421" name="Mighty Skullcrushers" hidden="false" targetId="f22b-7afb-d696-5145" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0472-ec32-ce10-0540" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8918-313c-dfeb-b3cc" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="63eb-4a71-0535-d61b" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="7293-c691-da64-9bc6" name="Mighty Skullcrushers" hidden="false" targetId="f22b-7afb-d696-5145" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8918-313c-dfeb-b3cc" type="equalTo"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0472-ec32-ce10-0540" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="ddf8-6907-5ede-5d1f" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="a328-fe79-72af-3001" name="Scyla Anfingrimm" hidden="false" targetId="6067-346b-d05a-72dc" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="28ef-ad11-57d9-0560" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="282c-9b05-3ead-127b" name="Garrek&apos;s Reavers" hidden="false" targetId="4473-6605-0c56-c66d" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="19a6-0648-2557-287a" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="a5d1-60ef-df14-00cc" name="Magore&apos;s Fiends" hidden="false" targetId="0b65-569d-9d0f-d290" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="5918-77bb-344d-48aa" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="4f89-129a-6ad0-170d" name="Chaos Spawn" hidden="false" targetId="3c49-5d28-4581-6b78" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="38d7-89b8-9731-1044" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs/>
+    </selectionEntry>
+    <selectionEntry id="4029-82e5-afde-0d4f" name="Battalion: Skall&apos;uk&apos;s Slaughterband (Open Play)" book="Start Collecting: Daemons of Khorne" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="949d-d3fe-e8ca-01ff" name="Cometh the Slaughter" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="In each of your hero phases, pick one Slaughterband unit that is within 3” of the enemy. All models in the unit you pick can immediately pile in and attack with Hellblades and Blades of Blood."/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="bf6c-aa7e-99fc-0906" name="1 Blood Throne of Khorne" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7963-1635-fda1-132c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="649d-3cf3-6b07-2737" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="83b5-01f5-63d6-461c" name="Blood Throne" hidden="false" targetId="d39a-4082-0c4c-b899" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="dc25-8059-cb11-1241" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="658a-2d5c-6e65-b247" name="1 unit of Bloodletters" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="174d-9b12-137d-2178" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5efd-a7a2-550f-a34f" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="2205-335a-9b2b-d775" name="Bloodletters" hidden="false" targetId="3012-ad18-c49d-24c2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="2c59-7dc7-8ea2-f7d1" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="db1a-e6c9-16c4-e36b" name="Bloodletters" hidden="false" targetId="3012-ad18-c49d-24c2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="notInstanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="5535-7859-b018-13eb" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="e5ea-bd30-7e32-5b51" name="1 unit of Bloodcrushers" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08c4-106f-2bc5-aef4" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="59d4-8f7b-a0c9-5fbe" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="16ac-294d-e7b4-8fc0" name="Bloodcrushers" hidden="false" targetId="e52f-0fd9-6fe1-5c89" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0472-ec32-ce10-0540" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9517-e07e-e189-6699" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="a687-245a-183c-0c28" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="393e-5d04-14bd-228d" name="Bloodcrushers" hidden="false" targetId="e52f-0fd9-6fe1-5c89" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9517-e07e-e189-6699" type="equalTo"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0472-ec32-ce10-0540" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="5768-f0b4-a502-063a" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs/>
+    </selectionEntry>
+    <selectionEntry id="bcdb-55cb-80d1-c1b4" name="Battalion: Goreblade Warband (Open Play) [Khorne Starter Set Battalion]" book="Battletome: Khorne Bloodbound (2015)" page="p.125" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="11e1-ab43-0c51-8bfd" name="Blood Rivals" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="You can re-roll charge rolls for the Goreblade Warband if any of its units made a successful charge in the same phase."/>
+          </characteristics>
+        </profile>
+        <profile id="7e24-7d0d-60cb-d736" name="Khorne Cares Not From Whence The Blood Flows" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="If any units are wiped out during the combat phase, you can add 1 to the Attacks characteristic of all melee weapons used by the Goreblade Warband for the remainder of that combat phase."/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="f5d5-430f-af60-e733" name="1 Bloodsecrator" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="35be-9ac4-c15b-b6e5" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5f9e-e832-4595-8e88" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="7b8d-7aad-0296-ad98" name="Bloodsecrator" hidden="false" targetId="56be-4ba7-aa8b-81d6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="207d-00b4-592b-3352" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="3f8d-f2c0-2359-a3f7" name="1 unit of Bloodreavers" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e96c-8493-eb38-8efa" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="958b-3d1e-cc74-42c0" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="a074-22a8-f323-3925" name="Bloodreavers" hidden="false" targetId="78be-9de2-98c0-1b84" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="2738-bbed-54af-eb4b" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="0139-6283-b676-381a" name="Bloodreavers" hidden="false" targetId="78be-9de2-98c0-1b84" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="notInstanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="8c62-de90-ff74-c90a" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="fa24-8abc-f928-812f" name="1 unit of Blood Warriors" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4183-5077-3617-3486" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="449c-5bde-a448-ae63" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="d246-1a5a-15c6-86a0" name="Blood Warriors" hidden="false" targetId="9361-fa26-31b7-4a10" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="notInstanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="373f-cb52-9b25-dbb1" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="120b-ede5-2a65-bc3b" name="Blood Warriors" hidden="false" targetId="9361-fa26-31b7-4a10" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="1910-2cf7-995b-b3c8" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="c883-0b1a-34d2-73a4" name="1 Mighty Lord of Khorne" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4d03-a55d-1e5d-3129" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0ce7-0e02-6954-de53" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="856f-51b0-9d6c-7de2" name="Mighty Lord of Khorne" hidden="false" targetId="50ba-f44c-8f95-a084" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="a679-7a5d-a93c-3ae3" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="c334-24bc-a02b-7e1c" name="Khorgos Khull" hidden="false" targetId="595a-599f-1b18-246c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="92ee-f46e-03ae-821f" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="d447-9f75-21e3-ce17" name="1 Bloodstoker" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5111-2733-d928-9e04" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="967c-8808-ee4b-ddfa" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="488c-4080-4ce7-09f4" name="Bloodstoker" hidden="false" targetId="7ee0-2ba0-c052-200a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="4940-744b-6821-e647" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="53e5-9487-3353-e25e" name="1 unit of Khorgorath" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="true" id="0254-7dcc-4445-aae0" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8db3-c648-04d4-a261" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="9e4b-3e35-a23a-f4c5" name="Khorgoraths" hidden="false" targetId="86c6-8197-045c-d1bb" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="8b33-9a88-42af-a31e" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks/>
@@ -18995,6 +22048,1404 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>
+      <entryLinks/>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="4026-5e0f-ea39-9ada" name="Any number of additional KHORNE DAEMON units or Warscroll Battalions" hidden="false" collective="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="c3d2-62f2-a1a0-aed1" name="Warscroll Battalions" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="e542-8b43-bad6-24e6" name="Battalion: Blood Host of Khorne" hidden="false" targetId="a7fd-9b56-eaff-f352" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="7e6c-2adc-cc09-547b" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="57a0-00d2-ba9a-072a" name="Battalion: Blood Hunt" hidden="false" targetId="cb7a-2a30-c407-d701" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="8772-04dd-112e-9fbc" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="620c-579a-10a6-7e6c" name="Battalion: Bloodthunder Stampede" hidden="false" targetId="80d0-e602-f091-6279" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="8e2e-7d29-2cf8-b4a5" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="2a1f-992b-9fa6-726b" name="Battalion: Charnel Host" hidden="false" targetId="a765-6bbb-3d30-5dda" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="31c0-71e2-d4f7-ec90" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="0f8b-610d-b171-f538" name="Battalion: Council of Blood" hidden="false" targetId="4871-f8d1-52f4-c5e0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="bbf6-b71e-6c87-dca8" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="1e68-8fbc-d25f-c075" name="Battalion: Daemon Legion of Khorne" hidden="false" targetId="502c-6a0a-4fc2-5bcc" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="a0a9-80bd-9af6-583c" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="6d73-addb-7f6f-c9ee" name="Battalion: Gorethunder Cohort" hidden="false" targetId="38b0-9eab-8717-1264" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="8576-9e97-48d3-aa40" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="5721-28a6-1c78-289a" name="Battalion: Murderhost" hidden="false" targetId="3e97-a678-8853-12df" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="7ddd-fa97-4bcf-76c8" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="a8c7-e7d5-4df4-cc68" name="Battalion: Skullseeker Host" hidden="false" targetId="a5f8-e838-f2a2-2441" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="d821-53bd-d2ba-5267" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="810a-c30d-9b0f-6820" name="Battalion: Daemon Cohort of Khorne (Open Play)" hidden="false" targetId="a9bc-7cff-e9fd-4425" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="d5d0-a35b-d3ae-1e60" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="8ee7-7ce9-500a-0d1d" name="Battalion: Skall&apos;uk&apos;s Slaughterband (Open Play)" hidden="false" targetId="4029-82e5-afde-0d4f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="ee58-59f7-52f1-d5ce" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="d334-2bac-77df-f35d" name="KHORNE DAEMON" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="f1a5-0487-6f06-0f84" name="BLOODTHIRSTER" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="f081-2d3c-c0b6-7f84" name="Wrath of Khorne Bloodthirster" hidden="false" targetId="510a-95e2-773f-81a9" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks>
+                    <categoryLink id="0ed5-ec6f-e642-506a" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                    <categoryLink id="8b7f-d3f7-d1df-1cd7" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+                <entryLink id="661c-ffc9-fc4c-cdda" name="Bloodthirster of Insensate Rage" hidden="false" targetId="8886-dbc9-97d5-ddad" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks>
+                    <categoryLink id="5a82-7aa6-09c4-d254" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                    <categoryLink id="8134-54bb-6901-1c0a" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+                <entryLink id="b436-74e5-7141-e6e2" name="Bloodthirster of Unfettered Fury" hidden="false" targetId="a59e-d6c6-24cb-cf41" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks>
+                    <categoryLink id="a4d1-b202-dcbc-6999" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                    <categoryLink id="f909-1db6-c9b6-907f" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+                <entryLink id="5691-210c-0fe8-1feb" name="Exalted Greater Daemon of Khorne" hidden="false" targetId="e137-a705-cb6c-a10f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c15b-93f3-f820-7e66" type="max"/>
+                  </constraints>
+                  <categoryLinks>
+                    <categoryLink id="75e7-febf-abb4-ab06" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                    <categoryLink id="7ee1-d71c-cdfc-dc97" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+                <entryLink id="cb85-9c29-16c9-172f" name="Skarbrand" hidden="false" targetId="580c-ab5a-f469-2866" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dbf0-fe61-c6ff-e8c4" type="max"/>
+                  </constraints>
+                  <categoryLinks>
+                    <categoryLink id="1324-bb78-eb2d-ffc3" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                    <categoryLink id="07a2-f2d3-70d7-919f" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="6bb5-98ea-9cac-7ff9" name="BLOODLETTER HERO" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="4a0e-6d2b-d885-e2fa" name="Skullmaster, Herald of Khorne" hidden="false" targetId="3f73-0a16-9b36-ae7a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks>
+                    <categoryLink id="ca51-ba9d-a16b-7399" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+                <entryLink id="afef-f68f-870b-323d" name="Skulltaker" hidden="false" targetId="d0d5-c7ce-b8ef-4805" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8476-7563-4090-5ad6" type="max"/>
+                  </constraints>
+                  <categoryLinks>
+                    <categoryLink id="598e-5334-4d68-1821" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+                <entryLink id="4668-f013-0510-a1ca" name="Bloodmaster, Herald of Khorne" hidden="false" targetId="049f-9f7d-343e-c78c" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks>
+                    <categoryLink id="fcbb-0ce2-5e39-45bc" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+                <entryLink id="d2bf-71f4-b515-e147" name="Blood Throne" hidden="false" targetId="d39a-4082-0c4c-b899" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks>
+                    <categoryLink id="762b-caa0-f96c-2c3b" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="b881-f42a-9897-ec02" name="Bloodcrushers" hidden="false" targetId="e52f-0fd9-6fe1-5c89" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9517-e07e-e189-6699" type="equalTo"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0472-ec32-ce10-0540" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="da90-c216-3cd4-3fe9" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="5986-6a02-562f-83d1" name="Bloodcrushers" hidden="false" targetId="e52f-0fd9-6fe1-5c89" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0472-ec32-ce10-0540" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9517-e07e-e189-6699" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="3dd9-e7b6-14c3-50ba" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="ec37-f6c8-bac2-a418" name="Bloodletters" hidden="false" targetId="3012-ad18-c49d-24c2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="notInstanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="5894-6d2f-e37e-94fc" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="fda6-0e67-cd01-13c4" name="Bloodletters" hidden="false" targetId="3012-ad18-c49d-24c2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="ad33-b3d2-59a1-b8d5" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="6e75-b6a2-989c-a1c8" name="Daemon Prince (of Khorne)" hidden="false" targetId="8ce7-8f12-7675-5e3d" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="a7cb-0218-61b6-900d" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="b297-741f-50cd-150c" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="3ec3-70ee-2ba2-7fdf" name="Flesh Hounds" hidden="false" targetId="3fd9-43de-d22c-48a0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0472-ec32-ce10-0540" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a41-d215-35d9-3a00" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="9f07-cfa4-5807-4c39" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="83df-811b-4972-eacf" name="Flesh Hounds" hidden="false" targetId="3fd9-43de-d22c-48a0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a41-d215-35d9-3a00" type="equalTo"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0472-ec32-ce10-0540" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="a18b-b2b2-9cfb-1eb4" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="d189-53b3-4820-a9aa" name="Furies (of Khorne)" hidden="false" targetId="6549-dda6-35e3-8010" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="0a25-209f-bbb4-40ea" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="e337-f354-ff3a-7d68" name="Karanak" hidden="false" targetId="6578-af62-39ff-f9f2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="adfa-8c9d-8c03-bb7a" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="8bbd-4b40-70c7-472e" name="Mazrall the Butcher, Daemon Prince of Khorne" hidden="false" targetId="de8c-b9b6-51fb-6c9a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="93c5-f052-0892-39f8" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="68d2-409a-38cf-9ca4" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="8a25-d1fb-c442-932d" name="Skull Cannons" hidden="false" targetId="2163-0d0c-6837-de92" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="e730-e146-3a68-005c" name="New CategoryLink" hidden="false" targetId="1d26-07fc-6a66-d73e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="8061-9c2d-75b4-722d" name="Riptooth" hidden="false" targetId="d884-a283-9eba-c27b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="2708-c34f-6e2c-9f0e" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="3a62-04ad-7b29-f4a4" name="Soul Grinder (of Khorne)" hidden="false" targetId="05ed-b451-22d2-d2ab" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="d4b0-7ec3-746f-f3c3" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="7fe7-81b3-4c7e-9fae" name="Any number of additional KHORNE BLOODBOUND units or Warscroll Battalions" hidden="false" collective="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="06d8-cf19-02fc-c033" name="BLOODBOUND" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="99db-6d8c-9e8b-97bc" name="Aspiring Deathbringer" hidden="false" targetId="c098-9c13-471b-7fc8" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="9a6a-2004-167c-09cc" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="297a-9a4b-4a87-3ebd" name="Slaughterpriest" hidden="false" targetId="b805-6a44-d7ec-92e0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="24f3-c2dc-4949-2142" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="f093-72a1-111e-0141" name="Exalted Deathbringer" hidden="false" targetId="e888-8eef-c485-8b83" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="7ff2-58c8-e2d0-5e67" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="1c89-8a00-42f2-0ed6" name="Bloodsecrator" hidden="false" targetId="56be-4ba7-aa8b-81d6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="9098-baa7-b6cc-86f1" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="31d0-f93f-3fee-7398" name="Skullgrinder" hidden="false" targetId="e167-7729-8c8b-bf26" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="6715-9e67-baa5-3f88" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="c88f-601d-a635-e1cc" name="Bloodstoker" hidden="false" targetId="7ee0-2ba0-c052-200a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="9450-49ff-0d8f-c885" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="5904-ca89-728b-0a58" name="Mighty Lord of Khorne" hidden="false" targetId="50ba-f44c-8f95-a084" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="e31c-c15c-9677-46ab" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="641a-2b7a-77aa-daba" name="Skarr Bloodwrath" hidden="false" targetId="be72-b584-fc3e-decc" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="b79d-8ba1-b6ab-bcce" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="9a3b-cd8f-0cbc-68b0" name="Valkia the Bloody" hidden="false" targetId="c8c7-4d19-2acc-1c0c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="a3ea-2643-73ac-a625" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="2e81-5096-d982-7cd8" name="Lord of Khorne on Juggernaut" hidden="false" targetId="f423-90c7-d450-d22b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="d14d-a80c-a4b7-9e49" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="58c3-aaa5-34e5-beeb" name="Khorgos Khull" hidden="false" targetId="595a-599f-1b18-246c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="b5a4-a916-e302-6901" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="2521-2a7a-a0fc-7f6e" name="Blood Warriors" hidden="false" targetId="9361-fa26-31b7-4a10" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="notInstanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="2cbb-4037-35b5-f976" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="1412-a83a-8db7-fbec" name="Blood Warriors" hidden="false" targetId="9361-fa26-31b7-4a10" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="75b8-c97e-b511-cd76" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="ba18-e8cd-b1ca-c41b" name="Bloodreavers" hidden="false" targetId="78be-9de2-98c0-1b84" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="c4d8-34b9-aa65-0eba" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="829b-b76c-f781-9781" name="Bloodreavers" hidden="false" targetId="78be-9de2-98c0-1b84" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="notInstanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="1226-ce19-04ab-717d" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="f587-6022-3193-ac73" name="Skullreapers" hidden="false" targetId="be0c-d1b0-5f46-48c4" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="8def-ce71-53f9-b4d2" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="63ba-054e-8a28-d28a" name="Wrathmongers" hidden="false" targetId="4fc6-7808-d334-a716" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="ac09-83b2-e022-fe6d" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="aa5a-c173-e49b-4be8" name="Mighty Skullcrushers" hidden="false" targetId="f22b-7afb-d696-5145" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0472-ec32-ce10-0540" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8918-313c-dfeb-b3cc" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="073d-8d8f-d92c-08e8" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="d199-a5db-38be-89e9" name="Mighty Skullcrushers" hidden="false" targetId="f22b-7afb-d696-5145" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8918-313c-dfeb-b3cc" type="equalTo"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0472-ec32-ce10-0540" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="766b-7d70-1277-40b2" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="a78d-6dd6-4490-3311" name="Scyla Anfingrimm" hidden="false" targetId="6067-346b-d05a-72dc" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="8d3a-2424-33c3-7929" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="1c17-2da7-cfc3-f95b" name="Khorgoraths" hidden="false" targetId="86c6-8197-045c-d1bb" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="6a59-faf7-cd67-d896" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="0efe-5b61-2278-d140" name="Garrek&apos;s Reavers" hidden="false" targetId="4473-6605-0c56-c66d" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="25b8-6118-476b-f701" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="75c0-4f3d-3f06-0b0f" name="Magore&apos;s Fiends" hidden="false" targetId="0b65-569d-9d0f-d290" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="693a-d97b-355c-f121" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="309d-5e08-a10a-2a99" name="Warscroll Battalions" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="e0c5-222d-cebd-9f02" name="Battalion: Bloodbound Warband" hidden="false" targetId="a584-3218-b0cd-294f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="861f-bf79-a179-f67c" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="9c65-acd0-e4f9-c74c" name="Battalion: Bloodforged" hidden="false" targetId="d28c-99c1-fb9b-7755" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="f13a-4af6-d954-17e7" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="73aa-62f2-097d-ce6a" name="Battalion: Brass Stampede" hidden="false" targetId="54ed-273a-ff0d-b1d0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="7dc7-9d73-67ba-3d19" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="ab0b-b3b1-5864-e4b2" name="Battalion: Dark Feast" hidden="false" targetId="ed0a-8b27-5e9c-2d74" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="3d9c-e817-3554-0ef0" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="09e1-aeeb-11de-7eb8" name="Battalion: Gore Pilgrims" hidden="false" targetId="b9b7-ea01-585d-aed2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="66d8-560e-9b93-00fc" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="ce1c-0e66-adfd-7a89" name="Battalion: Red Headsmen" hidden="false" targetId="c470-a112-03b6-9129" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="c145-ccab-00ef-48e5" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="8f33-d160-988f-a86c" name="Battalion: Slaughterborn" hidden="false" targetId="7901-eafc-3534-afe8" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="9359-4410-c593-dd3b" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="271d-9ba1-7257-385b" name="Battalion: Skulltake" hidden="false" targetId="3258-9691-5f0d-19e0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="62e5-b011-afd1-b485" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="e49e-6045-5b02-d67f" name="Battalion: Khorne Bloodbound Murderband (Open Play)" hidden="false" targetId="7e93-92f2-50b5-2185" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="8dba-fc36-d1ff-1a77" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="be53-dfde-f5c7-724d" name="Battalion: Khorne Bloodbound Slaughterstorm (Open Play)" hidden="false" targetId="61d9-ceff-02a4-d364" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="36e4-5101-b5a9-f688" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="fa2c-28a4-908f-c51f" name="Battalion: The Gorechosen" hidden="false" targetId="f7da-d7af-dfa7-865d" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="4541-b3f4-7228-4c77" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks/>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>


### PR DESCRIPTION
Resolves #419 
Validation for all Khorne battalions in Catalog
Updated battalions to include available open-play battalions
Updated Khorne catalog to include 'edge-case' daemons to allow access to KHORNE Artefacts
Removed 'Hide' for Skaarac
Added Forgeworld Mazrall the Butcher
Added KHORNE everchosen battalion to allow validation inside the KHORNE catalog