### PR TITLE
Update weapon Choices for Skaven Warlord

### DIFF
--- a/Chaos - Skaven.cat
+++ b/Chaos - Skaven.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="bcc4-c671-9435-d259" name="Chaos - Skaven" book="Chaos Battletome - Grand Alliance: Chaos / Battletome: Skaven Pestilens" revision="15" battleScribeVersion="2.01" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://gitter.im/BSData/warhammer-age-of-sigmar" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="23" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="bcc4-c671-9435-d259" name="Chaos - Skaven" book="Chaos Battletome - Grand Alliance: Chaos / Battletome: Skaven Pestilens" revision="16" battleScribeVersion="2.01" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://gitter.im/BSData/warhammer-age-of-sigmar" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="23" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -10375,7 +10375,7 @@
                 <cost name="pts" costTypeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="cc6d-0979-93da-f717" name="War Halberd" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="cc6d-0979-93da-f717" name="War Halberd and Barbed Blade" hidden="false" collective="false" type="upgrade">
               <profiles>
                 <profile id="d7be-69cf-dcde-93ad" name="War Halberd" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
                   <profiles/>
@@ -10389,6 +10389,21 @@
                     <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="3+"/>
                     <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
                     <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-1"/>
+                    <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
+                  </characteristics>
+                </profile>
+                <profile id="c01d-ac02-8b9c-3c2d" name="Barbed Blade" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                    <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
+                    <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="5"/>
+                    <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="3+"/>
+                    <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="4+"/>
+                    <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-"/>
                     <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
                   </characteristics>
                 </profile>


### PR DESCRIPTION
Per the warscroll Skaven Warlord weapon choices should be:
Halberd and Blade, Two Blades, Warpstone Blade
Resolves #772 