### PR TITLE
Updated Chaos Knight Profile

### DIFF
--- a/Chaos - Slaves to Darkness.cat
+++ b/Chaos - Slaves to Darkness.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="798b-2f60-3166-c5bf" name="Chaos - Slaves to Darkness" book="Grand Alliance: Chaos" revision="8" battleScribeVersion="2.01" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="16" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="798b-2f60-3166-c5bf" name="Chaos - Slaves to Darkness" book="Grand Alliance: Chaos" revision="9" battleScribeVersion="2.01" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="16" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -1775,22 +1775,7 @@
       </profiles>
       <rules/>
       <infoLinks/>
-      <modifiers>
-        <modifier type="decrement" field="points" value="160">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="e432-9436-085d-4c93" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ace4-3dba-055a-a5d1" type="greaterThan"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-        <modifier type="increment" field="points" value="160">
-          <repeats>
-            <repeat field="selections" scope="e432-9436-085d-4c93" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ace4-3dba-055a-a5d1" repeats="1" roundUp="false"/>
-          </repeats>
-          <conditions/>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
+      <modifiers/>
       <constraints/>
       <categoryLinks>
         <categoryLink id="c18d-f77f-8355-e70c" name="New CategoryLink" hidden="false" targetId="7cdd-80ea-cbeb-8e16" primary="false">
@@ -1823,7 +1808,7 @@
         </categoryLink>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="ace4-3dba-055a-a5d1" name="5 Chaos Knights" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="ace4-3dba-055a-a5d1" name="5 Chaos Knights" hidden="false" collective="false" type="model">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1837,7 +1822,7 @@
           <selectionEntryGroups/>
           <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" costTypeId="points" value="160.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a94a-894a-9a26-62dc" name="Chaos Runeshields" hidden="false" collective="false" type="upgrade">
@@ -1907,6 +1892,51 @@
           <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a36f-b516-3954-2ca9" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b447-c4c6-fcbc-03a8" name="New SelectionEntry" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs/>
+        </selectionEntry>
+        <selectionEntry id="8ed0-ca72-6cc9-6bef" name="War Steed&apos;s Roughshod Hooves" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="5279-4a35-7581-461f" name="War Steed&apos;s Roughshod Hooves" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
+                <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="2"/>
+                <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="4+"/>
+                <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="4+"/>
+                <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-"/>
+                <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ceba-ab21-8bdf-a510" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ca1-8594-8fdb-df46" type="max"/>
           </constraints>
           <categoryLinks/>
           <selectionEntries/>
@@ -2013,9 +2043,7 @@
           <categoryLinks/>
         </entryLink>
       </entryLinks>
-      <costs>
-        <cost name="pts" costTypeId="points" value="160.0"/>
-      </costs>
+      <costs/>
     </selectionEntry>
     <selectionEntry id="ae9b-b9fe-18ba-2f9a" name="Chaos Lord on Daemonic Mount" hidden="false" collective="false" type="unit">
       <profiles>
@@ -3316,7 +3344,7 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="08c1-05a1-4828-6983" name="Chaos Marauders" hidden="false" collective="false" type="unit">
+    <selectionEntry id="08c1-05a1-4828-6983" name="*Chaos Marauders" hidden="false" collective="false" type="unit">
       <profiles>
         <profile id="8d86-7f7b-2965-429d" name="Chaos Marauders" hidden="false" profileTypeId="1960-ca8e-67ce-2014" profileTypeName="Unit">
           <profiles/>
@@ -3351,29 +3379,7 @@
       </profiles>
       <rules/>
       <infoLinks/>
-      <modifiers>
-        <modifier type="decrement" field="points" value="60">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="08c1-05a1-4828-6983" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2e0a-c703-22d1-0f26" type="greaterThan"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-        <modifier type="increment" field="points" value="60">
-          <repeats>
-            <repeat field="selections" scope="08c1-05a1-4828-6983" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2e0a-c703-22d1-0f26" repeats="1" roundUp="false"/>
-          </repeats>
-          <conditions/>
-          <conditionGroups/>
-        </modifier>
-        <modifier type="decrement" field="points" value="40">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="08c1-05a1-4828-6983" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2e0a-c703-22d1-0f26" type="equalTo"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
+      <modifiers/>
       <constraints/>
       <categoryLinks>
         <categoryLink id="57f0-06e3-3729-eb69" name="New CategoryLink" hidden="false" targetId="7cdd-80ea-cbeb-8e16" primary="false">
@@ -3406,21 +3412,29 @@
         </categoryLink>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="2e0a-c703-22d1-0f26" name="10 Chaos Marauders" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="2e0a-c703-22d1-0f26" name="20 Chaos Marauders" hidden="false" collective="false" type="upgrade">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="decrement" field="points" value="20">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="08c1-05a1-4828-6983" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2e0a-c703-22d1-0f26" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="707d-4dd2-5d13-0390" type="min"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f0f9-1aa2-6f64-528b" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f0f9-1aa2-6f64-528b" type="max"/>
           </constraints>
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" costTypeId="points" value="120.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="7aac-17fd-7461-f7eb" name="Icon Bearer" hidden="false" collective="false" type="upgrade">
@@ -3610,9 +3624,7 @@
           <categoryLinks/>
         </entryLink>
       </entryLinks>
-      <costs>
-        <cost name="pts" costTypeId="points" value="60.0"/>
-      </costs>
+      <costs/>
     </selectionEntry>
     <selectionEntry id="1080-2582-0880-dd78" name="Chaos Sorcerer Lord" hidden="false" collective="false" type="unit">
       <profiles>
@@ -4675,7 +4687,7 @@
         <cost name="pts" costTypeId="points" value="90.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="89b1-9d63-4211-96da" name="Chaos Warshrine" hidden="false" collective="false" type="unit">
+    <selectionEntry id="89b1-9d63-4211-96da" name="*Chaos Warshrine" hidden="false" collective="false" type="unit">
       <profiles>
         <profile id="5b6d-45a1-dd89-36b4" name="Chaos Warshrine" hidden="false" profileTypeId="1960-ca8e-67ce-2014" profileTypeName="Unit">
           <profiles/>
@@ -5001,7 +5013,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="180.0"/>
+        <cost name="pts" costTypeId="points" value="160.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b2a4-c572-6ab2-6b4e" name="Daemon Prince" hidden="false" collective="false" type="unit">
@@ -6671,7 +6683,7 @@
         <cost name="pts" costTypeId="points" value="140.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1ccb-5743-64df-f027" name="Lord of Chaos" hidden="false" collective="false" type="unit">
+    <selectionEntry id="1ccb-5743-64df-f027" name="*Lord of Chaos" hidden="false" collective="false" type="unit">
       <profiles>
         <profile id="2764-a9bc-bd78-19e2" name="Lord of Chaos" hidden="false" profileTypeId="1960-ca8e-67ce-2014" profileTypeName="Unit">
           <profiles/>
@@ -6926,7 +6938,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="100.0"/>
+        <cost name="pts" costTypeId="points" value="140.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ca1d-13ba-4662-6e9f" name="Battalion: Ruinbringer Warband" hidden="false" collective="false" type="upgrade">


### PR DESCRIPTION
Updated Points for:
Chaos Lord
Chaos Warshrine
Modified minimum for Marauders to increments of 20 and matching points