### PR TITLE
Resolves #452

### DIFF
--- a/Chaos - Tzeentch.cat
+++ b/Chaos - Tzeentch.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="40a7-b89a-b3cb-cea9" name="Chaos - Tzeentch" book="Chaos Battletome: Disciples of Tzeentch" revision="2" battleScribeVersion="2.01" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="23" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="40a7-b89a-b3cb-cea9" name="Chaos - Tzeentch" book="Chaos Battletome: Disciples of Tzeentch" revision="3" battleScribeVersion="2.01" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="23" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -3044,7 +3044,64 @@
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2a7b-af3a-8ed6-4faf" type="max"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa00-65b1-6e49-e1c7" type="max"/>
       </constraints>
-      <categoryLinks/>
+      <categoryLinks>
+        <categoryLink id="b83c-0f29-9f2d-42f6" name="New CategoryLink" hidden="false" targetId="7cdd-80ea-cbeb-8e16" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="3472-91cd-b82c-611e" name="New CategoryLink" hidden="false" targetId="1418-9a68-9f9e-e9a7" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="039b-4719-a5fb-5c11" name="New CategoryLink" hidden="false" targetId="7d12-f4c5-3832-0f19" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="d171-b49a-7540-e105" name="New CategoryLink" hidden="false" targetId="1959-9f6a-3056-913a" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="4bf8-2c72-a362-ee72" name="New CategoryLink" hidden="false" targetId="4e0e-664d-51ea-0929" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="f3e9-17bc-73f7-54e2" name="New CategoryLink" hidden="false" targetId="4f53-8230-2f02-9639" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="1aa8-fb30-86d5-3972" name="New CategoryLink" hidden="false" targetId="b6a3-dca6-901a-2b93" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="5a6a-36a4-fe83-718a" name="New CategoryLink" hidden="false" targetId="3118-83b7-37d0-aacf" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ce9d-b5aa-3071-c475" name="Staff of Tomorrow" hidden="false" collective="false" type="upgrade">
           <profiles>
@@ -15177,6 +15234,7 @@
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a63-3f2a-ef36-9638" type="max"/>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7110-a750-2559-6fec" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58e3-2cee-811e-6a3b" type="min"/>
       </constraints>
       <categoryLinks/>
       <selectionEntries/>
@@ -15293,7 +15351,10 @@
           <conditionGroups/>
         </modifier>
       </modifiers>
-      <constraints/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c895-1452-03d0-376b" type="max"/>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c9da-3f43-04fc-a9de" type="min"/>
+      </constraints>
       <categoryLinks/>
       <selectionEntries>
         <selectionEntry id="e18a-1424-11a0-976c" name="1. Bolt of Tzeentch" hidden="false" collective="false" type="upgrade">
@@ -15482,7 +15543,10 @@
           </conditionGroups>
         </modifier>
       </modifiers>
-      <constraints/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e5b-8b88-540c-a835" type="max"/>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="178e-c7cf-2259-f0e5" type="min"/>
+      </constraints>
       <categoryLinks/>
       <selectionEntries>
         <selectionEntry id="1b48-c0cf-7f44-3fa1" name="1. Bolt of Tzeentch" hidden="false" collective="false" type="upgrade">
@@ -16022,6 +16086,7 @@
       </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c8d-b932-39e3-d2bd" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e59d-5946-a726-9f9f" type="min"/>
       </constraints>
       <categoryLinks/>
       <selectionEntries/>
@@ -16460,11 +16525,19 @@
               <profiles/>
               <rules/>
               <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d4e6-e076-3c3d-d347" type="min"/>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="81eb-90a3-9b13-5859" type="max"/>
-              </constraints>
+              <modifiers>
+                <modifier type="set" field="7e5b-8b88-540c-a835" value="2">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="178e-c7cf-2259-f0e5" value="2">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
               <categoryLinks/>
             </entryLink>
           </entryLinks>
@@ -16638,11 +16711,19 @@
               <profiles/>
               <rules/>
               <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d883-337d-5727-7d00" type="min"/>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09fc-a4f0-4497-b80e" type="max"/>
-              </constraints>
+              <modifiers>
+                <modifier type="set" field="c895-1452-03d0-376b" value="2">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="c9da-3f43-04fc-a9de" value="2">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
               <categoryLinks/>
             </entryLink>
           </entryLinks>
@@ -16821,11 +16902,19 @@
               <profiles/>
               <rules/>
               <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94d6-dad3-6a59-3e46" type="min"/>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c631-c97a-a0a8-4f2f" type="max"/>
-              </constraints>
+              <modifiers>
+                <modifier type="set" field="7e5b-8b88-540c-a835" value="2">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="178e-c7cf-2259-f0e5" value="2">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
               <categoryLinks/>
             </entryLink>
           </entryLinks>


### PR DESCRIPTION
Kairos unable to take spell lores due to missing categories
Able to take multiple spells
Updated validation for 'Arch Sorcerer' trait to allow multiple spells while Spell Lores only allow a single additional spell.
Added flagging for missing command trait if one isn't selected after selection of general.