### PR TITLE
Updated Destruction Catalogs

### DIFF
--- a/Destruction - Beastclaw Raiders.cat
+++ b/Destruction - Beastclaw Raiders.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="50c5-e039-3d93-b26b" name="Destruction - Beastclaw Raiders" book="Destruction - Beastclaw Radiers" revision="11" battleScribeVersion="2.01" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="6" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="50c5-e039-3d93-b26b" name="Destruction - Beastclaw Raiders" book="Destruction - Beastclaw Radiers" revision="12" battleScribeVersion="2.01" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="6" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -909,60 +909,15 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="75c2-ca4e-5213-b756" name="Battalion: Alfrostun" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="75c2-ca4e-5213-b756" name="Super Battalion: Alfrostun" hidden="false" collective="false" type="upgrade">
       <profiles>
-        <profile id="cf06-e946-66c5-7490" name="Skal" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1"/>
-          </characteristics>
-        </profile>
-        <profile id="b14f-51c3-277d-df8b" name="Torrbad" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1"/>
-          </characteristics>
-        </profile>
-        <profile id="e03f-79de-6623-f804" name="Eurlbad" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1"/>
-          </characteristics>
-        </profile>
-        <profile id="d702-7411-cab2-16cb" name="Jorlbad" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1"/>
-          </characteristics>
-        </profile>
-        <profile id="28db-646c-c297-cd25" name="Frostlord on Stonehorn or Frostlord on Thundertusk" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1"/>
-          </characteristics>
-        </profile>
         <profile id="1b99-ba21-3a02-e5f6" name="Alfrostun Avalanche" book="Beastclaw Raiders" page="97" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="When an entire Alfrostun stampedes towards its foes, it is akin to an unstoppable avalanche that sweeps away all before it. On a turn in which they charged into combat, you can re-roll all failed wound rolls made for BEASTCLAW RAIDER models in the combat phase."/>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="On a turn in which they charged into combat, you can re-roll all failed wound rolls made for BEASTCLAW RAIDER models from this battalion in the combat phase."/>
           </characteristics>
         </profile>
       </profiles>
@@ -972,7 +927,143 @@
       <constraints/>
       <categoryLinks/>
       <selectionEntries/>
-      <selectionEntryGroups/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="3bbd-0bb4-a452-bf2b" name="1. Frostlord" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="467f-996d-e0f3-e69f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e61-90d2-caf1-32db" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="f5f1-9eea-64fc-0713" name="Frostlord on Stonehorn" hidden="false" targetId="550d-7e51-8ddd-11f7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="f588-ee21-ce2e-d871" name="Frostlord on Thundertusk" hidden="false" targetId="fa5f-aba0-a5f9-fd23" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="644b-e1ea-afc3-9b46" name="2. Jorlbad" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09cf-d517-0cf6-7c28" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a405-bdf0-e53e-86fe" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="ab5b-651a-19b0-504f" name="Battalion: Jorlbad" hidden="false" targetId="8cea-bdc1-c017-2f5f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e626-c779-26b0-0318" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a5f-444b-7664-a3ea" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="3a22-38c3-0ce0-6f7c" name="3. Eurlbad" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3f1-9cd3-118a-ec94" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d65-fbc1-a529-50ab" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="0ca3-18cf-a369-325f" name="Battalion: Eurlbad" hidden="false" targetId="dbeb-bd23-4e21-b1ab" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="967a-01c4-68e0-2e1b" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d22-514b-8d1a-771d" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="8707-e083-74dc-4d63" name="4. Torrbad" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87ae-2c02-e7a4-9355" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc21-c355-f645-0984" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="1075-d071-2042-400d" name="Battalion: Torrbad" hidden="false" targetId="b04c-dd95-eadb-fc13" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b985-183d-f91f-a3a0" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="49a1-94e1-75d1-6ed2" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="ef1b-61c5-7356-a8e6" name="5. Skal" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="24af-e8d8-9fec-fcc1" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96ce-e275-1fe7-4887" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="9d26-9e87-eddb-0d18" name="Battalion: Skal" hidden="false" targetId="69f3-9903-964f-c102" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="518a-8df4-0721-fa12" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3ac-af8c-a53b-3cd7" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="100.0"/>
@@ -986,7 +1077,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="The Stonehorns of the Svard are resilient in the extreme, perhaps the toughest of their breed, and are renowned as such across the Mortal Realms. Add 1 to Braggoth’s Wounds characteristic."/>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Add 1 to Braggoth’s Wounds characteristic."/>
           </characteristics>
         </profile>
         <profile id="0c64-b01c-77c0-69e0" name="Fierce Rivals" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
@@ -995,7 +1086,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Though they have formed an uneasy alliance, the Ironjawz and Beastclaw Raiders are both attempting to prove they are the best. You can add 1 to hit rolls made for any BEASTCLAW RAIDERS unit from this battalion whilst it is within 6&quot; of an IRONJAWZ unit from this battalion, and vice versa."/>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="You can add 1 to hit rolls made for any BEASTCLAW RAIDERS unit from this battalion whilst it is within 6&quot; of an IRONJAWZ unit from this battalion, and vice versa."/>
           </characteristics>
         </profile>
         <profile id="4f2d-072e-8c12-ae5d" name="Overrunning Stampede" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
@@ -1004,34 +1095,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="The combined mass of bestial muscle and savage rage of the Beast Hammer will smash aside anything in its path. Once per battle, at the end of any of your combat phases, this battalion can make an Overrunning Stampede. When it does so, each unit in this battalion that charged successfully this turn can immediately pile in and attack again, in an order of your choice."/>
-          </characteristics>
-        </profile>
-        <profile id="b378-2921-fcdd-7e0e" name="Gore-gruntas (Ironjawz)" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="2"/>
-          </characteristics>
-        </profile>
-        <profile id="bcfc-d367-5f8f-2258" name="Frostlord on Stonehorn (Braggoth Vardruk)" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1"/>
-          </characteristics>
-        </profile>
-        <profile id="a8da-b72c-73ef-467a" name="Mournfang Pack" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="2"/>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Once per battle, at the end of any of your combat phases, this battalion can make an Overrunning Stampede. When it does so, each unit in this battalion that charged successfully this turn can immediately pile in and attack again, in an order of your choice."/>
           </characteristics>
         </profile>
       </profiles>
@@ -1041,7 +1105,86 @@
       <constraints/>
       <categoryLinks/>
       <selectionEntries/>
-      <selectionEntryGroups/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="e0f2-512f-967c-d606" name="1. Braggoth Vardruk" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fcad-33da-74b9-9f7b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7a0-43ec-4d79-ef16" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="09fa-a1e4-b2bd-6bb2" name="Frostlord on Stonehorn" hidden="false" targetId="550d-7e51-8ddd-11f7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ffa-a692-1de0-2b00" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db46-af67-7652-83a4" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="e0ba-c6f8-16aa-8fd1" name="2. Mournfang Packs" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="542b-511c-f785-b979" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84f4-8f46-b28e-6d5c" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="24f8-8341-de45-1764" name="Mournfang Pack" hidden="false" targetId="c5e4-e780-c534-d17c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eaf1-1536-35c7-3808" type="min"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3bb-26ee-23ae-d58e" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="e1e0-dd49-2b00-48ba" name="3. Gore-gruntas" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="63ee-2b5b-67b8-6957" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5956-bfa7-5f3e-1790" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="19fb-13ae-41f0-7837" name="Orruk Gore-gruntas" hidden="false" targetId="2bca-dc9c-7582-0784" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d50-4cf2-efab-4562" type="min"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8092-a989-2fb3-6e42" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="230.0"/>
@@ -1055,7 +1198,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Those that face the destructive attentions of the Eurlbad are assured of a brutal death. If you roll a wound roll of 6 or more for an Eurlbad model in the combat phase, that attack inflicts one mortal wound on the target in addition to the normal damage."/>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="If you roll a wound roll of 6 or more for an Eurlbad model in the combat phase, that attack inflicts one mortal wound on the target in addition to the normal damage."/>
           </characteristics>
         </profile>
         <profile id="770d-3d3a-b868-5b27" name="Eating Hand" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
@@ -1064,34 +1207,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="As one of the Frostlord’s favoured leaders, the Huskard of the Eurlbad is always on the lookout for an opportunity to prove his worth and crush the foes of the Alfrostun. Add 1 to the Damage characteristic of all melee weapons used by the Eurlbad’s Huskard."/>
-          </characteristics>
-        </profile>
-        <profile id="1c02-cf9b-efcc-eccb" name="Stonehorn Beastriders" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1-3"/>
-          </characteristics>
-        </profile>
-        <profile id="6374-1090-5e07-754d" name="Huskard on Stonehorn" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1"/>
-          </characteristics>
-        </profile>
-        <profile id="7a24-3a2e-35a9-d65f" name="Mournfang Packs" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="2-4"/>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Add 1 to the Damage characteristic of all melee weapons used by the Eurlbad’s Huskard."/>
           </characteristics>
         </profile>
       </profiles>
@@ -1101,7 +1217,84 @@
       <constraints/>
       <categoryLinks/>
       <selectionEntries/>
-      <selectionEntryGroups/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="f210-f121-a9d3-5012" name="1. Huskard on Stonehorn" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd61-e7fc-2466-3e83" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f64-59af-a8b0-6625" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="b21a-3f0a-b473-76d2" name="Huskard on Stonehorn" hidden="false" targetId="fafb-eaad-f659-ba2d" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a18-52a5-787c-ab55" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9754-76a6-9431-1ccc" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="ba1f-c974-103f-69c3" name="2. Stonehorn Beastriders (1 to 3)" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6928-3abd-4986-11f0" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="413b-d095-1ed6-4a48" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="f13e-618c-814c-e7c3" name="Stonehorn Beastriders" hidden="false" targetId="559c-0689-72d3-c291" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f595-d8e8-a6c9-bb98" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="ddcc-c216-73a3-20c9" name="3. Mournfang Packs (2 to 4)" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1c6-a167-39fc-7417" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c84d-79d6-8743-b772" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="a4c4-ecf3-33c8-148b" name="Mournfang Pack" hidden="false" targetId="c5e4-e780-c534-d17c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1673-e524-beba-89d2" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="170.0"/>
@@ -1109,40 +1302,13 @@
     </selectionEntry>
     <selectionEntry id="8cea-bdc1-c017-2f5f" name="Battalion: Jorlbad" hidden="false" collective="false" type="upgrade">
       <profiles>
-        <profile id="fb2f-894f-9da2-6847" name="Huskard on Stonehorn" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1"/>
-          </characteristics>
-        </profile>
-        <profile id="184e-e1ed-bbad-48e0" name="Stonehorn Beastriders" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1-3"/>
-          </characteristics>
-        </profile>
-        <profile id="8858-5df4-6f92-ad1d" name="Mournfang Packs" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="2-4"/>
-          </characteristics>
-        </profile>
         <profile id="d02b-3fc0-eeba-b5f9" name="Tip of the Hunting Spear" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Charging at the forefront of any Alfrostun’s attack, the Jorlbad are the first to hit the enemy lines. Jorlbad units can run and charge in the same turn."/>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Jorlbad units can run and charge in the same turn."/>
           </characteristics>
         </profile>
         <profile id="4d9a-7ce5-903b-b53f" name="Fighting Hand" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
@@ -1151,7 +1317,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Second only to the Frostlord within the Alfrostun’s ranks, the Huskard Jorl holds great authority over his kin and can inspire them in battle. You can re-roll failed battleshock tests for friendly BEASTCLAW RAIDERS units that are within 12&quot; of the Jorlbad’s Huskard."/>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="You can re-roll failed battleshock tests for friendly BEASTCLAW RAIDERS units that are within 12&quot; of the Jorlbad’s Huskard."/>
           </characteristics>
         </profile>
       </profiles>
@@ -1161,13 +1327,90 @@
       <constraints/>
       <categoryLinks/>
       <selectionEntries/>
-      <selectionEntryGroups/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="fbc3-ce81-c6b4-cc91" name="1. Huskard on Stonehorn" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc7d-29f5-53a7-b3e5" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91c5-6809-3524-bdaf" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="4bf2-a3a0-dd73-aea2" name="Huskard on Stonehorn" hidden="false" targetId="fafb-eaad-f659-ba2d" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="54ba-dd81-3cfc-cc3e" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0bb1-8b00-bc99-768c" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="7fab-ac7f-2dc2-bdc7" name="3. Mournfang Packs (2 to 4)" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="277e-dd78-abc2-4893" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d58-54d9-b5ce-be3d" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="8d68-b200-8de9-f6a0" name="Mournfang Pack" hidden="false" targetId="c5e4-e780-c534-d17c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3cfc-e873-2c67-237b" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6994-83a5-9f2b-aee9" name="2. Stonehorn Beastriders (1 to 3)" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21d8-41e7-c95b-99a6" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4261-eaa3-5019-deed" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="4361-4593-6309-18b5" name="Stonehorn Beastriders" hidden="false" targetId="559c-0689-72d3-c291" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5827-ff93-69af-c7f9" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="160.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="45d2-b7ad-d33c-f773" name="Battalion: Olwyr Alfrostun" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="45d2-b7ad-d33c-f773" name="Super Battalion: Olwyr Alfrostun" hidden="false" collective="false" type="upgrade">
       <profiles>
         <profile id="0276-4867-5889-89d9" name="Vicious Beasts" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>
@@ -1175,7 +1418,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Olwyr Mournfangs are amongst the most savage of their kind. You can add 1 to all hit rolls made for an Olwyr Mournfang’s Tusks."/>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="You can add 1 to all hit rolls made for an Olwyr Mournfang’s Tusks."/>
           </characteristics>
         </profile>
         <profile id="e1ce-ed20-264a-778e" name="Swiftstride" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
@@ -1184,7 +1427,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="The Olwyr are adept and skilled riders, and their Icebrow Hunters are renowned for their long stride. You can re-roll run rolls for all Olwyr units."/>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="You can re-roll run rolls for all Olwyr units."/>
           </characteristics>
         </profile>
         <profile id="ed41-a097-5013-4e6f" name="Cunning and Wise" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
@@ -1193,52 +1436,24 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="An Olwyr general can have two command traits instead of one. If you choose to randomly generate your general’s command trait, re-roll any duplicate results."/>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="If you choose to randomly generate your general’s command trait, re-roll any duplicate results."/>
           </characteristics>
         </profile>
-        <profile id="48e8-9d45-0961-2617" name="Skal" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
+        <profile id="4179-a183-ad81-37e8" name="Alfrostun Avalanche" book="Beastclaw Raiders" page="97" hidden="true" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4dab-9768-a42c-232a" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
           <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="0-1"/>
-          </characteristics>
-        </profile>
-        <profile id="8f0a-fbc2-97a7-5465" name="Torrbad" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="0-1"/>
-          </characteristics>
-        </profile>
-        <profile id="7d4c-646d-67ed-3c10" name="Eurlbad" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1 (must include 3-6 Mournfang Packs instead of 2-4)"/>
-          </characteristics>
-        </profile>
-        <profile id="a4e8-4695-7c0a-c814" name="Jorlbad" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="0-1"/>
-          </characteristics>
-        </profile>
-        <profile id="e180-214a-1130-76c4" name="Frostlord on Thundertusk" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1"/>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="On a turn in which they charged into combat, you can re-roll all failed wound rolls made for BEASTCLAW RAIDER models from this battalion in the combat phase."/>
           </characteristics>
         </profile>
       </profiles>
@@ -1248,7 +1463,240 @@
       <constraints/>
       <categoryLinks/>
       <selectionEntries/>
-      <selectionEntryGroups/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="3de3-49bf-8c96-0ae5" name="1. Frostlord on Thundertusk" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4094-5db9-801e-2100" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="63ef-4532-62db-0dc7" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="7284-5eab-d100-a57a" name="Frostlord on Thundertusk" hidden="false" targetId="fa5f-aba0-a5f9-fd23" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3dad-3da3-b031-d811" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f6c-bf2d-8bd9-f156" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="b49c-7ee1-93f9-f7e3" name="2. Eurlbad" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe5f-9aac-e7bc-3a8b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="022e-2468-a378-da59" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="aca4-e59e-d2c3-9c16" name="Battalion: Eurlbad" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="278a-d053-2cff-2e05" name="Crush, Mangle, Tenderise" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="If you roll a wound roll of 6 or more for an Eurlbad model in the combat phase, that attack inflicts one mortal wound on the target in addition to the normal damage."/>
+                  </characteristics>
+                </profile>
+                <profile id="38c4-fb4b-8645-d3c4" name="Eating Hand" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Add 1 to the Damage characteristic of all melee weapons used by the Eurlbad’s Huskard."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bede-b89e-b72d-e873" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4407-7597-6cfa-8286" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="9eaa-21be-b9f0-a89b" name="1. Huskard on Stonehorn" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa8f-4b28-55ee-47d9" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9fc-882b-7fae-1509" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="b6bf-855a-5c39-4139" name="Huskard on Stonehorn" hidden="false" targetId="fafb-eaad-f659-ba2d" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="829f-7942-b668-7982" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3582-7344-42c2-1b70" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="e2c7-6957-08e6-43fa" name="2. Stonehorn Beastriders (1 to 3)" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbba-404f-3cbc-1a98" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="62b7-3f85-3f45-d0fe" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="e925-7966-5243-a9c7" name="Stonehorn Beastriders" hidden="false" targetId="559c-0689-72d3-c291" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1564-a31c-c713-8a7f" type="min"/>
+                      </constraints>
+                      <categoryLinks/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="ebe2-598e-becb-0202" name="3. Mournfang Packs (3 to 6)" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="613b-d540-4690-cb5c" type="max"/>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="992b-75d2-2806-f22e" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="7adf-8dab-0678-3c3b" name="Mournfang Pack" hidden="false" targetId="c5e4-e780-c534-d17c" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3fb-8802-dce3-182c" type="min"/>
+                      </constraints>
+                      <categoryLinks/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="170.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="0126-d40f-880b-5e8f" name="3. Additional Battalions" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="38c4-cf79-33ce-7c30" name="2. Torrbad" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d6c2-bab9-3964-0ab9" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="d634-7007-11ab-82db" name="Battalion: Torrbad" hidden="false" targetId="b04c-dd95-eadb-fc13" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="9a95-3750-4e9a-0a2a" name="3. Skal" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0570-3f02-4c14-e839" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="4226-0d5f-1d8b-ef55" name="Battalion: Skal" hidden="false" targetId="69f3-9903-964f-c102" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="55e6-d41f-ee30-74e8" name="1. Jorlbad" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ba8-4284-0ac8-1412" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="7d54-5495-38ee-3b45" name="Battalion: Jorlbad" hidden="false" targetId="8cea-bdc1-c017-2f5f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="190.0"/>
@@ -1262,25 +1710,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="When Icebrow Hunters are on the hunt, they will often take their best packs of Frost Sabres along to aid them as they prepare a deadly ambush. During set-up, you can place units of Frost Sabres from the Skal to one side. In any of your hero phases, when an Icebrow Hunter from this battalion sets up from ambush (see the Icebrow Hunter’s Masters of Ambush ability, pg 114), you can also set up any units of Frost Sabres that you set to one side earlier – these units are set up anywhere on the battlefield that is within 18&quot; of an ambushing Icebrow Hunter, but not within 9&quot; of any enemy models. This is their move for the following movement phase."/>
-          </characteristics>
-        </profile>
-        <profile id="5c31-9023-148b-eaec" name="Frost Sabres" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="2 - 10 units"/>
-          </characteristics>
-        </profile>
-        <profile id="641e-ba90-8c59-7eb2" name="Icebrow Hunters" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1-6"/>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="During set-up, you can place units of Frost Sabres from the Skal to one side. In any of your hero phases, when an Icebrow Hunter from this battalion sets up from ambush, you can also set up any units of Frost Sabres that you set to one side earlier – these units are set up anywhere on the battlefield that is within 18&quot; of an ambushing Icebrow Hunter, but not within 9&quot; of any enemy models. This is their move for the following movement phase."/>
           </characteristics>
         </profile>
       </profiles>
@@ -1290,13 +1720,64 @@
       <constraints/>
       <categoryLinks/>
       <selectionEntries/>
-      <selectionEntryGroups/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="0ae2-5f03-70d1-f346" name="1. Icebrow Hunters (1 to 6)" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f1e-ad5a-1b1e-2cfd" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6ee-6acd-05d6-6120" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="adb8-7641-12a4-8e12" name="Icebrow Hunter" hidden="false" targetId="fc5c-2a36-ec09-f1c3" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e25-a362-2ecf-5b98" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="3143-ec81-2a1a-16f3" name="2. Frost Sabres (2 to 10)" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2152-90ab-bda6-51b0" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d83b-9eb1-bcb6-41f3" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="9662-555f-8bb2-b69e" name="Frost Sabres" hidden="false" targetId="68f4-e571-980e-30f3" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c179-f518-565c-5cb3" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="150.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6e12-78d2-7832-7cdc" name="Battalion: Svard Alfrostun" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="6e12-78d2-7832-7cdc" name="Super Battalion: Svard Alfrostun" hidden="false" collective="false" type="upgrade">
       <profiles>
         <profile id="a9d0-eccd-3bb1-2dbc" name="A Hardy Breed" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>
@@ -1304,61 +1785,24 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="The Stonehorns of the Svard are resilient in the extreme, perhaps the toughest of their breed, and are renowned as such across the Mortal Realms. Add 1 to the Wounds characteristic of all Svard STONEHORN models."/>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Add 1 to the Wounds characteristic of all Svard STONEHORN models."/>
           </characteristics>
         </profile>
-        <profile id="a832-49ee-6a4b-506f" name="Jorlbad" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
+        <profile id="a7fb-e45b-db93-7195" name="Alfrostun Avalanche" book="Beastclaw Raiders" page="97" hidden="true" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4dab-9768-a42c-232a" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
           <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1 (must include 3-9 units of Stonehorn Beastriders instead of 1-3)"/>
-          </characteristics>
-        </profile>
-        <profile id="b5ea-0d6c-2b13-a4d9" name="Skal" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="0-1"/>
-          </characteristics>
-        </profile>
-        <profile id="8781-5d30-521f-179a" name="Torrbad" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="0-1"/>
-          </characteristics>
-        </profile>
-        <profile id="417e-e009-f912-ca0e" name="Eurlbad" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="0-1"/>
-          </characteristics>
-        </profile>
-        <profile id="6b62-0f11-7856-b681" name="Frostlord on Stonehorn" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1"/>
-          </characteristics>
-        </profile>
-        <profile id="50df-0129-3b53-a52b" name="Helwinter Vambrace" hidden="false" profileTypeId="0ac4-aacb-2481-8e72" profileTypeName="Artefact">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Artefact Details" characteristicTypeId="0918-c47a-d84e-c0cf" value="In addition to any other artefacts of power your army has, one Svard HERO can have the following artefact of power instead of one chosen:  Thought to have been scavenged from a suit of meteoric iron, these crude scraps of armour can turn aside the most powerful blows. Roll a dice each time the bearer suffers a mortal wound; on a 5 or more that wound is ignored"/>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="On a turn in which they charged into combat, you can re-roll all failed wound rolls made for BEASTCLAW RAIDER models from this battalion in the combat phase."/>
           </characteristics>
         </profile>
       </profiles>
@@ -1368,7 +1812,237 @@
       <constraints/>
       <categoryLinks/>
       <selectionEntries/>
-      <selectionEntryGroups/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="cd5b-db27-4ab0-8c6b" name="1. Frostlord on Stonehorn" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2b16-4589-8b7f-8337" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b138-39cd-a908-b3ff" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="8e76-ebb7-d48f-e982" name="Frostlord on Stonehorn" hidden="false" targetId="550d-7e51-8ddd-11f7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5478-3eae-7396-8aac" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f043-daff-ec8c-2546" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="44fb-2862-c7a4-1612" name="2. Jorlbad" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d56-0322-b38c-f82c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b86-a878-9348-56e0" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="9b45-1b0b-b84e-e760" name="Battalion: Jorlbad" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="6ce2-9f42-7c8b-3a70" name="Tip of the Hunting Spear" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Jorlbad units can run and charge in the same turn."/>
+                  </characteristics>
+                </profile>
+                <profile id="3f7a-37ad-f47d-a7ea" name="Fighting Hand" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="You can re-roll failed battleshock tests for friendly BEASTCLAW RAIDERS units that are within 12&quot; of the Jorlbad’s Huskard."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc5f-1780-79e5-d991" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7750-97c8-84f8-b238" type="min"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="ca9c-1450-2b76-fb99" name="1. Huskard on Stonehorn" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="b0a4-1c45-748c-bb82" name="Huskard on Stonehorn" hidden="false" targetId="fafb-eaad-f659-ba2d" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c5c7-9e73-7ea6-0bbe" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e9e-a537-3dc4-925e" type="min"/>
+                      </constraints>
+                      <categoryLinks/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="57b1-61c8-7b35-268b" name="3. Mournfang Packs (2 to 4)" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4171-b0c3-46ec-e4d9" type="max"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d64c-582d-d718-9b33" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="3035-f0c2-6542-335b" name="Mournfang Pack" hidden="false" targetId="c5e4-e780-c534-d17c" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d0d-425a-67e8-0b9c" type="min"/>
+                      </constraints>
+                      <categoryLinks/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="9b96-b48a-f847-d507" name="2. Stonehorn Beastriders (3 to 9)" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3934-c099-acf7-0ebf" type="max"/>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="954f-3f46-2c8d-1ec2" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="c637-4b91-0926-4380" name="Stonehorn Beastriders" hidden="false" targetId="559c-0689-72d3-c291" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3805-a26e-abc2-0155" type="min"/>
+                      </constraints>
+                      <categoryLinks/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="160.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="4dab-9768-a42c-232a" name="3. Additional Battalions" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="e794-9c9e-e88c-7a49" name="1. Eurlbad" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fab5-5872-30d9-d599" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="09ce-5572-143a-7d80" name="Battalion: Eurlbad" hidden="false" targetId="dbeb-bd23-4e21-b1ab" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="2408-0711-8de4-4794" name="2. Torrbad" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1a9-b1c9-0b36-56bb" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="1e0a-3ee4-be2e-d77d" name="Battalion: Torrbad" hidden="false" targetId="b04c-dd95-eadb-fc13" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="9090-9d05-3256-883f" name="3. Skal" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9078-36ab-57be-c336" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="fd0f-36d8-73bd-a14d" name="Battalion: Skal" hidden="false" targetId="69f3-9903-964f-c102" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="150.0"/>
@@ -1382,34 +2056,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="When the Thundertusks of the Torrbad gather in number, the strength of their freezing magical enchantments magnifies to chill the blood of those not used to its bitter touch. Enemy units cannot retreat whilst they are within 3&quot; of any Torrbad unit. Furthermore, roll a dice in each of your hero phases for each enemy unit within 3&quot; of at least one of your Torrbad Thundertusk. Add 1 to the result of the dice roll for each additinoal Torrbad Thundertusk that is within 3&quot; of the unit being rolled for. On a 6 the unit suffers A MORTAL WOUND, on a 7 it suffers D3 MORTAL WOUNDS and on an 8 OR MORE it suffers D6 MORTAL WOUNDS."/>
-          </characteristics>
-        </profile>
-        <profile id="7322-845b-ce11-33dd" name="Huskard on Thundertusk" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1"/>
-          </characteristics>
-        </profile>
-        <profile id="c5ee-7c53-b2b4-e9cb" name="Thundertusk Beastriders" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="3-9"/>
-          </characteristics>
-        </profile>
-        <profile id="8cda-b7ff-c461-b7ef" name="Icefall Yhetees" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="0-3"/>
+            <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="Enemy units cannot retreat whilst they are within 3&quot; of any Torrbad unit. Furthermore, roll a dice in each of your hero phases for each enemy unit within 3&quot; of at least one of your Torrbad Thundertusk. Add 1 to the result of the dice roll for each additinoal Torrbad Thundertusk that is within 3&quot; of the unit being rolled for. On a 6, the unit suffers 1 mortal wound, on a 7 it suffers D3 mortal wounds and on an 8+, it suffers D6 mortal wounds."/>
           </characteristics>
         </profile>
       </profiles>
@@ -1419,7 +2066,83 @@
       <constraints/>
       <categoryLinks/>
       <selectionEntries/>
-      <selectionEntryGroups/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="5c95-2288-3ca4-fc39" name="1. Huskard on Thundertusk" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26ee-5bd5-37fb-42ac" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db74-cf7d-baac-2263" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="8585-7423-fb01-4b8f" name="Huskard on Thundertusk" hidden="false" targetId="6ba6-af42-5060-ef84" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5101-e201-29b3-f7f6" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="63a8-8172-2697-e3a2" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="9f54-4ffc-d15f-b3c2" name="2. Thundertusk Beastriders (3 to 9)" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="376e-1d62-3094-431b" type="max"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c0f-212e-6541-b645" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="5a69-5459-7a03-dca3" name="Thundertusk Beastriders" hidden="false" targetId="078e-320b-e175-9d00" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a01c-cbc8-7162-b812" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="b3b0-d519-d3ba-c1b0" name="3. Icefall Yhetees (0 to 3)" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db1d-64aa-6172-5439" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="063b-3166-8e90-0882" name="Icefall Yhetees" hidden="false" targetId="e660-38b1-e212-9eb0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1297-2d5b-b7e2-526a" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="170.0"/>
@@ -4462,6 +5185,170 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="2bca-dc9c-7582-0784" name="Orruk Gore-gruntas" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="c144-33f1-961a-787d" name="Fanged Maw and Hooves" hidden="false" profileTypeId="96df-ab28-5d72-bbb3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+            <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
+            <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="4"/>
+            <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="4+"/>
+            <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="4+"/>
+            <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-"/>
+            <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1*"/>
+          </characteristics>
+        </profile>
+        <profile id="9206-781e-c83b-ac5e" name="Gore-Grunta Charge" hidden="false" profileTypeId="c924-5a68-471a-2fd5">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="Even by the destructive standards of the IRONJAWZ, a Gore-Grunta charge is horrific to behold, enemy units vanishing under a roaring, grunting mass. However, a Grunta needs a bit of a run-up to really get going! When you declare a charge with a unit of Gore-Gruntas, measure the distance to the nearest enemy unit. If the distance is 8&quot; or more and the charge is successful, the gruntas’ Fanged Maw and Hooves have a Damage characteristic of D3 instead of 1 until the end of that turn."/>
+          </characteristics>
+        </profile>
+        <profile id="2b25-0ebb-736b-1305" name="Orruk Gore-Gruntas" book="Destruction Battletomb: Ironjawz" page="116" hidden="false" profileTypeId="1960-ca8e-67ce-2014">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Move" characteristicTypeId="8655-6213-2824-1752" value="9&quot;"/>
+            <characteristic name="Wounds" characteristicTypeId="cd0e-fea6-411f-904d" value="5"/>
+            <characteristic name="Bravery" characteristicTypeId="0c85-bf79-836b-759e" value="7"/>
+            <characteristic name="Save" characteristicTypeId="f8dd-4f2a-8543-4f36" value="4+"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="84e2-0683-28e5-7495" name="Gore-Grunta Boss" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <description>The leader of each unit is a Gore-grunta Boss. They make 4 attacks rather than 3.</description>
+        </rule>
+        <rule id="ab85-3d10-7242-1ae6" name="Orruk Gore-Gruntas" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <description>A unit of Orruk Gore-Gruntas has 3 or more models. The riders of some units of Gore-Gruntas are armed with Pig-iron Choppas, while others carry Jagged Gore-hackas. Their mounts tear at the enemy with their Fanged Maws and Hooves.</description>
+        </rule>
+      </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries>
+        <selectionEntry id="73e7-d3ab-e9b3-d53b" name="3 Gore-Gruntas" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1ce2-0b48-1f0f-3803" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b09b-68dd-eb98-d9a5" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="140.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="71b6-ebf6-c46a-9ce2" name="Unit Weapon Options" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4534-fad0-194d-2f3d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="703d-671d-0129-290b" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="4cdd-8911-1ba9-6665" name="Pig-iron Choppa" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="494e-9748-566c-cda8" name="Pig-iron Choppa" hidden="false" profileTypeId="96df-ab28-5d72-bbb3">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                    <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
+                    <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="3"/>
+                    <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="3+"/>
+                    <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+                    <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-1"/>
+                    <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b36d-b16f-f0de-1785" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1c45-b88e-f9b8-7aa0" name="Jagged Gore-hacka" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="59e9-7c47-ba62-b46a" name="Jagged Gore-hacka" hidden="false" profileTypeId="96df-ab28-5d72-bbb3">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                    <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="2&quot;"/>
+                    <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="3"/>
+                    <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="4+"/>
+                    <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+                    <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-1"/>
+                    <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1ed2-4ed2-4f31-ab6d" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="e342-fd48-5b29-c708" name="Beastclaw Raider Magical Artefacts" hidden="false" collective="false">
@@ -4934,7 +5821,42 @@
           <constraints/>
         </categoryLink>
       </categoryLinks>
-      <selectionEntries/>
+      <selectionEntries>
+        <selectionEntry id="3f38-c43f-b01b-7566" name="Helwinter Vambrace" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="5813-cde1-c39b-a970" name="Helwinter Vambrace" hidden="false" profileTypeId="0ac4-aacb-2481-8e72" profileTypeName="Artefact">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Artefact Details" characteristicTypeId="0918-c47a-d84e-c0cf" value="Roll a dice each time the bearer suffers a mortal wound; on a 5 or more that wound is ignored."/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6e12-78d2-7832-7cdc" type="notInstanceOf"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="b1d3-0527-eb58-60c4" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups/>
       <entryLinks>
         <entryLink id="83f1-c8c3-33b8-f2ba" name="Artefacts of Destruction" hidden="false" targetId="ca3c-6bfc-07f1-2953" type="selectionEntryGroup">

--- a/Destruction - Bonesplitterz.cat
+++ b/Destruction - Bonesplitterz.cat
@@ -1,28 +1,24 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="7e25-33bb-f612-bfca" name="Destruction - Bonesplitterz" book="Destruction Battletome: Bonesplitterz" revision="7" battleScribeVersion="2.01" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="6" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="7e25-33bb-f612-bfca" name="Destruction - Bonesplitterz" book="Destruction Battletome: Bonesplitterz" revision="10" battleScribeVersion="2.01" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="6" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
   <costTypes/>
   <profileTypes>
-    <profileType id="f7ce-f73f-e66e-8a92" name="Damage Table: Stornhorn">
-      <characteristicTypes>
-        <characteristicType id="2e53-f878-8529-f717" name="Move"/>
-        <characteristicType id="107a-2e9d-0266-0426" name="Horn Attacks"/>
-        <characteristicType id="9948-0848-e4ba-d0f5" name="Crushing Hooves"/>
-      </characteristicTypes>
-    </profileType>
-    <profileType id="b30f-f7bd-58e7-2395" name="Damage Table: Thundertusk">
-      <characteristicTypes>
-        <characteristicType id="ad70-7958-2119-ab08" name="Move"/>
-        <characteristicType id="52ad-8267-7682-1505" name="Frost-Wreathed Ice"/>
-        <characteristicType id="ca56-5de6-8223-726d" name="Crushing Blows"/>
-      </characteristicTypes>
-    </profileType>
     <profileType id="5814-7e7f-e83d-1669" name="Ritual Dance">
       <characteristicTypes>
         <characteristicType id="6add-0606-370e-d20a" name="Result"/>
         <characteristicType id="7469-ca16-8e98-299a" name="Description"/>
+      </characteristicTypes>
+    </profileType>
+    <profileType id="34cd-e678-fd4f-9f1b" name="D66">
+      <characteristicTypes>
+        <characteristicType id="9d7b-b684-7633-86eb" name="Strategem"/>
+      </characteristicTypes>
+    </profileType>
+    <profileType id="5dfb-25e6-9322-983a" name="D6">
+      <characteristicTypes>
+        <characteristicType id="2c27-08ec-8a3a-6a3e" name="Monster Hunters Result"/>
       </characteristicTypes>
     </profileType>
   </profileTypes>
@@ -140,6 +136,27 @@
       <constraints/>
     </categoryEntry>
     <categoryEntry id="c9ee-e3ba-3b83-fe1c" name="Savage Big Boss" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="688f-a281-d5d0-4f24" name="BONEGRINZ" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="72b6-9777-df40-1149" name="DRAKKFOOT" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="de74-0645-34e8-23e4" name="ICEBONE" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -278,7 +295,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="a4f3-1c7b-caba-b530" name="Savage Orruks Morboys" hidden="false" targetId="64ec-d3e1-bc29-aa24" type="selectionEntry">
+    <entryLink id="a4f3-1c7b-caba-b530" name="Savage Orruk Morboys" hidden="false" targetId="64ec-d3e1-bc29-aa24" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -311,17 +328,12 @@
           <repeats/>
           <conditions/>
           <conditionGroups>
-            <conditionGroup type="or">
-              <conditions/>
-              <conditionGroups>
-                <conditionGroup type="and">
-                  <conditions>
-                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db37-22b2-39f5-f49e" type="lessThan"/>
-                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33cb-28e3-cf3d-7f21" type="lessThan"/>
-                  </conditions>
-                  <conditionGroups/>
-                </conditionGroup>
-              </conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c55-3eee-a90a-ac07" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33cb-28e3-cf3d-7f21" type="lessThan"/>
+              </conditions>
+              <conditionGroups/>
             </conditionGroup>
           </conditionGroups>
         </modifier>
@@ -351,7 +363,7 @@
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db37-22b2-39f5-f49e" type="lessThan"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c55-3eee-a90a-ac07" type="lessThan"/>
                     <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33cb-28e3-cf3d-7f21" type="lessThan"/>
                   </conditions>
                   <conditionGroups/>
@@ -381,17 +393,12 @@
           <repeats/>
           <conditions/>
           <conditionGroups>
-            <conditionGroup type="or">
-              <conditions/>
-              <conditionGroups>
-                <conditionGroup type="and">
-                  <conditions>
-                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db37-22b2-39f5-f49e" type="lessThan"/>
-                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33cb-28e3-cf3d-7f21" type="lessThan"/>
-                  </conditions>
-                  <conditionGroups/>
-                </conditionGroup>
-              </conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c55-3eee-a90a-ac07" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33cb-28e3-cf3d-7f21" type="lessThan"/>
+              </conditions>
+              <conditionGroups/>
             </conditionGroup>
           </conditionGroups>
         </modifier>
@@ -421,7 +428,7 @@
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db37-22b2-39f5-f49e" type="lessThan"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c55-3eee-a90a-ac07" type="lessThan"/>
                     <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33cb-28e3-cf3d-7f21" type="lessThan"/>
                   </conditions>
                   <conditionGroups/>
@@ -451,17 +458,12 @@
           <repeats/>
           <conditions/>
           <conditionGroups>
-            <conditionGroup type="or">
-              <conditions/>
-              <conditionGroups>
-                <conditionGroup type="and">
-                  <conditions>
-                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db37-22b2-39f5-f49e" type="lessThan"/>
-                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33cb-28e3-cf3d-7f21" type="lessThan"/>
-                  </conditions>
-                  <conditionGroups/>
-                </conditionGroup>
-              </conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c55-3eee-a90a-ac07" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33cb-28e3-cf3d-7f21" type="lessThan"/>
+              </conditions>
+              <conditionGroups/>
             </conditionGroup>
           </conditionGroups>
         </modifier>
@@ -486,17 +488,12 @@
           <repeats/>
           <conditions/>
           <conditionGroups>
-            <conditionGroup type="or">
-              <conditions/>
-              <conditionGroups>
-                <conditionGroup type="and">
-                  <conditions>
-                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db37-22b2-39f5-f49e" type="lessThan"/>
-                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33cb-28e3-cf3d-7f21" type="lessThan"/>
-                  </conditions>
-                  <conditionGroups/>
-                </conditionGroup>
-              </conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c55-3eee-a90a-ac07" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33cb-28e3-cf3d-7f21" type="lessThan"/>
+              </conditions>
+              <conditionGroups/>
             </conditionGroup>
           </conditionGroups>
         </modifier>
@@ -526,7 +523,7 @@
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db37-22b2-39f5-f49e" type="lessThan"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c55-3eee-a90a-ac07" type="lessThan"/>
                     <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33cb-28e3-cf3d-7f21" type="lessThan"/>
                   </conditions>
                   <conditionGroups/>
@@ -667,7 +664,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="e1f7-f0ed-918b-e8eb" name="Savage Orruks Morboys" hidden="false" targetId="64ec-d3e1-bc29-aa24" type="selectionEntry">
+    <entryLink id="e1f7-f0ed-918b-e8eb" name="Savage Orruk Morboys" hidden="false" targetId="64ec-d3e1-bc29-aa24" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -705,7 +702,7 @@
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db37-22b2-39f5-f49e" type="lessThan"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c55-3eee-a90a-ac07" type="lessThan"/>
                     <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33cb-28e3-cf3d-7f21" type="lessThan"/>
                   </conditions>
                   <conditionGroups/>
@@ -740,7 +737,7 @@
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db37-22b2-39f5-f49e" type="lessThan"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c55-3eee-a90a-ac07" type="lessThan"/>
                     <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33cb-28e3-cf3d-7f21" type="lessThan"/>
                   </conditions>
                   <conditionGroups/>
@@ -758,14 +755,7 @@
     <selectionEntry id="9dbb-2d1a-12d8-7faf" name="Allegiance" hidden="false" collective="false" type="upgrade">
       <profiles/>
       <rules/>
-      <infoLinks>
-        <infoLink id="1b9b-d261-3593-88df" name="Rampaging Destroyers" hidden="false" targetId="4571-8f36-98ca-2d16" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
+      <infoLinks/>
       <modifiers/>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
@@ -793,8 +783,27 @@
           </constraints>
           <categoryLinks/>
           <selectionEntries>
-            <selectionEntry id="db37-22b2-39f5-f49e" name="*Destruction*" hidden="false" collective="false" type="upgrade">
-              <profiles/>
+            <selectionEntry id="33cb-28e3-cf3d-7f21" name="Bonesplitterz" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="87f9-38bb-8a13-b1cb" name="Warpaint" hidden="false" profileTypeId="c137-4d1f-9d1a-524d" profileTypeName="Battle Trait">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Battle Trait Details" characteristicTypeId="9fdd-b4b1-5f7a-0970" value="When making a save roll for a BONESPLITTERZ model, a dice result of 6 (before modifiers) is always a successful save. This means there is always a chance of passing a save roll, regardless of the attack’s Rend.   Furthermore, roll a dice each time a BONESPLITTERZ model suffers a mortal wound; on a 6, that mortal wound is ignored as the warpaint somehow saves the orruk from harm."/>
+                  </characteristics>
+                </profile>
+                <profile id="df67-0ed5-0773-32d5" name="Monster Hunters" hidden="false" profileTypeId="c137-4d1f-9d1a-524d" profileTypeName="Battle Trait">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Battle Trait Details" characteristicTypeId="9fdd-b4b1-5f7a-0970" value="If a BONESPLITTERZ unit kills a MONSTER in the combat phase, the released spirit imbues them with the courage of a fierce beast. The unit does not need to take battleshock tests until your next hero phase.  In addition, if a BONESPLITTERZ unit is chosen to make its attacks in the combat phase and it is within 3&quot; of an enemy MONSTER, roll a dice before piling in and consult the attached table."/>
+                  </characteristics>
+                </profile>
+              </profiles>
               <rules/>
               <infoLinks/>
               <modifiers/>
@@ -802,24 +811,242 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <categoryLinks/>
-              <selectionEntries/>
+              <selectionEntries>
+                <selectionEntry id="2d3b-0786-e04b-2ff7" name="Monster Hunters Table" hidden="false" collective="false" type="upgrade">
+                  <profiles>
+                    <profile id="cf1b-bad1-8536-fac6" name="5-6; Berserk Strength" hidden="false" profileTypeId="5dfb-25e6-9322-983a" profileTypeName="D6">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Monster Hunters Result" characteristicTypeId="2c27-08ec-8a3a-6a3e" value="Each time a model in this unit rolls a wound roll of 6 or more against a MONSTER in this phase, the MONSTER suffers a mortal wound in addition to the normal damage."/>
+                      </characteristics>
+                    </profile>
+                    <profile id="2f5e-7ff7-3a0b-851c" name="1-2; Wild Abandon" hidden="false" profileTypeId="5dfb-25e6-9322-983a" profileTypeName="D6">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Monster Hunters Result" characteristicTypeId="2c27-08ec-8a3a-6a3e" value="The unit can pile in 6&quot; this phase, instead of only 3&quot;."/>
+                      </characteristics>
+                    </profile>
+                    <profile id="7dff-629d-f065-f5db" name="3-4; Stab! Stab! Stab!" hidden="false" profileTypeId="5dfb-25e6-9322-983a" profileTypeName="D6">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Monster Hunters Result" characteristicTypeId="2c27-08ec-8a3a-6a3e" value="You can reroll any failed wound rolls for models in the unit that direct their attacks against a MONSTER this phase."/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8c3e-8bb7-4a52-4123" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d226-4943-d003-fe88" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
               <selectionEntryGroups/>
               <entryLinks/>
               <costs>
                 <cost name="pts" costTypeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="33cb-28e3-cf3d-7f21" name="Bonesplitterz" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="3c55-3eee-a90a-ac07" name="*Destruction*" hidden="false" collective="false" type="upgrade">
               <profiles/>
               <rules/>
-              <infoLinks/>
+              <infoLinks>
+                <infoLink id="523a-2f27-f750-bf4e" name="Rampaging Destroyers" hidden="false" targetId="4571-8f36-98ca-2d16" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
               <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
+              <constraints/>
               <categoryLinks/>
               <selectionEntries/>
-              <selectionEntryGroups/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="ada8-7960-370e-a3aa" name="Firestorm: Stoneklaw&apos;s Gutstompas" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70e0-5748-6c3d-6cb8" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7832-62a6-10aa-a83b" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries>
+                    <selectionEntry id="dbe2-c49f-2af0-bf6d" name="Stoneklaw&apos;s Gutstompas" hidden="false" collective="false" type="upgrade">
+                      <profiles>
+                        <profile id="7b7c-cb30-6491-c096" name="Insane Advice" hidden="false" profileTypeId="c137-4d1f-9d1a-524d" profileTypeName="Battle Trait">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <characteristics>
+                            <characteristic name="Battle Trait Details" characteristicTypeId="9fdd-b4b1-5f7a-0970" value="After setting up, but before the first battle round begins, make two D66 rolls to determine the advice given to Stoneklaw by his pair of severed heads. You must pick one of the rolls, which is the advice that is followed.  The advice allows you to use a stratagem without having to spend strategy points in order to do so, and it also allows you to use the stratagem in a non-campaign game where strategy points are not being used."/>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks/>
+                      <selectionEntries>
+                        <selectionEntry id="8179-8ecf-f9a2-dca9" name="Insane Advice Table" hidden="false" collective="false" type="upgrade">
+                          <profiles>
+                            <profile id="6855-842f-5f59-64f1" name="11-13" hidden="false" profileTypeId="34cd-e678-fd4f-9f1b" profileTypeName="D66">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <characteristics>
+                                <characteristic name="Strategem" characteristicTypeId="9d7b-b684-7633-86eb" value="Choose a result."/>
+                              </characteristics>
+                            </profile>
+                            <profile id="df90-f716-1322-b9a3" name="61-63" hidden="false" profileTypeId="34cd-e678-fd4f-9f1b" profileTypeName="D66">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <characteristics>
+                                <characteristic name="Strategem" characteristicTypeId="9d7b-b684-7633-86eb" value="Regicide"/>
+                              </characteristics>
+                            </profile>
+                            <profile id="b461-bae5-971b-d43e" name="54-56" hidden="false" profileTypeId="34cd-e678-fd4f-9f1b" profileTypeName="D66">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <characteristics>
+                                <characteristic name="Strategem" characteristicTypeId="9d7b-b684-7633-86eb" value="Redeploy"/>
+                              </characteristics>
+                            </profile>
+                            <profile id="4f33-ceb1-4630-2de4" name="51-53" hidden="false" profileTypeId="34cd-e678-fd4f-9f1b" profileTypeName="D66">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <characteristics>
+                                <characteristic name="Strategem" characteristicTypeId="9d7b-b684-7633-86eb" value="Pre-emptive Attack"/>
+                              </characteristics>
+                            </profile>
+                            <profile id="6883-2ce1-56fc-0aeb" name="44-46" hidden="false" profileTypeId="34cd-e678-fd4f-9f1b" profileTypeName="D66">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <characteristics>
+                                <characteristic name="Strategem" characteristicTypeId="9d7b-b684-7633-86eb" value="Night Attack"/>
+                              </characteristics>
+                            </profile>
+                            <profile id="cdc9-9ce2-33af-5f57" name="41-43" hidden="false" profileTypeId="34cd-e678-fd4f-9f1b" profileTypeName="D66">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <characteristics>
+                                <characteristic name="Strategem" characteristicTypeId="9d7b-b684-7633-86eb" value="Inspiring Speech"/>
+                              </characteristics>
+                            </profile>
+                            <profile id="ae02-af45-bcfc-cd1d" name="34-36" hidden="false" profileTypeId="34cd-e678-fd4f-9f1b" profileTypeName="D66">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <characteristics>
+                                <characteristic name="Strategem" characteristicTypeId="9d7b-b684-7633-86eb" value="Hatred"/>
+                              </characteristics>
+                            </profile>
+                            <profile id="3514-5525-4002-c1d9" name="31-33" hidden="false" profileTypeId="34cd-e678-fd4f-9f1b" profileTypeName="D66">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <characteristics>
+                                <characteristic name="Strategem" characteristicTypeId="9d7b-b684-7633-86eb" value="Forced March"/>
+                              </characteristics>
+                            </profile>
+                            <profile id="caa6-fa57-e273-9fac" name="24-26" hidden="false" profileTypeId="34cd-e678-fd4f-9f1b" profileTypeName="D66">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <characteristics>
+                                <characteristic name="Strategem" characteristicTypeId="9d7b-b684-7633-86eb" value="Firestarter"/>
+                              </characteristics>
+                            </profile>
+                            <profile id="2363-1993-3647-a138" name="14-16" hidden="false" profileTypeId="34cd-e678-fd4f-9f1b" profileTypeName="D66">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <characteristics>
+                                <characteristic name="Strategem" characteristicTypeId="9d7b-b684-7633-86eb" value="Ambush"/>
+                              </characteristics>
+                            </profile>
+                            <profile id="5039-c9e0-1614-dc99" name="21-23" hidden="false" profileTypeId="34cd-e678-fd4f-9f1b" profileTypeName="D66">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <characteristics>
+                                <characteristic name="Strategem" characteristicTypeId="9d7b-b684-7633-86eb" value="Feigned Retreat"/>
+                              </characteristics>
+                            </profile>
+                            <profile id="ed70-589c-0e3d-51ea" name="64-66" hidden="false" profileTypeId="34cd-e678-fd4f-9f1b" profileTypeName="D66">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <characteristics>
+                                <characteristic name="Strategem" characteristicTypeId="9d7b-b684-7633-86eb" value="Reinforcements"/>
+                              </characteristics>
+                            </profile>
+                          </profiles>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a01f-2a2c-846a-48ba" type="max"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d3d0-9073-c005-b1dd" type="min"/>
+                          </constraints>
+                          <categoryLinks/>
+                          <selectionEntries/>
+                          <selectionEntryGroups/>
+                          <entryLinks/>
+                          <costs>
+                            <cost name="pts" costTypeId="points" value="0.0"/>
+                          </costs>
+                        </selectionEntry>
+                      </selectionEntries>
+                      <selectionEntryGroups/>
+                      <entryLinks/>
+                      <costs>
+                        <cost name="pts" costTypeId="points" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
               <entryLinks/>
               <costs>
                 <cost name="pts" costTypeId="points" value="0.0"/>
@@ -835,7 +1062,7 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c044-9f27-d1ed-e77c" name="Battalion: Bonegrinz Warclan" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="c044-9f27-d1ed-e77c" name="Super Battalion: Bonegrinz Warclan" hidden="false" collective="false" type="upgrade">
       <profiles>
         <profile id="6a88-a6a3-c369-7285" name="Loadsa Boyz" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>
@@ -855,13 +1082,27 @@
             <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Bonegrinz are emboldened each time a part of Gorkamorka’s essence is freed. Add 1 to the Bravery of all Bonegrinz models the first time a MONSTERis slain in the battle."/>
           </characteristics>
         </profile>
-        <profile id="81a9-890c-1a37-dc67" name="Extra Ju-Ju Warpaint" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+        <profile id="81a9-890c-1a37-dc67" name="Extra Ju-Ju Warpaint" hidden="true" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="c044-9f27-d1ed-e77c" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3bf7-8429-3529-026d" type="equalTo"/>
+                    <condition field="selections" scope="c044-9f27-d1ed-e77c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a378-eeff-c532-3f74" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
           <characteristics>
-            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="If the battalion contains a Wurrgog Prophet and the maximum number of battalions, it gains the Extra Ju-ju Warpaint ability:  When a Savage Warclan gathers for battle, the shamans daub their warriors and war boars in an extra layer of warpaint making them especially lucky. You can re-roll all failed save rolls for models in a Savage Warclan, but the re-rolled saves will only be passed on the roll of a 6, irrespective of the unit’s actual Save characteristic or any modifiers that apply to the attack. In addition, you can re-roll the dice rolled to see if a Savage Warclan’s model’s warpaint saves them from any mortal wounds they suffer"/>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="You can re-roll all failed save rolls for models in a Savage Warclan, but the re-rolled saves will only be passed on the roll of a 6, irrespective of the unit’s actual Save characteristic or any modifiers that apply to the attack. In addition, you can re-roll the dice rolled to see if a Savage Warclan’s model’s warpaint saves them from any mortal wounds they suffer"/>
           </characteristics>
         </profile>
       </profiles>
@@ -869,58 +1110,18 @@
       <infoLinks/>
       <modifiers/>
       <constraints/>
-      <categoryLinks/>
-      <selectionEntries>
-        <selectionEntry id="c6c7-ed8c-6e54-f7f8" name="Kunnin&apos; Rukk" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="686a-d293-0d9a-0a4a" name="Dead Sneaky" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Orruks can be surprisingly sneaky when they want, catching out a foe with an unexpected advance or a sudden sneak attack. In each of your hero phases, pick one unit from the Kunnin’ Rukk that is within 10&quot; of the battalion’s Savage Big Boss. The unit you pick can move as if it were the movement phase if it is more than 3&quot; from the enemy (and is allowed to run), shoot as if it were the shooting phase, or pile in and attack as if it were the combat phase if it is within 3&quot; of an enemy. It can still perform actions normally later in the turn, whatever it does in the hero phase."/>
-              </characteristics>
-            </profile>
-          </profiles>
+      <categoryLinks>
+        <categoryLink id="e9dd-308c-a801-cbb3" name="BONEGRINZ" hidden="false" targetId="688f-a281-d5d0-4f24" primary="false">
+          <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b25-46ae-36c5-515a" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="961e-2e19-9a32-6714" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="d937-80db-c0b1-36e1" name="Chop, Dice, Shoot" hidden="false" targetId="aa5d-e75c-1634-d90b" type="selectionEntryGroup">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="9cf8-bf03-d3cf-3e0e" name="Savage Big Boss" hidden="false" targetId="5e7e-f978-4c37-4666" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd8a-3ed3-dfae-c40b" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="013d-5083-160f-3eab" type="min"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries/>
       <selectionEntryGroups>
-        <selectionEntryGroup id="3bf7-8429-3529-026d" name="Other Battalions" hidden="false" collective="false">
+        <selectionEntryGroup id="3bf7-8429-3529-026d" name="3. Other Battalions" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -974,19 +1175,235 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="ea8d-7c68-5ed4-731f" name="Warrgog Prophet" hidden="false" targetId="f6fa-7f5f-0836-e986" type="selectionEntry">
+        <selectionEntryGroup id="a378-eeff-c532-3f74" name="2. Wurrgog Prophet" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="6d7b-bc8d-c07f-3b70" name="Wurrgog Prophet" hidden="false" targetId="f6fa-7f5f-0836-e986" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ddd-0898-6a75-f086" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="923b-1c41-b91f-4675" name="4. Additional Bonesplitterz Units" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="f15d-f669-d4f4-2c70" name="Maniak Weirdnob" hidden="false" targetId="2d80-c52b-1ec8-3c5d" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="d946-6008-53e6-69ab" name="Savage Big Boss" hidden="false" targetId="5e7e-f978-4c37-4666" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="bf2c-e0af-f818-3d47" name="Savage Big Stabbas" hidden="false" targetId="e930-136b-3f26-a52c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="2844-5234-6a2f-a364" name="Savage Boarboy Maniaks" hidden="false" targetId="52f0-7837-1600-09b4" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="0b48-c38b-35e2-65fa" name="Savage Boarboys" hidden="false" targetId="00a3-3560-0e7e-4008" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="6e2b-74eb-1d12-68f1" name="Savage Orruks" hidden="false" targetId="bfed-dba3-ebd5-04b1" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="1a6d-dee7-6aa4-8837" name="Savage Orruks Arrowboys" hidden="false" targetId="c5d3-2af4-16d0-77cf" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="4979-eb5c-0832-0fdb" name="Savage Orruks Morboys" hidden="false" targetId="64ec-d3e1-bc29-aa24" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="dd55-296e-01e2-72ae" name="Wardokk" hidden="false" targetId="99a1-6ae4-4f8c-bc69" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="ae83-4dfc-fa54-a65a" name="Wurrgog Prophet" hidden="false" targetId="f6fa-7f5f-0836-e986" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="b857-6a5f-0d47-2111" name="1. Kunnin&apos; Rukk" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dcec-c9be-ae99-9b57" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="311a-406b-7487-6054" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ddc-dc8b-0f24-f76c" type="min"/>
           </constraints>
           <categoryLinks/>
-        </entryLink>
-      </entryLinks>
+          <selectionEntries>
+            <selectionEntry id="3031-a18b-c818-d0e5" name="Battalion: Kunnin&apos; Rukk" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="a91f-908b-d198-3dec" name="Dead Sneaky" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Orruks can be surprisingly sneaky when they want, catching out a foe with an unexpected advance or a sudden sneak attack. In each of your hero phases, pick one unit from the Kunnin’ Rukk that is within 10&quot; of the battalion’s Savage Big Boss. The unit you pick can move as if it were the movement phase if it is more than 3&quot; from the enemy (and is allowed to run), shoot as if it were the shooting phase, or pile in and attack as if it were the combat phase if it is within 3&quot; of an enemy. It can still perform actions normally later in the turn, whatever it does in the hero phase."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="3e91-4268-405c-fa77" name="1. Savage Big Boss" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12e7-e8b2-2b20-f11d" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2478-af50-8351-a6ac" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="2c7b-7eea-0dd5-2206" name="Savage Big Boss" hidden="false" targetId="5e7e-f978-4c37-4666" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35ab-8b24-49cb-b344" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a75-2d6b-2ab0-5c0c" type="min"/>
+                      </constraints>
+                      <categoryLinks/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="f792-13b5-0a42-687e" name="2. Savages &amp; Arrowboys (4to 10)" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e604-2b8e-bccd-c388" type="max"/>
+                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b75c-cd38-3a95-34fb" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="2695-24c4-4b15-e1ac" name="Savage Orruks" hidden="false" targetId="bfed-dba3-ebd5-04b1" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks>
+                        <categoryLink id="57c9-586f-2d04-986c" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </categoryLink>
+                      </categoryLinks>
+                    </entryLink>
+                    <entryLink id="2eb8-5fd8-70a1-1840" name="Savage Orruks Arrowboys" hidden="false" targetId="c5d3-2af4-16d0-77cf" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks>
+                        <categoryLink id="8104-57c6-6b47-16a6" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </categoryLink>
+                      </categoryLinks>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="200.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="110.0"/>
       </costs>
@@ -1010,7 +1427,7 @@
       <categoryLinks/>
       <selectionEntries/>
       <selectionEntryGroups>
-        <selectionEntryGroup id="3e51-af21-c2d1-3653" name="Orruks and Boarboys" hidden="false" collective="false">
+        <selectionEntryGroup id="3e51-af21-c2d1-3653" name="2. Orruks and Boarboys (2 to 5)" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1057,25 +1474,39 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="d7b4-0f6d-d6b4-d98e" name="Savage Big Boss" hidden="false" targetId="5e7e-f978-4c37-4666" type="selectionEntry">
+        <selectionEntryGroup id="5e0f-0733-d38a-c1ae" name="1. Savage Big Boss" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5355-4e28-f463-777d" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="62e0-cd50-4367-50d1" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1811-4330-978a-018d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7bf-f587-b4eb-9ee8" type="min"/>
           </constraints>
           <categoryLinks/>
-        </entryLink>
-      </entryLinks>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="1e85-0352-f59e-44f5" name="Savage Big Boss" hidden="false" targetId="5e7e-f978-4c37-4666" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9178-a3aa-ecbe-2de5" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08bd-0a2d-cf29-a1fd" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="160.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="ff95-682a-cd0b-3dbe" name="Battalion: Drakkfoot Warclan" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="ff95-682a-cd0b-3dbe" name="Super Battalion: Drakkfoot Warclan" hidden="false" collective="false" type="upgrade">
       <profiles>
         <profile id="6703-985e-ce83-4ba4" name="Red Waaagh! Paint" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>
@@ -1114,13 +1545,27 @@
             <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Drakkfoot Warclan WIZARDS know the Blood Waaagh! spell in addition to any others they know. Only one WIZARDcan attempt to cast Blood Waaagh! in each hero phase"/>
           </characteristics>
         </profile>
-        <profile id="6fb6-8e23-fdbd-929d" name="Extra Ju-Ju Warpaint" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+        <profile id="3154-f294-f02e-4e7f" name="Extra Ju-Ju Warpaint" hidden="true" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="ff95-682a-cd0b-3dbe" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a88d-9695-ba6a-a34d" type="equalTo"/>
+                    <condition field="selections" scope="ff95-682a-cd0b-3dbe" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26bf-ef30-7f83-b87c" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
           <characteristics>
-            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="If the battalion contains a Wurrgog Prophet and the maximum number of battalions, it gains the Extra Ju-ju Warpaint ability:  When a Savage Warclan gathers for battle, the shamans daub their warriors and war boars in an extra layer of warpaint making them especially lucky. You can re-roll all failed save rolls for models in a Savage Warclan, but the re-rolled saves will only be passed on the roll of a 6, irrespective of the unit’s actual Save characteristic or any modifiers that apply to the attack. In addition, you can re-roll the dice rolled to see if a Savage Warclan’s model’s warpaint saves them from any mortal wounds they suffer"/>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="You can re-roll all failed save rolls for models in a Savage Warclan, but the re-rolled saves will only be passed on the roll of a 6, irrespective of the unit’s actual Save characteristic or any modifiers that apply to the attack. In addition, you can re-roll the dice rolled to see if a Savage Warclan’s model’s warpaint saves them from any mortal wounds they suffer"/>
           </characteristics>
         </profile>
       </profiles>
@@ -1128,93 +1573,18 @@
       <infoLinks/>
       <modifiers/>
       <constraints/>
-      <categoryLinks/>
-      <selectionEntries>
-        <selectionEntry id="01ab-c9dc-56d3-c719" name="Battalion: Kop Rukk" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="143b-d47f-d9fe-1a4a" name="Savage Waaagh! Energy" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="The build up of Waaagh! energy in the presence of so many crazed boys makes the Wardokks’ powers even more dangerous – sometimes for the orruks themselves. Add 1 to all casting rolls made by a Kop Rukk Wardokk that is within 12&quot; of 20 or more Savage Orruk Morboys. If the Wardokk is within 12&quot; of 30 or more Savage Orruk Morboys, add 2 to that model’s casting rolls instead. If the casting roll is a double, you must remove D3 models from the nearest unit of Savage Orruk Morboys as the build up of Waaagh! energy causes their heads to explode"/>
-              </characteristics>
-            </profile>
-          </profiles>
+      <categoryLinks>
+        <categoryLink id="170d-3552-f3a8-1679" name="DRAKKFOOT" hidden="false" targetId="72b6-9777-df40-1149" primary="false">
+          <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="bcb8-b293-cebe-c9ba" name="Savage Orruks Morboys" hidden="false" targetId="64ec-d3e1-bc29-aa24" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f270-a2e0-e149-1a11" type="max"/>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b97-9405-e3af-c704" type="min"/>
-              </constraints>
-              <categoryLinks>
-                <categoryLink id="a87d-bb05-72a9-555e" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </categoryLink>
-              </categoryLinks>
-            </entryLink>
-            <entryLink id="71d1-7a60-7538-c523" name="Wardokk" hidden="false" targetId="99a1-6ae4-4f8c-bc69" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups>
-                    <conditionGroup type="or">
-                      <conditions/>
-                      <conditionGroups>
-                        <conditionGroup type="and">
-                          <conditions>
-                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db37-22b2-39f5-f49e" type="lessThan"/>
-                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33cb-28e3-cf3d-7f21" type="lessThan"/>
-                          </conditions>
-                          <conditionGroups/>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d49-36bc-d537-6142" type="min"/>
-                <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="86d7-0d2b-93ee-b81c" type="max"/>
-              </constraints>
-              <categoryLinks>
-                <categoryLink id="6756-cfc6-cc6b-a8a5" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </categoryLink>
-              </categoryLinks>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" costTypeId="points" value="200.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries/>
       <selectionEntryGroups>
-        <selectionEntryGroup id="a88d-9695-ba6a-a34d" name="Other Battalions" hidden="false" collective="false">
+        <selectionEntryGroup id="a88d-9695-ba6a-a34d" name="3. Other Battalions" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1223,39 +1593,347 @@
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a003-9063-7bdf-f49e" type="max"/>
           </constraints>
           <categoryLinks/>
-          <selectionEntries/>
+          <selectionEntries>
+            <selectionEntry id="36bc-53d8-f60d-9661" name="Battalion: Snaga Rukk" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="d043-4681-d6ef-46c8" name="Maniak Stampede" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="When the enemy’s scent is in their nostrils, nothing can stop the boys of a Snaga Rukk from charging full pelt.In your hero phase, one Savage Boarboy Maniak unit from the Snaga Rukk can attempt to charge an enemy unit (if there is an eligible unit within 12&quot;) as if it were the charge phase. You can re-roll the charge roll if the Savage Boarboy Maniaks are within 10&quot; of either of the battalion’s Maniak Weirdnobs. If the charge is successful, roll a dice for each charging model that ends within 1&quot; of an enemy model: on a 4 or more, the enemy unit suffers a mortal wound. For each roll of 1, however, the charging unit suffers a mortal wound instead."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="08c5-f49f-27c7-def3" name="1. Maniak Weirdnobs (2 to 3)" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="24f1-37ee-6625-1cd1" type="min"/>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1fe-8d52-74fa-e359" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="33c3-068c-e3d6-d20e" name="Maniak Weirdnob" hidden="false" targetId="2d80-c52b-1ec8-3c5d" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbca-e7e4-c1e6-1dbd" type="max"/>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d46-96d7-3103-8959" type="min"/>
+                      </constraints>
+                      <categoryLinks>
+                        <categoryLink id="6ea4-b73b-cf16-b6f4" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </categoryLink>
+                      </categoryLinks>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="400a-28dc-f38f-86f0" name="2. Savage Boarboy Maniaks (2 to 10)" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6350-4472-d311-15f2" type="max"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f8a-fbf9-383f-7a76" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="2cd7-e4b9-74a0-67c8" name="Savage Boarboy Maniaks" hidden="false" targetId="52f0-7837-1600-09b4" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee92-3840-fb71-b770" type="min"/>
+                        <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e715-51f1-38eb-d2b0" type="max"/>
+                      </constraints>
+                      <categoryLinks>
+                        <categoryLink id="ba8c-68cd-56a3-74ea" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </categoryLink>
+                      </categoryLinks>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="170.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c1f6-94e1-a814-9b6a" name="Battalion: Brutal Rukk" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="eae7-a723-8c22-aab5" name="Savage Swiftness" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Orruks are always competing to be the first to get stuck in, and run at breakneck pace to fight the foe. You can re-roll the dice when determining how far a unit from a Brutal Rukk runs. The Brutal Rukk’s Savage Big Boss and any unit that starts their move within 10&quot; of the big boss always move an extra 6&quot; when they run (there is no need to roll the dice)."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="1069-dabc-ab04-c2fd" name="2. Orruks and Boarboys (2 to 5)" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85ed-a8aa-45b2-57fe" type="min"/>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2fd-fb16-ccbc-c81c" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="ae5d-862a-4ff1-86ef" name="Savage Boarboys" hidden="false" targetId="00a3-3560-0e7e-4008" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks>
+                        <categoryLink id="2bea-2d84-397e-fafc" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="false">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </categoryLink>
+                      </categoryLinks>
+                    </entryLink>
+                    <entryLink id="76e1-8b48-f2a8-1456" name="Savage Orruks" hidden="false" targetId="bfed-dba3-ebd5-04b1" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks>
+                        <categoryLink id="120c-d96d-699b-75e4" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </categoryLink>
+                      </categoryLinks>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="faf5-e2bb-4306-03b8" name="1. Savage Big Boss" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3df4-0f38-fac3-b119" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="440a-ac18-f3bd-cdfe" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="0a09-d131-cbcb-c8f1" name="Savage Big Boss" hidden="false" targetId="5e7e-f978-4c37-4666" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8807-9a9b-7bf9-3515" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1aa-33de-5b65-df28" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="10a7-8ff0-f21e-35b9" name="3. Wardokk" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="622d-8df4-9370-4eec" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="7c54-c5e2-4d6b-42e9" name="Wardokk" hidden="false" targetId="99a1-6ae4-4f8c-bc69" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d062-5223-cebc-d6f9" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="160.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6b30-dfbe-05ae-5516" name="Battalion: Kunnin&apos; Rukk" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="c6e5-7036-4b1d-4529" name="Dead Sneaky" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Orruks can be surprisingly sneaky when they want, catching out a foe with an unexpected advance or a sudden sneak attack. In each of your hero phases, pick one unit from the Kunnin’ Rukk that is within 10&quot; of the battalion’s Savage Big Boss. The unit you pick can move as if it were the movement phase if it is more than 3&quot; from the enemy (and is allowed to run), shoot as if it were the shooting phase, or pile in and attack as if it were the combat phase if it is within 3&quot; of an enemy. It can still perform actions normally later in the turn, whatever it does in the hero phase."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="40a3-73fe-7a66-70ca" name="1. Savage Big Boss" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc56-a4fc-365e-dc4d" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2be-b8ac-bbc2-7a20" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="c7cf-8c43-eaf4-8440" name="Savage Big Boss" hidden="false" targetId="5e7e-f978-4c37-4666" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a9c-8b10-312b-17b2" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eadb-4a66-860e-0711" type="min"/>
+                      </constraints>
+                      <categoryLinks/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="1c16-bf19-3832-056b" name="2. Savages &amp; Arrowboys (2 to 5)" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8e1-dace-a13e-d85e" type="max"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9257-a3fd-a457-618a" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="e6c3-1602-964b-1aaf" name="Savage Orruks" hidden="false" targetId="bfed-dba3-ebd5-04b1" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks>
+                        <categoryLink id="5742-e7e1-9a00-4f04" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </categoryLink>
+                      </categoryLinks>
+                    </entryLink>
+                    <entryLink id="6c23-2450-c424-8e0f" name="Savage Orruks Arrowboys" hidden="false" targetId="c5d3-2af4-16d0-77cf" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks>
+                        <categoryLink id="9ca4-ac9c-625e-ca96" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </categoryLink>
+                      </categoryLinks>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="8e11-c007-25f4-df0a" name="3. Wardokk" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e057-9513-1833-2221" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="acc5-3165-2992-ae57" name="Wardokk" hidden="false" targetId="99a1-6ae4-4f8c-bc69" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db93-add3-f13a-19d1" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="200.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="a4c1-65d6-be69-d2d1" name="Battalion: Brutal Rukk" hidden="false" targetId="ee34-6e96-2da0-46f0" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ce8-b35a-3ae1-fbd6" type="max"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="c3db-ce07-b409-56f2" name="Battalion: Kunnin&apos; Rukk" hidden="false" targetId="c80e-9ef9-e607-5035" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11d3-18dd-dcb7-cc5a" type="max"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="605e-1e13-f23b-ba3b" name="Battalion: Snaga Rukk" hidden="false" targetId="0443-ee65-3b72-bdef" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2960-2980-9672-afaa" type="max"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
             <entryLink id="fa61-b5f4-d135-e437" name="Battalion: Teef Rukk" hidden="false" targetId="b5c4-0dea-165b-3f21" type="selectionEntry">
               <profiles/>
               <rules/>
@@ -1268,20 +1946,237 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="2896-9f49-c3de-bc9d" name="Warrgog Prophet" hidden="false" targetId="f6fa-7f5f-0836-e986" type="selectionEntry">
+        <selectionEntryGroup id="68bd-8da2-ba13-23ee" name="4. Additional Bonesplitterz Units" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="7b6d-ad83-6a77-5c8e" name="Maniak Weirdnob" hidden="false" targetId="2d80-c52b-1ec8-3c5d" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="8a89-4231-5783-d297" name="Savage Big Boss" hidden="false" targetId="5e7e-f978-4c37-4666" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="3740-c0fb-f7b9-836a" name="Savage Big Stabbas" hidden="false" targetId="e930-136b-3f26-a52c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="cfa4-6588-e7b9-e464" name="Savage Boarboy Maniaks" hidden="false" targetId="52f0-7837-1600-09b4" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="a7e7-ac7f-fa98-1974" name="Savage Boarboys" hidden="false" targetId="00a3-3560-0e7e-4008" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="6076-49db-332e-e4e1" name="Savage Orruks" hidden="false" targetId="bfed-dba3-ebd5-04b1" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="e116-278e-ae66-f8ce" name="Savage Orruks Arrowboys" hidden="false" targetId="c5d3-2af4-16d0-77cf" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="3426-8c1f-3f22-1bd0" name="Savage Orruks Morboys" hidden="false" targetId="64ec-d3e1-bc29-aa24" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="ec4d-0afb-c1fd-fd2a" name="Wardokk" hidden="false" targetId="99a1-6ae4-4f8c-bc69" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="3cf2-25ab-4de4-9a87" name="Wurrgog Prophet" hidden="false" targetId="f6fa-7f5f-0836-e986" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="c537-749d-da18-fa89" name="1. Wurrgog Prophet" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a5d-85fc-70e0-ee57" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f030-b1d1-e3a4-391a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c9b5-7e67-320a-10cc" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af1b-f2d0-bce2-316a" type="max"/>
           </constraints>
           <categoryLinks/>
-        </entryLink>
-      </entryLinks>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="26bf-ef30-7f83-b87c" name="Wurrgog Prophet" hidden="false" targetId="f6fa-7f5f-0836-e986" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a9cc-8b34-0678-4af9" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2381-9dd2-4a83-7099" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="bc62-baa7-98c7-6b2d" name="2. Kop Rukk" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dbbb-53a3-5847-1e89" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6565-e2ff-7e1a-e07a" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="c458-08b6-3aa7-8e16" name="Battalion: Kop Rukk" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="737a-36fd-e250-a9a5" name="Savage Waaagh! Energy" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Add 1 to all casting rolls made by a Kop Rukk Wardokk that is within 12&quot; of 20 or more Savage Orruk Morboys. If the Wardokk is within 12&quot; of 30 or more Savage Orruk Morboys, add 2 to that model’s casting rolls instead. If the casting roll is a double, you must remove D3 models from the nearest unit of Savage Orruk Morboys as the build up of Waaagh! energy causes their heads to explode."/>
+                  </characteristics>
+                </profile>
+                <profile id="eca6-ebba-4107-5481" name="Waaagh! Stomp" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Add 1 to any wound rolls made for a Savage Orruk Morboy if its unit is within 12&quot; of at least two Wardokks from this battalion when it makes its attacks."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="5e86-163a-4936-19cd" name="1. Wardokks (3 to 6)" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="1eae-cefc-66d6-56d5" name="Wardokk" hidden="false" targetId="99a1-6ae4-4f8c-bc69" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="37d9-9ff0-94fd-eda8" type="min"/>
+                        <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d475-8b08-92a0-08d0" type="max"/>
+                      </constraints>
+                      <categoryLinks>
+                        <categoryLink id="342f-64f7-e792-3332" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </categoryLink>
+                      </categoryLinks>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="7d4e-3534-8a57-c326" name="2. Savage Orruk Morboys (2 to 5)" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="ce22-1ff5-da2c-c48d" name="Savage Orruk Morboys" hidden="false" targetId="64ec-d3e1-bc29-aa24" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b8f6-33e6-8a40-4caf" type="max"/>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2bc-d753-42aa-7af5" type="min"/>
+                      </constraints>
+                      <categoryLinks>
+                        <categoryLink id="fbba-9033-8c49-84a1" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </categoryLink>
+                      </categoryLinks>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="200.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="140.0"/>
       </costs>
@@ -1294,7 +2189,16 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="The build up of Waaagh! energy in the presence of so many crazed boys makes the Wardokks’ powers even more dangerous – sometimes for the orruks themselves. Add 1 to all casting rolls made by a Kop Rukk Wardokk that is within 12&quot; of 20 or more Savage Orruk Morboys. If the Wardokk is within 12&quot; of 30 or more Savage Orruk Morboys, add 2 to that model’s casting rolls instead. If the casting roll is a double, you must remove D3 models from the nearest unit of Savage Orruk Morboys as the build up of Waaagh! energy causes their heads to explode"/>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Add 1 to all casting rolls made by a Kop Rukk Wardokk that is within 12&quot; of 20 or more Savage Orruk Morboys. If the Wardokk is within 12&quot; of 30 or more Savage Orruk Morboys, add 2 to that model’s casting rolls instead. If the casting roll is a double, you must remove D3 models from the nearest unit of Savage Orruk Morboys as the build up of Waaagh! energy causes their heads to explode."/>
+          </characteristics>
+        </profile>
+        <profile id="df16-c595-fe4c-e52f" name="Waaagh! Stomp" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Add 1 to any wound rolls made for a Savage Orruk Morboy if its unit is within 12&quot; of at least two Wardokks from this battalion when it makes its attacks."/>
           </characteristics>
         </profile>
       </profiles>
@@ -1304,66 +2208,71 @@
       <constraints/>
       <categoryLinks/>
       <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks>
-        <entryLink id="187e-f108-f0d8-ac6b" name="Savage Orruks Morboys" hidden="false" targetId="64ec-d3e1-bc29-aa24" type="selectionEntry">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="72f7-a425-cbe9-0265" name="1. Wardokks (2 to 5)" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f4b4-0466-dba3-6370" type="max"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a32-b506-0fc2-75c2" type="min"/>
-          </constraints>
-          <categoryLinks>
-            <categoryLink id="072e-09da-f1e8-e4fc" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="5284-940c-368a-d9f8" name="Wardokk" hidden="false" targetId="99a1-6ae4-4f8c-bc69" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints/>
-            </categoryLink>
-          </categoryLinks>
-        </entryLink>
-        <entryLink id="5ecb-4377-12d3-e1ee" name="Wardokk" hidden="false" targetId="99a1-6ae4-4f8c-bc69" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fab6-cd91-74af-0123" type="min"/>
+                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7249-6635-3f2a-613b" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="ab6c-f44a-c9e6-026c" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="04c4-0973-795b-5cec" name="2. Savage Orruk Morboys (2 to 5)" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <repeats/>
-              <conditions/>
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions/>
-                  <conditionGroups>
-                    <conditionGroup type="and">
-                      <conditions>
-                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db37-22b2-39f5-f49e" type="lessThan"/>
-                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33cb-28e3-cf3d-7f21" type="lessThan"/>
-                      </conditions>
-                      <conditionGroups/>
-                    </conditionGroup>
-                  </conditionGroups>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8412-c22a-55c4-f46e" type="min"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c83-dc2b-6a7b-77a0" type="max"/>
-          </constraints>
-          <categoryLinks>
-            <categoryLink id="7ea0-f6e8-6889-9c1b" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="b59a-4fc4-9425-12eb" name="Savage Orruk Morboys" hidden="false" targetId="64ec-d3e1-bc29-aa24" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints/>
-            </categoryLink>
-          </categoryLinks>
-        </entryLink>
-      </entryLinks>
+              <constraints>
+                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2a4-31d9-db83-04b6" type="max"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a70-6054-b7b6-f6e8" type="min"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="1043-0960-b1da-4e71" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="200.0"/>
       </costs>
@@ -1386,33 +2295,87 @@
       <constraints/>
       <categoryLinks/>
       <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks>
-        <entryLink id="c5dc-9985-1033-a51d" name="Savage Big Boss" hidden="false" targetId="5e7e-f978-4c37-4666" type="selectionEntry">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="04a0-a83d-59f2-0ec0" name="1. Savage Big Boss" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d411-7153-3dbf-f2b2" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1943-df08-4eed-2100" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e0e-0356-3ab4-f382" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b5a-3d0d-3ad5-425b" type="max"/>
           </constraints>
           <categoryLinks/>
-        </entryLink>
-        <entryLink id="3e8c-c7ce-b9ac-d47f" name="Chop, Dice, Shoot" hidden="false" targetId="aa5d-e75c-1634-d90b" type="selectionEntryGroup">
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="8707-44f6-17cb-3e4b" name="Savage Big Boss" hidden="false" targetId="5e7e-f978-4c37-4666" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c810-4860-129c-fa99" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="adcf-2a87-1f10-6baf" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="7e4b-e736-cfd9-b042" name="2. Savages &amp; Arrowboys (2 to 5)" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3c3-3fa8-4211-5aa6" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a42-ee7c-106a-052c" type="min"/>
+          </constraints>
           <categoryLinks/>
-        </entryLink>
-      </entryLinks>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="b0e7-1ce2-a826-bfe7" name="Savage Orruks" hidden="false" targetId="bfed-dba3-ebd5-04b1" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="f4ff-33e2-65e6-9e2e" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="3389-d4e8-0826-7bb7" name="Savage Orruks Arrowboys" hidden="false" targetId="c5d3-2af4-16d0-77cf" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="ff76-3ca8-9e14-3c1b" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="200.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e988-0041-4417-8932" name="Battalion: Savage Warclan" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="e988-0041-4417-8932" name="Super Battalion: Savage Warclan" hidden="false" collective="false" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks>
@@ -1420,46 +2383,13 @@
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="hidden" value="false">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
+          <modifiers/>
         </infoLink>
       </infoLinks>
       <modifiers/>
       <constraints/>
       <categoryLinks/>
-      <selectionEntries>
-        <selectionEntry id="c859-b6a3-d81e-2cfb" name="Warrgog Prophet" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b02-2b80-05a5-dda0" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b22-0d98-9ada-3174" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="882e-a12d-5843-0bc3" name="Warrgog Prophet" hidden="false" targetId="f6fa-7f5f-0836-e986" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+      <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
         <entryLink id="30c1-8989-c7a0-6da9" name="Battalion: Brutal Rukk" hidden="false" targetId="ee34-6e96-2da0-46f0" type="selectionEntry">
@@ -1517,6 +2447,17 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
+        <entryLink id="16a8-7f43-adb7-d88c" name="Wurrgog Prophet" hidden="false" targetId="f6fa-7f5f-0836-e986" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb72-49a2-4112-550c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2c5-e2df-e929-24df" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="80.0"/>
@@ -1540,55 +2481,77 @@
       <constraints/>
       <categoryLinks/>
       <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks>
-        <entryLink id="5d2c-1a16-287a-41e7" name="Maniak Wierdnob" hidden="false" targetId="2d80-c52b-1ec8-3c5d" type="selectionEntry">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="992a-c19e-accd-d6b4" name="1. Maniak Weirdnobs" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2e1-5051-dccc-10de" type="max"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bfcd-89a6-7a8e-8302" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97ce-469f-5aa5-6fa6" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f949-6018-716e-d542" type="max"/>
           </constraints>
-          <categoryLinks>
-            <categoryLink id="2a4c-a61d-bc7a-b7d1" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="ab0a-bce0-d808-4452" name="Maniak Weirdnob" hidden="false" targetId="2d80-c52b-1ec8-3c5d" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints/>
-            </categoryLink>
-          </categoryLinks>
-        </entryLink>
-        <entryLink id="1b38-da1d-24c0-79d0" name="Savage Boarboy Maniaks" hidden="false" targetId="52f0-7837-1600-09b4" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b775-f54a-1bdf-d756" type="max"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80f2-b7c6-ef27-a461" type="min"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="3d11-1c7d-3bc2-6e8f" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6246-ddf8-076f-5516" name="2. Savage Boarboy Maniaks (2 to 10)" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="f29f-b08a-bf64-e26b" value="2">
-              <repeats/>
-              <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="999b-8d46-ee24-c8d5" type="instanceOf"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
+          <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f29f-b08a-bf64-e26b" type="min"/>
-            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58ad-a2cf-b3a8-5bac" type="max"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3686-9ccc-d965-cea5" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae4c-f81b-f69b-130e" type="min"/>
           </constraints>
-          <categoryLinks>
-            <categoryLink id="a4f8-c145-d9ee-e16d" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="a06a-3f35-356e-45a6" name="Savage Boarboy Maniaks" hidden="false" targetId="52f0-7837-1600-09b4" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints/>
-            </categoryLink>
-          </categoryLinks>
-        </entryLink>
-      </entryLinks>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b3bd-3df2-e148-c791" type="min"/>
+                <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f665-8211-bffd-b111" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="5eba-b02f-51ee-6bd3" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="170.0"/>
       </costs>
@@ -1611,54 +2574,58 @@
       <constraints/>
       <categoryLinks/>
       <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks>
-        <entryLink id="7510-3356-788f-0aa9" name="Savage Big Stabbas" hidden="false" targetId="e930-136b-3f26-a52c" type="selectionEntry">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="f9d9-a47f-b62c-bdb8" name="1. Savage Big Stabbas (2 to 5*)" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers>
-            <modifier type="set" field="hidden" value="true">
+            <modifier type="set" field="fa91-3be9-ffd2-618f" value="1">
               <repeats/>
-              <conditions/>
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions/>
-                  <conditionGroups>
-                    <conditionGroup type="and">
-                      <conditions>
-                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db37-22b2-39f5-f49e" type="lessThan"/>
-                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33cb-28e3-cf3d-7f21" type="lessThan"/>
-                      </conditions>
-                      <conditionGroups/>
-                    </conditionGroup>
-                  </conditionGroups>
-                </conditionGroup>
-              </conditionGroups>
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c044-9f27-d1ed-e77c" type="instanceOf"/>
+              </conditions>
+              <conditionGroups/>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="feff-db6d-65ab-563f" type="max"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e596-0a88-c309-fee0" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d84-6f6e-52aa-ecb3" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa91-3be9-ffd2-618f" type="max"/>
           </constraints>
-          <categoryLinks>
-            <categoryLink id="59e8-551f-880e-d2ef" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="5514-a6d3-8478-a72f" name="Savage Big Stabbas" hidden="false" targetId="e930-136b-3f26-a52c" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints/>
-            </categoryLink>
-          </categoryLinks>
-        </entryLink>
-      </entryLinks>
+              <constraints>
+                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d555-2e5f-d143-6663" type="max"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e123-c0c6-a4db-fd23" type="min"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="0b46-86e3-8982-20f1" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="100.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2d80-c52b-1ec8-3c5d" name="Maniak Wierdnob" hidden="false" collective="false" type="unit">
+    <selectionEntry id="2d80-c52b-1ec8-3c5d" name="Maniak Weirdnob" hidden="false" collective="false" type="unit">
       <profiles>
-        <profile id="c76f-fe1c-85f6-909e" name="Maniak Wierdnob" hidden="false" profileTypeId="1960-ca8e-67ce-2014" profileTypeName="Unit">
+        <profile id="c76f-fe1c-85f6-909e" name="Maniak Weirdnob" hidden="false" profileTypeId="1960-ca8e-67ce-2014" profileTypeName="Unit">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1698,7 +2665,7 @@
             <characteristic name="Spells Known" characteristicTypeId="dc9c-47d3-6931-859c" value="Arcane Bolt, Mystic Shield and Bone Spirit"/>
           </characteristics>
         </profile>
-        <profile id="2dcb-fc6d-64b3-a2dd" name="Maniak Wierdnob" hidden="false" profileTypeId="2e81-5e22-c6e1-73cb" profileTypeName="Spell">
+        <profile id="2dcb-fc6d-64b3-a2dd" name="Bone Spirit" hidden="false" profileTypeId="2e81-5e22-c6e1-73cb" profileTypeName="Spell">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1851,6 +2818,29 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
+        <entryLink id="f333-6ced-7539-1455" name="Warclan Extras" hidden="true" targetId="b384-5be7-036f-143c" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="688f-a281-d5d0-4f24" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="72b6-9777-df40-1149" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="de74-0645-34e8-23e4" type="instanceOf"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="120.0"/>
@@ -1998,6 +2988,29 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
+        <entryLink id="9a09-ef9b-f474-4741" name="Warclan Extras" hidden="true" targetId="b384-5be7-036f-143c" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="688f-a281-d5d0-4f24" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="72b6-9777-df40-1149" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="de74-0645-34e8-23e4" type="instanceOf"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="120.0"/>
@@ -2038,22 +3051,7 @@
       </profiles>
       <rules/>
       <infoLinks/>
-      <modifiers>
-        <modifier type="increment" field="points" value="100">
-          <repeats>
-            <repeat field="selections" scope="e930-136b-3f26-a52c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e2e7-4755-0488-3e39" repeats="1" roundUp="false"/>
-          </repeats>
-          <conditions/>
-          <conditionGroups/>
-        </modifier>
-        <modifier type="decrement" field="points" value="100">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="e930-136b-3f26-a52c" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e2e7-4755-0488-3e39" type="greaterThan"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
+      <modifiers/>
       <constraints/>
       <categoryLinks>
         <categoryLink id="3a8b-5b04-5fce-d3bc" name="New CategoryLink" hidden="false" targetId="d963-a5fb-c348-2371" primary="false">
@@ -2100,7 +3098,7 @@
           <selectionEntryGroups/>
           <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" costTypeId="points" value="100.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="1219-cd36-3334-79d7" name="Gork Toof" hidden="false" collective="false" type="upgrade">
@@ -2140,7 +3138,7 @@
       <selectionEntryGroups/>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="100.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="52f0-7837-1600-09b4" name="Savage Boarboy Maniaks" hidden="false" collective="false" type="unit">
@@ -2185,22 +3183,7 @@
           <modifiers/>
         </infoLink>
       </infoLinks>
-      <modifiers>
-        <modifier type="increment" field="points" value="140">
-          <repeats>
-            <repeat field="selections" scope="52f0-7837-1600-09b4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="65c5-a317-4e7d-595a" repeats="1" roundUp="false"/>
-          </repeats>
-          <conditions/>
-          <conditionGroups/>
-        </modifier>
-        <modifier type="decrement" field="points" value="140">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="52f0-7837-1600-09b4" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="65c5-a317-4e7d-595a" type="greaterThan"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
+      <modifiers/>
       <constraints/>
       <categoryLinks>
         <categoryLink id="51ab-df05-fbf2-ec02" name="New CategoryLink" hidden="false" targetId="d963-a5fb-c348-2371" primary="false">
@@ -2247,7 +3230,7 @@
           <selectionEntryGroups/>
           <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" costTypeId="points" value="140.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0209-07c0-433e-dd9e" name="War Boar&apos;s Tusks" hidden="false" collective="false" type="upgrade">
@@ -2307,28 +3290,63 @@
             <cost name="pts" costTypeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
+        <selectionEntry id="a8fb-24b1-5f69-e13e" name="Boar Thumper" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="1d71-577c-7c05-a62a" name="Boar Thumper" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="Unit Abilities">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="Models in this unit may be Boar Thumpers. You can add 2 to the charge rolls of a unit that includes any Boar Thumpers."/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e60b-cbfd-d9e6-f424" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7924-1687-3445-2282" name="Boar Totems" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="12f8-2590-1e0e-7db4" name="Boar Totems" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="Unit Abilities">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="Models in this unit may carry Boar Totems. You can add 2 to the Bravery of all models in a unit that includes any Bone Totems as long as there is an enemy model within 3&quot; of the unit."/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1365-6dea-87e4-4d8c" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>
-      <entryLinks>
-        <entryLink id="8fd7-0fe4-eb8a-9cb4" name="Boar Thumper" hidden="false" targetId="657a-9295-b3cb-4f82" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="e266-09f9-091d-8909" name="Boar Totems" hidden="false" targetId="088c-0ea5-45c9-94bf" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-      </entryLinks>
+      <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="140.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="00a3-3560-0e7e-4008" name="Savage Boarboys" hidden="false" collective="false" type="unit">
@@ -2393,22 +3411,7 @@
       </profiles>
       <rules/>
       <infoLinks/>
-      <modifiers>
-        <modifier type="increment" field="points" value="100">
-          <repeats>
-            <repeat field="selections" scope="00a3-3560-0e7e-4008" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="72f1-324d-410a-0560" repeats="1" roundUp="false"/>
-          </repeats>
-          <conditions/>
-          <conditionGroups/>
-        </modifier>
-        <modifier type="decrement" field="points" value="100">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="00a3-3560-0e7e-4008" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="72f1-324d-410a-0560" type="greaterThan"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
+      <modifiers/>
       <constraints/>
       <categoryLinks>
         <categoryLink id="7b0a-6df1-5a85-d0d7" name="New CategoryLink" hidden="false" targetId="d963-a5fb-c348-2371" primary="false">
@@ -2455,7 +3458,7 @@
           <selectionEntryGroups/>
           <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" costTypeId="points" value="100.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="af26-56e5-2cc3-41ab" name="Boar Stikka" hidden="false" collective="false" type="upgrade">
@@ -2604,7 +3607,7 @@
       <selectionEntryGroups/>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="100.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="bfed-dba3-ebd5-04b1" name="Savage Orruks" hidden="false" collective="false" type="unit">
@@ -2677,20 +3680,6 @@
           </conditions>
           <conditionGroups/>
         </modifier>
-        <modifier type="decrement" field="points" value="120">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="bfed-dba3-ebd5-04b1" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d7c0-be7c-766b-c015" type="greaterThan"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-        <modifier type="increment" field="points" value="120">
-          <repeats>
-            <repeat field="selections" scope="bfed-dba3-ebd5-04b1" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d7c0-be7c-766b-c015" repeats="1" roundUp="false"/>
-          </repeats>
-          <conditions/>
-          <conditionGroups/>
-        </modifier>
       </modifiers>
       <constraints/>
       <categoryLinks>
@@ -2738,7 +3727,7 @@
           <selectionEntryGroups/>
           <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" costTypeId="points" value="120.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -2816,7 +3805,7 @@
       </selectionEntryGroups>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="120.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c5d3-2af4-16d0-77cf" name="Savage Orruks Arrowboys" hidden="false" collective="false" type="unit">
@@ -2842,22 +3831,7 @@
       </profiles>
       <rules/>
       <infoLinks/>
-      <modifiers>
-        <modifier type="decrement" field="points" value="140">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="c5d3-2af4-16d0-77cf" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="123b-17cb-f474-facd" type="greaterThan"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-        <modifier type="increment" field="points" value="140">
-          <repeats>
-            <repeat field="selections" scope="c5d3-2af4-16d0-77cf" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="123b-17cb-f474-facd" repeats="1" roundUp="false"/>
-          </repeats>
-          <conditions/>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
+      <modifiers/>
       <constraints/>
       <categoryLinks>
         <categoryLink id="1fd6-c5cd-525d-fb5e" name="New CategoryLink" hidden="false" targetId="d963-a5fb-c348-2371" primary="false">
@@ -2904,7 +3878,7 @@
           <selectionEntryGroups/>
           <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" costTypeId="points" value="140.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="8a28-28b8-eede-af3e" name="Arrows" hidden="false" collective="false" type="upgrade">
@@ -2994,7 +3968,7 @@
           </constraints>
           <categoryLinks/>
           <selectionEntries>
-            <selectionEntry id="a24e-a583-18dc-b9fc" name="Choppa" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="a24e-a583-18dc-b9fc" name="Chompa" hidden="false" collective="false" type="upgrade">
               <profiles/>
               <rules/>
               <infoLinks>
@@ -3058,31 +4032,66 @@
             <cost name="pts" costTypeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
+        <selectionEntry id="abef-7ff5-5a9c-7e49" name="Bone Totems" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="42f9-76f3-b999-9fcc" name="Bone Totems" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="Unit Abilities">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="Models in this unit may carry Bone Totems. You can add 2 to the Bravery of all models in a unit that includes any Bone Totems as long as there is an enemy model within 3&quot; of the unit."/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3eb4-2072-07d1-3ff6" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5103-cac8-9c5a-9871" name="Skull Thumper" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="8cfa-8958-255c-845d" name="Skull Thumper" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="Unit Abilities">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="Models in this unit may be Skull Thumpers. You can add 2 to the charge rolls of a unit that includes any Skull Thumpers."/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1349-924e-61ae-ab70" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>
-      <entryLinks>
-        <entryLink id="e8f6-db16-5a22-b29f" name="Bone Totems" hidden="false" targetId="3161-5576-fd0e-88ad" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="3467-f135-db79-f418" name="Skull Thumper" hidden="false" targetId="ada3-b4ec-72d6-3f51" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-      </entryLinks>
+      <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="140.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="64ec-d3e1-bc29-aa24" name="Savage Orruks Morboys" hidden="false" collective="false" type="unit">
+    <selectionEntry id="64ec-d3e1-bc29-aa24" name="Savage Orruk Morboys" hidden="false" collective="false" type="unit">
       <profiles>
         <profile id="65e4-80c8-4f12-a03c" name="Savage Orruks Morboys" hidden="false" profileTypeId="1960-ca8e-67ce-2014" profileTypeName="Unit">
           <profiles/>
@@ -3125,20 +4134,6 @@
           </conditions>
           <conditionGroups/>
         </modifier>
-        <modifier type="decrement" field="points" value="120">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="64ec-d3e1-bc29-aa24" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6fc5-a96e-258e-b3cd" type="greaterThan"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-        <modifier type="increment" field="points" value="120">
-          <repeats>
-            <repeat field="selections" scope="64ec-d3e1-bc29-aa24" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6fc5-a96e-258e-b3cd" repeats="1" roundUp="false"/>
-          </repeats>
-          <conditions/>
-          <conditionGroups/>
-        </modifier>
       </modifiers>
       <constraints/>
       <categoryLinks>
@@ -3172,7 +4167,7 @@
         </categoryLink>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="6fc5-a96e-258e-b3cd" name="10 Savage Orruks Morboys" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="6fc5-a96e-258e-b3cd" name="10 Savage Orruk Morboys" hidden="false" collective="false" type="upgrade">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3186,7 +4181,7 @@
           <selectionEntryGroups/>
           <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" costTypeId="points" value="120.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="79f5-bd3e-ea02-7e41" name="Toof Shiv" hidden="false" collective="false" type="upgrade">
@@ -3246,28 +4241,63 @@
             <cost name="pts" costTypeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
+        <selectionEntry id="56d2-259e-e573-5d89" name="Bone Totems" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="a186-4866-3eae-9035" name="Bone Totems" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="Unit Abilities">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="Models in this unit may carry Bone Totems. You can add 2 to the Bravery of all models in a unit that includes any Bone Totems as long as there is an enemy model within 3&quot; of the unit."/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d7f-dc3e-6722-fb0d" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8906-fdd6-3f78-7508" name="Skull Thumper" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="e09d-4de6-cb15-54e7" name="Skull Thumper" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="Unit Abilities">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="Models in this unit may be Skull Thumpers. You can add 2 to the charge rolls of a unit that includes any Skull Thumpers."/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8cb4-12f2-6a8c-9802" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>
-      <entryLinks>
-        <entryLink id="2134-6b88-b7ba-297d" name="Bone Totems" hidden="false" targetId="3161-5576-fd0e-88ad" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="27e4-8c7a-4aa3-893e" name="Skull Thumper" hidden="false" targetId="ada3-b4ec-72d6-3f51" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-      </entryLinks>
+      <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="120.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="99a1-6ae4-4f8c-bc69" name="Wardokk" hidden="false" collective="false" type="unit">
@@ -3431,6 +4461,29 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
+        <entryLink id="da43-bec6-9852-248f" name="Warclan Extras" hidden="true" targetId="b384-5be7-036f-143c" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="688f-a281-d5d0-4f24" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="72b6-9777-df40-1149" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="de74-0645-34e8-23e4" type="instanceOf"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="100.0"/>
@@ -3454,17 +4507,17 @@
           <modifiers/>
           <characteristics>
             <characteristic name="Cast/Unbind" characteristicTypeId="8294-f605-2c0f-8f92" value="2"/>
-            <characteristic name="Spells Known" characteristicTypeId="dc9c-47d3-6931-859c" value="Arcane Bolt, Mystic Shield and Fists of Gork"/>
+            <characteristic name="Spells Known" characteristicTypeId="dc9c-47d3-6931-859c" value="Arcane Bolt, Mystic Shield, and Fists of Gork"/>
           </characteristics>
         </profile>
-        <profile id="5acb-ded5-46f7-d3f8" name="FISTS OF GORK" hidden="false" profileTypeId="2e81-5e22-c6e1-73cb" profileTypeName="Spell">
+        <profile id="5acb-ded5-46f7-d3f8" name="Fists of Gork" hidden="false" profileTypeId="2e81-5e22-c6e1-73cb" profileTypeName="Spell">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <characteristics>
             <characteristic name="Casting Value" characteristicTypeId="2508-b604-1258-a920" value="8"/>
-            <characteristic name="Description" characteristicTypeId="76ff-781d-b8e6-5f27" value="Fists of Gork has a casting value of 8. If successfully cast, pick an enemy unit within 18&quot;. Roll one dice for each model in the unit that is visible to the caster. The unit suffers 1 mortal wound for each roll of 6. If the casting roll was a double and the spell was cast, the unit suffers a mortal wound for each roll of 5 or more instead."/>
+            <characteristic name="Description" characteristicTypeId="76ff-781d-b8e6-5f27" value="If successfully cast, pick an enemy unit within 18&quot;. Roll one dice for each model in the unit that is visible to the caster. The unit suffers 1 mortal wound for each roll of 6. If the casting roll was a double and the spell was cast, the unit suffers a mortal wound for each roll of 5 or more instead."/>
           </characteristics>
         </profile>
         <profile id="e48e-bf33-5bb6-629b" name="Beast Mask" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="Unit Abilities">
@@ -3664,6 +4717,29 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
+        <entryLink id="d1da-68d7-8280-a982" name="Warclan Extras" hidden="true" targetId="b384-5be7-036f-143c" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="688f-a281-d5d0-4f24" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="72b6-9777-df40-1149" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="de74-0645-34e8-23e4" type="instanceOf"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="140.0"/>
@@ -3709,111 +4785,7 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="3161-5576-fd0e-88ad" name="Bone Totems" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="0c79-b29f-75e7-0138" name="Bone Totems" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="Unit Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="Models in this unit may carry Bone Totems. You can add 2 to the Bravery of all models in a unit that includes any Bone Totems as long as there is an enemy model within 3&quot; of the unit."/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7fff-2d57-8f46-828d" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="ada3-b4ec-72d6-3f51" name="Skull Thumper" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="4106-4a01-a903-fc05" name="Skull Thumper" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="Unit Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="Models in this unit may be Skull Thumpers. You can add 2 to the charge rolls of a unit that includes any Skull Thumpers."/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f7eb-16b0-4f10-9b77" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="088c-0ea5-45c9-94bf" name="Boar Totems" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="d8f2-ed8d-9fce-367b" name="Boar Totems" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="Unit Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="Models in this unit may carry Boar Totems. You can add 2 to the Bravery of all models in a unit that includes any Bone Totems as long as there is an enemy model within 3&quot; of the unit."/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0789-b424-a07e-5f00" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="657a-9295-b3cb-4f82" name="Boar Thumper" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="669c-728a-81a1-0a5d" name="Boar Thumper" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="Unit Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="Models in this unit may be Boar Thumpers. You can add 2 to the charge rolls of a unit that includes any Boar Thumpers."/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0fdd-371a-5787-ba70" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="999b-8d46-ee24-c8d5" name="Battalion: Icebone Warclan" book="" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="999b-8d46-ee24-c8d5" name="Super Battalion: Icebone Warclan" book="" hidden="false" collective="false" type="upgrade">
       <profiles>
         <profile id="8f70-2cbb-233d-772a" name="Freezin’ Weapons" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>
@@ -3833,13 +4805,27 @@
             <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Icebone Warclans use only the hardiest warboars to track their prey at great speed. Icebone Savage Boarboys, Savage Boarboy Maniaks and Maniak Weirdnobs have a Move of 11&quot; instead of 9&quot;."/>
           </characteristics>
         </profile>
-        <profile id="2b5d-846b-3e66-fd44" name="Extra Ju-Ju Warpaint" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+        <profile id="7f0c-460e-cdaa-0980" name="Extra Ju-Ju Warpaint" hidden="true" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="999b-8d46-ee24-c8d5" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1e46-775a-14ee-f898" type="equalTo"/>
+                    <condition field="selections" scope="999b-8d46-ee24-c8d5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="776e-54ab-6182-1d8c" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
           <characteristics>
-            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="If the battalion contains a Wurrgog Prophet and the maximum number of battalions, it gains the Extra Ju-ju Warpaint ability:  When a Savage Warclan gathers for battle, the shamans daub their warriors and war boars in an extra layer of warpaint making them especially lucky. You can re-roll all failed save rolls for models in a Savage Warclan, but the re-rolled saves will only be passed on the roll of a 6, irrespective of the unit’s actual Save characteristic or any modifiers that apply to the attack. In addition, you can re-roll the dice rolled to see if a Savage Warclan’s model’s warpaint saves them from any mortal wounds they suffer"/>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="You can re-roll all failed save rolls for models in a Savage Warclan, but the re-rolled saves will only be passed on the roll of a 6, irrespective of the unit’s actual Save characteristic or any modifiers that apply to the attack. In addition, you can re-roll the dice rolled to see if a Savage Warclan’s model’s warpaint saves them from any mortal wounds they suffer"/>
           </characteristics>
         </profile>
       </profiles>
@@ -3855,77 +4841,17 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="f2eb-e993-c5aa-7f88" name="Battalion: Snaga Rukk" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="b2fa-f0df-9927-8782" name="Maniak Stampede" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="When the enemy’s scent is in their nostrils, nothing can stop the boys of a Snaga Rukk from charging full pelt.In your hero phase, one Savage Boarboy Maniak unit from the Snaga Rukk can attempt to charge an enemy unit (if there is an eligible unit within 12&quot;) as if it were the charge phase. You can re-roll the charge roll if the Savage Boarboy Maniaks are within 10&quot; of either of the battalion’s Maniak Weirdnobs. If the charge is successful, roll a dice for each charging model that ends within 1&quot; of an enemy model: on a 4 or more, the enemy unit suffers a mortal wound. For each roll of 1, however, the charging unit suffers a mortal wound instead."/>
-              </characteristics>
-            </profile>
-          </profiles>
+        <categoryLink id="c041-28d9-04bf-3155" name="ICEBONE" hidden="false" targetId="de74-0645-34e8-23e4" primary="false">
+          <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="894b-78d4-66e6-f3f7" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01a8-cc9f-b6f8-070b" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="ff1f-76a8-6a38-33e2" name="Maniak Wierdnob" hidden="false" targetId="2d80-c52b-1ec8-3c5d" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b469-f75c-92de-dfba" type="max"/>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9f8-a895-7f67-af9a" type="min"/>
-              </constraints>
-              <categoryLinks>
-                <categoryLink id="296d-14cf-4c25-872f" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </categoryLink>
-              </categoryLinks>
-            </entryLink>
-            <entryLink id="01e2-b887-7ca3-c87d" name="Savage Boarboy Maniaks" hidden="false" targetId="52f0-7837-1600-09b4" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef1c-9a2d-4bcc-d031" type="min"/>
-                <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a170-acff-5894-5001" type="max"/>
-              </constraints>
-              <categoryLinks>
-                <categoryLink id="b187-e54b-5799-c99a" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </categoryLink>
-              </categoryLinks>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" costTypeId="points" value="140.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries/>
       <selectionEntryGroups>
-        <selectionEntryGroup id="1e46-775a-14ee-f898" name="Other Battalions" hidden="false" collective="false">
+        <selectionEntryGroup id="1e46-775a-14ee-f898" name="3. Other Battalions" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3934,19 +4860,138 @@
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d882-99fe-445e-429f" type="max"/>
           </constraints>
           <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="0fba-bf22-77fa-f719" name="Battalion: Brutal Rukk" hidden="false" targetId="ee34-6e96-2da0-46f0" type="selectionEntry">
-              <profiles/>
+          <selectionEntries>
+            <selectionEntry id="131e-5a51-7533-6906" name="Battalion: Brutal Rukk" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="e7f4-b69c-b201-d142" name="Savage Swiftness" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Orruks are always competing to be the first to get stuck in, and run at breakneck pace to fight the foe. You can re-roll the dice when determining how far a unit from a Brutal Rukk runs. The Brutal Rukk’s Savage Big Boss and any unit that starts their move within 10&quot; of the big boss always move an extra 6&quot; when they run (there is no need to roll the dice)."/>
+                  </characteristics>
+                </profile>
+              </profiles>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e30-bcd4-f92d-07b2" type="max"/>
-              </constraints>
+              <constraints/>
               <categoryLinks/>
-            </entryLink>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="b653-120b-74de-e709" name="2. Orruks and Boarboys (2 to 7)" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da36-3168-524f-c1ac" type="min"/>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae6c-9723-6b7c-373e" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="4aa8-8e31-7dde-750d" name="Savage Boarboys" hidden="false" targetId="00a3-3560-0e7e-4008" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks>
+                        <categoryLink id="ded9-9bd8-9d42-e8ed" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="false">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </categoryLink>
+                      </categoryLinks>
+                    </entryLink>
+                    <entryLink id="e99c-f914-1d4a-f517" name="Savage Orruks" hidden="false" targetId="bfed-dba3-ebd5-04b1" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks>
+                        <categoryLink id="f7b7-8453-2c61-8e57" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </categoryLink>
+                      </categoryLinks>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="8146-7c94-a44c-ddf2" name="1. Savage Big Boss" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f032-87c5-766e-28ad" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4fe6-0bc2-2ba9-d09d" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="98c6-c40c-33fb-2a62" name="Savage Big Boss" hidden="false" targetId="5e7e-f978-4c37-4666" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0df-0a09-304b-d640" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ec3-4b23-2446-4488" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="e9af-3b13-3630-5126" name="3. Wardokk" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <repeats/>
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ff95-682a-cd0b-3dbe" type="notInstanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="6bb1-0a03-a225-6612" name="Wardokk" hidden="false" targetId="99a1-6ae4-4f8c-bc69" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5506-216f-14d6-2e70" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="160.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
             <entryLink id="fa45-1097-b0b8-f47d" name="Battalion: Kop Rukk" hidden="false" targetId="048c-4aec-28ac-8cdf" type="selectionEntry">
               <profiles/>
               <rules/>
@@ -3969,19 +5014,230 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="af41-f073-6a49-1fcd" name="Warrgog Prophet" hidden="false" targetId="f6fa-7f5f-0836-e986" type="selectionEntry">
+        <selectionEntryGroup id="3098-77e2-2f0f-e398" name="4. Additional Bonesplitterz Units" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="5a50-2583-9fe8-76d5" name="Maniak Weirdnob" hidden="false" targetId="2d80-c52b-1ec8-3c5d" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="4eaa-da2e-0f97-3953" name="Savage Big Boss" hidden="false" targetId="5e7e-f978-4c37-4666" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="0fb5-a37c-546d-7135" name="Savage Big Stabbas" hidden="false" targetId="e930-136b-3f26-a52c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="3c72-029c-c941-69fd" name="Savage Boarboy Maniaks" hidden="false" targetId="52f0-7837-1600-09b4" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="3922-ccbb-2c91-735a" name="Savage Boarboys" hidden="false" targetId="00a3-3560-0e7e-4008" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="095e-754a-4ee8-e0eb" name="Savage Orruks" hidden="false" targetId="bfed-dba3-ebd5-04b1" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="38d9-9e44-a01e-2b5e" name="Savage Orruks Arrowboys" hidden="false" targetId="c5d3-2af4-16d0-77cf" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="daca-d322-6863-3c7b" name="Savage Orruks Morboys" hidden="false" targetId="64ec-d3e1-bc29-aa24" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="63e1-ff9a-a76c-871e" name="Wardokk" hidden="false" targetId="99a1-6ae4-4f8c-bc69" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="5e6f-f5d6-e94c-c588" name="Wurrgog Prophet" hidden="false" targetId="f6fa-7f5f-0836-e986" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="4d33-45f0-0745-3fd8" name="2. Wurrgog Prophet" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="776e-54ab-6182-1d8c" name="Wurrgog Prophet" hidden="false" targetId="f6fa-7f5f-0836-e986" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e6a-6e81-1180-ce7f" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="7234-8320-7a3c-f75c" name="1. Snaga Rukk" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f762-5bdb-ecbe-d62c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d08b-61e5-3ad5-abbe" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb2b-fca7-a44f-2062" type="min"/>
           </constraints>
           <categoryLinks/>
-        </entryLink>
-      </entryLinks>
+          <selectionEntries>
+            <selectionEntry id="f66b-9c44-f76f-bd7b" name="Battalion: Snaga Rukk" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="3007-fdc0-d5ab-302c" name="Maniak Stampede" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="When the enemy’s scent is in their nostrils, nothing can stop the boys of a Snaga Rukk from charging full pelt.In your hero phase, one Savage Boarboy Maniak unit from the Snaga Rukk can attempt to charge an enemy unit (if there is an eligible unit within 12&quot;) as if it were the charge phase. You can re-roll the charge roll if the Savage Boarboy Maniaks are within 10&quot; of either of the battalion’s Maniak Weirdnobs. If the charge is successful, roll a dice for each charging model that ends within 1&quot; of an enemy model: on a 4 or more, the enemy unit suffers a mortal wound. For each roll of 1, however, the charging unit suffers a mortal wound instead."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="b446-4d2c-4ed5-9374" name="1. Maniak Weirdnobs" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e31e-64b8-ca77-f40e" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d730-fd29-55e7-2b0e" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="76f1-919e-4e1d-a0fb" name="Maniak Weirdnob" hidden="false" targetId="2d80-c52b-1ec8-3c5d" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f2b-d385-57e5-af5a" type="max"/>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2944-b731-70f1-b17c" type="min"/>
+                      </constraints>
+                      <categoryLinks>
+                        <categoryLink id="fc75-4f04-4c07-6eff" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </categoryLink>
+                      </categoryLinks>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="08a6-0570-8347-f3e8" name="2. Savage Boarboy Maniaks (4 to 15)" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f56a-4c77-105d-bdf1" type="max"/>
+                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e472-50ae-faee-62c4" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="c676-6e3a-0c8c-196c" name="Savage Boarboy Maniaks" hidden="false" targetId="52f0-7837-1600-09b4" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80ee-1baf-4e8e-68f6" type="min"/>
+                        <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b75-49fa-0c5e-50f0" type="max"/>
+                      </constraints>
+                      <categoryLinks>
+                        <categoryLink id="7a74-2d5b-6b87-9c8f" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </categoryLink>
+                      </categoryLinks>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="170.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="160.0"/>
       </costs>
@@ -4533,7 +5789,15 @@
       <profiles/>
       <rules/>
       <infoLinks/>
-      <modifiers/>
+      <modifiers>
+        <modifier type="set" field="bbc4-2edc-7570-6192" value="0.0">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0be7-af29-227d-5efb" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bbc4-2edc-7570-6192" type="max"/>
       </constraints>
@@ -4595,6 +5859,13 @@
           </conditions>
           <conditionGroups/>
         </modifier>
+        <modifier type="set" field="8712-b467-8b4a-c3c4" value="0.0">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f180-6d47-0fdb-d77f" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
       </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8712-b467-8b4a-c3c4" type="max"/>
@@ -4621,65 +5892,247 @@
         </entryLink>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="aa5d-e75c-1634-d90b" name="Chop, Dice, Shoot" hidden="false" collective="false">
+    <selectionEntryGroup id="b384-5be7-036f-143c" name="Warclan Extras" hidden="false" collective="false">
       <profiles/>
       <rules/>
       <infoLinks/>
       <modifiers>
-        <modifier type="increment" field="37e5-f755-df11-074c" value="2">
+        <modifier type="set" field="hidden" value="false">
           <repeats/>
-          <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c6c7-ed8c-6e54-f7f8" type="instanceOf"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-        <modifier type="increment" field="169e-41ef-e0d5-5c81" value="5">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c6c7-ed8c-6e54-f7f8" type="instanceOf"/>
-          </conditions>
-          <conditionGroups/>
+          <conditions/>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="688f-a281-d5d0-4f24" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="72b6-9777-df40-1149" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="de74-0645-34e8-23e4" type="instanceOf"/>
+              </conditions>
+              <conditionGroups/>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
-      <constraints>
-        <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="169e-41ef-e0d5-5c81" type="max"/>
-        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="37e5-f755-df11-074c" type="min"/>
-      </constraints>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries>
+        <selectionEntry id="f180-6d47-0fdb-d77f" name="Bring it Down, Ladz" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="417a-85c1-867f-5af6" name="Bring it Down, Ladz" hidden="false" profileTypeId="c749-bae4-71a8-0c36" profileTypeName="Command Trait">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Command Trait Details" characteristicTypeId="ee96-6f3a-e5ca-2350" value="Instead of rolling on the Monster Hunters table, your general and any friendly Bonegrinz unit within 12&quot; can always choose their result."/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="688f-a281-d5d0-4f24" type="notInstanceOf"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b745-17c4-8fbf-8b04" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fab9-7be1-1aab-aaa5" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87f0-4d69-0c61-232a" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0be7-af29-227d-5efb" name="Da Icebone Skull" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="677e-e9e8-cf57-03f5" name="Da Icebone Skull" hidden="false" profileTypeId="0ac4-aacb-2481-8e72" profileTypeName="Artefact">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Artefact Details" characteristicTypeId="0918-c47a-d84e-c0cf" value="This ancient, crystallized skull bestows the bearer with the endurance of an everlasting winter. All damage suffered by the bearer is halved (rounding down). In addition, the bearer heals 1 wound in each of your hero phases."/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="de74-0645-34e8-23e4" type="notInstanceOf"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f224-9a8a-59fe-58b2" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf67-c833-2947-2368" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1a80-8e21-ab27-e02c" name="Blood Waaagh!" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="8967-4856-b661-5e2d" name="Blood Waaagh!" hidden="false" profileTypeId="2e81-5e22-c6e1-73cb" profileTypeName="Spell">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Casting Value" characteristicTypeId="2508-b604-1258-a920" value="8"/>
+                <characteristic name="Description" characteristicTypeId="76ff-781d-b8e6-5f27" value="If successfully cast, pick a BONESPLITTERZ unit within 6&quot;. That unit can immediately pile in and attack as if it were the combat phase.  Only one WIZARD can attempt to cast Blood Waaagh! in each hero phase."/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="72b6-9777-df40-1149" type="notInstanceOf"/>
+                  </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f53-8230-2f02-9639" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="72b6-9777-df40-1149" type="notInstanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="55e6-caa3-344d-182c" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9767-2f57-471e-27ac" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="3135-5fd5-a577-157e" name="Additional Bonesplitterz Units" hidden="false" collective="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
       <categoryLinks/>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="d35e-e5d4-47e1-0d45" name="Savage Orruks" hidden="false" targetId="bfed-dba3-ebd5-04b1" type="selectionEntry">
+        <entryLink id="e591-0f3e-e888-8eb3" name="Maniak Weirdnob" hidden="false" targetId="2d80-c52b-1ec8-3c5d" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints/>
-          <categoryLinks>
-            <categoryLink id="20b3-51e8-defc-b0df" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </categoryLink>
-          </categoryLinks>
+          <categoryLinks/>
         </entryLink>
-        <entryLink id="5f29-1a63-505b-5aa3" name="Savage Orruks Arrowboys" hidden="false" targetId="c5d3-2af4-16d0-77cf" type="selectionEntry">
+        <entryLink id="1466-d7a3-6186-b2cc" name="Savage Big Boss" hidden="false" targetId="5e7e-f978-4c37-4666" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints/>
-          <categoryLinks>
-            <categoryLink id="8c4b-37dd-506f-f90a" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </categoryLink>
-          </categoryLinks>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="e17a-633e-1378-87b8" name="Savage Big Stabbas" hidden="false" targetId="e930-136b-3f26-a52c" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="098c-f3be-ed21-5ac7" name="Savage Boarboy Maniaks" hidden="false" targetId="52f0-7837-1600-09b4" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="c79c-1c07-5ac1-efab" name="Savage Boarboys" hidden="false" targetId="00a3-3560-0e7e-4008" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="f2ad-6f1c-1779-6b24" name="Savage Orruks" hidden="false" targetId="bfed-dba3-ebd5-04b1" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="0b40-12be-e1cd-8822" name="Savage Orruks Arrowboys" hidden="false" targetId="c5d3-2af4-16d0-77cf" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="cc4d-0d8f-2f35-85ad" name="Savage Orruks Morboys" hidden="false" targetId="64ec-d3e1-bc29-aa24" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="03b5-8d2e-9919-2358" name="Wardokk" hidden="false" targetId="99a1-6ae4-4f8c-bc69" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="64c9-0f06-bd7d-d6f5" name="Wurrgog Prophet" hidden="false" targetId="f6fa-7f5f-0836-e986" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
         </entryLink>
       </entryLinks>
     </selectionEntryGroup>
@@ -4802,7 +6255,7 @@
         <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
       </characteristics>
     </profile>
-    <profile id="0b24-24d0-8dba-5d4d" name="Choppa" hidden="false" profileTypeId="96df-ab28-5d72-bbb3">
+    <profile id="0b24-24d0-8dba-5d4d" name="Chompa" hidden="false" profileTypeId="96df-ab28-5d72-bbb3">
       <profiles/>
       <rules/>
       <infoLinks/>

--- a/Destruction - Gloomspite Gitz.cat
+++ b/Destruction - Gloomspite Gitz.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="750c-157c-3186-61d3" name="Destruction - Gloomspite Gitz" revision="9" battleScribeVersion="2.01" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="46" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="750c-157c-3186-61d3" name="Destruction - Gloomspite Gitz" revision="8" battleScribeVersion="2.01" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="46" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -55,6 +55,11 @@
     <profileType id="8b8c-5816-cbdb-9763" name="Unit Leader">
       <characteristicTypes>
         <characteristicType id="afb5-0652-767a-6769" name="Leader Ability"/>
+      </characteristicTypes>
+    </profileType>
+    <profileType id="31b3-8f26-7440-0ef9" name="D66">
+      <characteristicTypes>
+        <characteristicType id="9b5b-c24f-0e53-38a8" name="Strategem"/>
       </characteristicTypes>
     </profileType>
   </profileTypes>
@@ -129,49 +134,7 @@
       <modifiers/>
       <constraints/>
     </categoryEntry>
-    <categoryEntry id="a8ff-ab17-1842-65c7" name="GARGANT" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-    </categoryEntry>
-    <categoryEntry id="2cba-fb76-3dfa-b3f2" name="ALEGUZZLER" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-    </categoryEntry>
-    <categoryEntry id="c192-cb67-640b-fb3b" name="BONEGRINDER GARGANT" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-    </categoryEntry>
-    <categoryEntry id="9f49-6a9c-8b4d-7f38" name="COLOSSAL SQUIG" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-    </categoryEntry>
-    <categoryEntry id="e9ce-ea44-3505-1b68" name="FELLWATER" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-    </categoryEntry>
-    <categoryEntry id="d151-7ebd-e541-42d8" name="TROGGOTH HAG" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-    </categoryEntry>
-    <categoryEntry id="92dc-9b79-472e-37fe" name="SQUIG GOBBA" hidden="false">
+    <categoryEntry id="93bb-0e9a-301c-169c" name="ALEGUZZLER" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -225,7 +188,15 @@
       <profiles/>
       <rules/>
       <infoLinks/>
-      <modifiers/>
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="edba-4107-8dd7-8613" type="greaterThan"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
       <constraints/>
       <categoryLinks>
         <categoryLink id="539e-da6f-2491-3685" name="Battalion" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
@@ -257,7 +228,15 @@
       <profiles/>
       <rules/>
       <infoLinks/>
-      <modifiers/>
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="edba-4107-8dd7-8613" type="greaterThan"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
       <constraints/>
       <categoryLinks>
         <categoryLink id="f78e-757a-032d-63f6" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
@@ -273,7 +252,15 @@
       <profiles/>
       <rules/>
       <infoLinks/>
-      <modifiers/>
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="edba-4107-8dd7-8613" type="greaterThan"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
       <constraints/>
       <categoryLinks>
         <categoryLink id="80d9-404a-38d1-e227" name="HERO" hidden="false" targetId="4e0e-664d-51ea-0929" primary="false">
@@ -397,6 +384,7 @@
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e404-398e-c044-e29a" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="edba-4107-8dd7-8613" type="greaterThan"/>
               </conditions>
               <conditionGroups/>
             </conditionGroup>
@@ -429,6 +417,7 @@
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e404-398e-c044-e29a" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="edba-4107-8dd7-8613" type="greaterThan"/>
               </conditions>
               <conditionGroups/>
             </conditionGroup>
@@ -450,7 +439,15 @@
       <profiles/>
       <rules/>
       <infoLinks/>
-      <modifiers/>
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="edba-4107-8dd7-8613" type="greaterThan"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
       <constraints/>
       <categoryLinks>
         <categoryLink id="0df9-0eea-b4bd-29a2" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
@@ -549,6 +546,7 @@
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e404-398e-c044-e29a" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="edba-4107-8dd7-8613" type="greaterThan"/>
               </conditions>
               <conditionGroups/>
             </conditionGroup>
@@ -573,10 +571,16 @@
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <repeats/>
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e404-398e-c044-e29a" type="greaterThan"/>
-          </conditions>
-          <conditionGroups/>
+          <conditions/>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e404-398e-c044-e29a" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="edba-4107-8dd7-8613" type="greaterThan"/>
+              </conditions>
+              <conditionGroups/>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <constraints/>
@@ -845,7 +849,15 @@
       <profiles/>
       <rules/>
       <infoLinks/>
-      <modifiers/>
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="edba-4107-8dd7-8613" type="greaterThan"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
       <constraints/>
       <categoryLinks>
         <categoryLink id="fe62-f596-636a-b781" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
@@ -1011,7 +1023,15 @@
       <profiles/>
       <rules/>
       <infoLinks/>
-      <modifiers/>
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="edba-4107-8dd7-8613" type="greaterThan"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
       <constraints/>
       <categoryLinks>
         <categoryLink id="923a-f632-0c3d-a950" name="HERO" hidden="false" targetId="4e0e-664d-51ea-0929" primary="false">
@@ -1080,7 +1100,15 @@
       <profiles/>
       <rules/>
       <infoLinks/>
-      <modifiers/>
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="edba-4107-8dd7-8613" type="greaterThan"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
       <constraints/>
       <categoryLinks>
         <categoryLink id="a4a5-4d4b-3ddc-2bb3" name="DESTRUCTION" hidden="false" targetId="d963-a5fb-c348-2371" primary="false">
@@ -1235,7 +1263,15 @@
       <profiles/>
       <rules/>
       <infoLinks/>
-      <modifiers/>
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="edba-4107-8dd7-8613" type="greaterThan"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
       <constraints/>
       <categoryLinks>
         <categoryLink id="0a1a-19fb-cf00-4f3c" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
@@ -2971,6 +3007,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="182b-d13a-31b2-fef5" name="MONSTER" hidden="false" targetId="1959-9f6a-3056-913a" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="10b3-188e-1958-5bc2" name="ALEGUZZLER" hidden="false" targetId="93bb-0e9a-301c-169c" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5167,13 +5210,6 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="26da-6ad5-bb72-78b4" name="TROGGOTH" hidden="false" targetId="be2b-5e91-b381-5671" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-        <categoryLink id="a469-dcf0-61fc-5d2c" name="TROGGBOSS" hidden="false" targetId="b98e-fa5a-4d20-1b47" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -9677,20 +9713,6 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="9916-9c3e-01e8-8f27" name="FELLWATER" hidden="false" targetId="e9ce-ea44-3505-1b68" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-        <categoryLink id="2e3d-a304-5a23-9f2c" name="TROGGOTH HAG" hidden="false" targetId="d151-7ebd-e541-42d8" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="61c9-012e-dd47-25b6" name="Wounds Suffered" hidden="false" collective="false" type="upgrade">
@@ -10130,21 +10152,7 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="5565-f000-0f10-2ca0" name="ALEGUZZLER" hidden="false" targetId="2cba-fb76-3dfa-b3f2" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-        <categoryLink id="8d35-3ec0-bee5-42ee" name="BONEGRINDER GARGANT" hidden="false" targetId="c192-cb67-640b-fb3b" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-        <categoryLink id="f2d3-935c-89c3-fdf8" name="GARGANT" hidden="false" targetId="a8ff-ab17-1842-65c7" primary="false">
+        <categoryLink id="fd37-effe-e116-c45d" name="ALEGUZZLER" hidden="false" targetId="93bb-0e9a-301c-169c" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -10420,13 +10428,6 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="157d-f3ef-fd7d-4eb1" name="COLOSSAL SQUIG" hidden="false" targetId="9f49-6a9c-8b4d-7f38" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="3a48-f3f4-7c7a-ef8e" name="Wounds Suffered" hidden="false" collective="false" type="upgrade">
@@ -10672,13 +10673,6 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
-        <categoryLink id="64c7-6dc3-6d3e-0235" name="SQUIG GOBBA" hidden="false" targetId="92dc-9b79-472e-37fe" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="b739-483a-693c-5f80" name="Spit-squigs" hidden="false" collective="false" type="upgrade">
@@ -10866,27 +10860,6 @@
           </constraints>
           <categoryLinks/>
           <selectionEntries>
-            <selectionEntry id="3328-f51d-31c3-6d4b" name="*Destruction*" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="3886-31e4-7043-a85f" name="Rampaging Destroyers" hidden="false" targetId="4571-8f36-98ca-2d16" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
             <selectionEntry id="f8e3-641a-7a46-2f84" name="Gloomspite Gitz" hidden="false" collective="false" type="upgrade">
               <profiles>
                 <profile id="aa00-e721-3551-b962" name="The Bad Moon" hidden="false" profileTypeId="c137-4d1f-9d1a-524d" profileTypeName="Battle Trait">
@@ -10988,6 +10961,194 @@
                 </selectionEntry>
               </selectionEntries>
               <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2d13-f8f8-53ec-de7c" name="*Destruction*" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="1e1f-3d37-f5dd-49c7" name="Rampaging Destroyers" hidden="false" targetId="4571-8f36-98ca-2d16" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="ae04-e3dc-c4f4-64f9" name="Firestorm: Stoneklaw&apos;s Gutstompas" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af62-f576-2d92-c843" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ad3-94b6-efa5-25c6" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries>
+                    <selectionEntry id="edba-4107-8dd7-8613" name="Stoneklaw&apos;s Gutstompas" hidden="false" collective="false" type="upgrade">
+                      <profiles>
+                        <profile id="e025-0362-f9cf-47f3" name="Insane Advice" hidden="false" profileTypeId="c137-4d1f-9d1a-524d" profileTypeName="Battle Trait">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <characteristics>
+                            <characteristic name="Battle Trait Details" characteristicTypeId="9fdd-b4b1-5f7a-0970" value="After setting up, but before the first battle round begins, make two D66 rolls to determine the advice given to Stoneklaw by his pair of severed heads. You must pick one of the rolls, which is the advice that is followed.  The advice allows you to use a stratagem without having to spend strategy points in order to do so, and it also allows you to use the stratagem in a non-campaign game where strategy points are not being used."/>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks/>
+                      <selectionEntries>
+                        <selectionEntry id="a21b-0a78-d46a-7bfe" name="Insane Advice Table" hidden="false" collective="false" type="upgrade">
+                          <profiles>
+                            <profile id="6be7-74a5-5355-6a04" name="11-13" hidden="false" profileTypeId="31b3-8f26-7440-0ef9" profileTypeName="Insane Advice Table">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <characteristics>
+                                <characteristic name="Strategem" characteristicTypeId="9b5b-c24f-0e53-38a8" value="Choose a result."/>
+                              </characteristics>
+                            </profile>
+                            <profile id="1482-1acd-b073-1665" name="61-63" hidden="false" profileTypeId="31b3-8f26-7440-0ef9" profileTypeName="Insane Advice Table">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <characteristics>
+                                <characteristic name="Strategem" characteristicTypeId="9b5b-c24f-0e53-38a8" value="Regicide"/>
+                              </characteristics>
+                            </profile>
+                            <profile id="039f-9d71-0226-1b9c" name="54-56" hidden="false" profileTypeId="31b3-8f26-7440-0ef9" profileTypeName="Insane Advice Table">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <characteristics>
+                                <characteristic name="Strategem" characteristicTypeId="9b5b-c24f-0e53-38a8" value="Redeploy"/>
+                              </characteristics>
+                            </profile>
+                            <profile id="8ca6-1947-b961-566e" name="51-53" hidden="false" profileTypeId="31b3-8f26-7440-0ef9" profileTypeName="Insane Advice Table">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <characteristics>
+                                <characteristic name="Strategem" characteristicTypeId="9b5b-c24f-0e53-38a8" value="Pre-emptive Attack"/>
+                              </characteristics>
+                            </profile>
+                            <profile id="c56d-bec9-8556-115a" name="44-46" hidden="false" profileTypeId="31b3-8f26-7440-0ef9" profileTypeName="Insane Advice Table">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <characteristics>
+                                <characteristic name="Strategem" characteristicTypeId="9b5b-c24f-0e53-38a8" value="Night Attack"/>
+                              </characteristics>
+                            </profile>
+                            <profile id="9c90-2473-8309-9d8c" name="41-43" hidden="false" profileTypeId="31b3-8f26-7440-0ef9" profileTypeName="Insane Advice Table">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <characteristics>
+                                <characteristic name="Strategem" characteristicTypeId="9b5b-c24f-0e53-38a8" value="Inspiring Speech"/>
+                              </characteristics>
+                            </profile>
+                            <profile id="88ab-fa81-ce69-24db" name="34-36" hidden="false" profileTypeId="31b3-8f26-7440-0ef9" profileTypeName="Insane Advice Table">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <characteristics>
+                                <characteristic name="Strategem" characteristicTypeId="9b5b-c24f-0e53-38a8" value="Hatred"/>
+                              </characteristics>
+                            </profile>
+                            <profile id="5969-0c81-a9a8-80d4" name="31-33" hidden="false" profileTypeId="31b3-8f26-7440-0ef9" profileTypeName="Insane Advice Table">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <characteristics>
+                                <characteristic name="Strategem" characteristicTypeId="9b5b-c24f-0e53-38a8" value="Forced March"/>
+                              </characteristics>
+                            </profile>
+                            <profile id="b0ef-3e75-28d6-d8a3" name="24-26" hidden="false" profileTypeId="31b3-8f26-7440-0ef9" profileTypeName="Insane Advice Table">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <characteristics>
+                                <characteristic name="Strategem" characteristicTypeId="9b5b-c24f-0e53-38a8" value="Firestarter"/>
+                              </characteristics>
+                            </profile>
+                            <profile id="8ea8-5c66-cc85-b884" name="14-16" hidden="false" profileTypeId="31b3-8f26-7440-0ef9" profileTypeName="Insane Advice Table">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <characteristics>
+                                <characteristic name="Strategem" characteristicTypeId="9b5b-c24f-0e53-38a8" value="Ambush"/>
+                              </characteristics>
+                            </profile>
+                            <profile id="f769-b395-b7ac-bf0e" name="21-23" hidden="false" profileTypeId="31b3-8f26-7440-0ef9" profileTypeName="Insane Advice Table">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <characteristics>
+                                <characteristic name="Strategem" characteristicTypeId="9b5b-c24f-0e53-38a8" value="Feigned Retreat"/>
+                              </characteristics>
+                            </profile>
+                            <profile id="1f91-6fcf-4a73-451a" name="64-66" hidden="false" profileTypeId="31b3-8f26-7440-0ef9" profileTypeName="Insane Advice Table">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <characteristics>
+                                <characteristic name="Strategem" characteristicTypeId="9b5b-c24f-0e53-38a8" value="Reinforcements"/>
+                              </characteristics>
+                            </profile>
+                          </profiles>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cdb2-bdb2-6e14-8400" type="max"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b12e-8dc2-7547-6ec6" type="min"/>
+                          </constraints>
+                          <categoryLinks/>
+                          <selectionEntries/>
+                          <selectionEntryGroups/>
+                          <entryLinks/>
+                          <costs>
+                            <cost name="pts" costTypeId="points" value="0.0"/>
+                          </costs>
+                        </selectionEntry>
+                      </selectionEntries>
+                      <selectionEntryGroups/>
+                      <entryLinks/>
+                      <costs>
+                        <cost name="pts" costTypeId="points" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
               <entryLinks/>
               <costs>
                 <cost name="pts" costTypeId="points" value="0.0"/>
@@ -12631,7 +12792,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3328-f51d-31c3-6d4b" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2d13-f8f8-53ec-de7c" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -13463,7 +13624,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3328-f51d-31c3-6d4b" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2d13-f8f8-53ec-de7c" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -13620,7 +13781,7 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3328-f51d-31c3-6d4b" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2d13-f8f8-53ec-de7c" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>

--- a/Destruction - Ironjawz.cat
+++ b/Destruction - Ironjawz.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="fda2-055f-0f40-2e23" name="Destruction - Ironjawz" book="Destruction Battletome: Ironjawz" revision="12" battleScribeVersion="2.01" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="6" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="fda2-055f-0f40-2e23" name="Destruction - Ironjawz" book="Destruction Battletome: Ironjawz" revision="15" battleScribeVersion="2.01" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="6" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -24,6 +24,11 @@
         <characteristicType id="85cc-4c75-0058-b8f6" name="Move"/>
         <characteristicType id="89c3-c419-d973-8625" name="Mighty Fists"/>
         <characteristicType id="51f4-7738-ea97-df2b" name="Destructive Bulk"/>
+      </characteristicTypes>
+    </profileType>
+    <profileType id="341f-0e93-bc23-fb03" name="D66">
+      <characteristicTypes>
+        <characteristicType id="1250-a611-a8a1-287d" name="Strategem"/>
       </characteristicTypes>
     </profileType>
   </profileTypes>
@@ -615,7 +620,15 @@
       <profiles/>
       <rules/>
       <infoLinks/>
-      <modifiers/>
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c97b-ef6e-0177-f377" type="greaterThan"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
       <constraints/>
       <categoryLinks>
         <categoryLink id="f428-4a8d-4016-12be" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
@@ -647,7 +660,9 @@
           <conditions/>
           <conditionGroups>
             <conditionGroup type="or">
-              <conditions/>
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c97b-ef6e-0177-f377" type="greaterThan"/>
+              </conditions>
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
@@ -682,7 +697,9 @@
           <conditions/>
           <conditionGroups>
             <conditionGroup type="or">
-              <conditions/>
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c97b-ef6e-0177-f377" type="greaterThan"/>
+              </conditions>
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
@@ -757,7 +774,174 @@
               </constraints>
               <categoryLinks/>
               <selectionEntries/>
-              <selectionEntryGroups/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="5ac9-586d-6b97-e526" name="Firestorm: Stoneklaw&apos;s Gutstompas" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d907-1233-5fd8-a206" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="048f-d454-44f0-03ca" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries>
+                    <selectionEntry id="c97b-ef6e-0177-f377" name="Stoneklaw&apos;s Gutstompas" hidden="false" collective="false" type="upgrade">
+                      <profiles>
+                        <profile id="9736-fda7-421a-ecb7" name="Insane Advice" hidden="false" profileTypeId="c137-4d1f-9d1a-524d" profileTypeName="Battle Trait">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <characteristics>
+                            <characteristic name="Battle Trait Details" characteristicTypeId="9fdd-b4b1-5f7a-0970" value="After setting up, but before the first battle round begins, make two D66 rolls to determine the advice given to Stoneklaw by his pair of severed heads. You must pick one of the rolls, which is the advice that is followed.  The advice allows you to use a stratagem without having to spend strategy points in order to do so, and it also allows you to use the stratagem in a non-campaign game where strategy points are not being used."/>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks/>
+                      <selectionEntries>
+                        <selectionEntry id="803d-825f-4c73-2c84" name="Insane Advice Table" hidden="false" collective="false" type="upgrade">
+                          <profiles>
+                            <profile id="7b00-5ae4-a743-101b" name="11-13" hidden="false" profileTypeId="341f-0e93-bc23-fb03" profileTypeName="D66">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <characteristics>
+                                <characteristic name="Strategem" characteristicTypeId="1250-a611-a8a1-287d" value="Choose a result."/>
+                              </characteristics>
+                            </profile>
+                            <profile id="7e27-01cb-00b7-b42e" name="61-63" hidden="false" profileTypeId="341f-0e93-bc23-fb03" profileTypeName="D66">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <characteristics>
+                                <characteristic name="Strategem" characteristicTypeId="1250-a611-a8a1-287d" value="Regicide"/>
+                              </characteristics>
+                            </profile>
+                            <profile id="90a6-b2fb-c8fd-4402" name="54-56" hidden="false" profileTypeId="341f-0e93-bc23-fb03" profileTypeName="D66">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <characteristics>
+                                <characteristic name="Strategem" characteristicTypeId="1250-a611-a8a1-287d" value="Redeploy"/>
+                              </characteristics>
+                            </profile>
+                            <profile id="b09b-57b5-aee9-911c" name="51-53" hidden="false" profileTypeId="341f-0e93-bc23-fb03" profileTypeName="D66">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <characteristics>
+                                <characteristic name="Strategem" characteristicTypeId="1250-a611-a8a1-287d" value="Pre-emptive Attack"/>
+                              </characteristics>
+                            </profile>
+                            <profile id="6f35-d5f2-8ca3-3fb6" name="44-46" hidden="false" profileTypeId="341f-0e93-bc23-fb03" profileTypeName="D66">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <characteristics>
+                                <characteristic name="Strategem" characteristicTypeId="1250-a611-a8a1-287d" value="Night Attack"/>
+                              </characteristics>
+                            </profile>
+                            <profile id="144e-b1ca-fcfc-a79d" name="41-43" hidden="false" profileTypeId="341f-0e93-bc23-fb03" profileTypeName="D66">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <characteristics>
+                                <characteristic name="Strategem" characteristicTypeId="1250-a611-a8a1-287d" value="Inspiring Speech"/>
+                              </characteristics>
+                            </profile>
+                            <profile id="15f6-986e-4d8f-2586" name="34-36" hidden="false" profileTypeId="341f-0e93-bc23-fb03" profileTypeName="D66">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <characteristics>
+                                <characteristic name="Strategem" characteristicTypeId="1250-a611-a8a1-287d" value="Hatred"/>
+                              </characteristics>
+                            </profile>
+                            <profile id="3f4c-568c-78a8-fbc3" name="31-33" hidden="false" profileTypeId="341f-0e93-bc23-fb03" profileTypeName="D66">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <characteristics>
+                                <characteristic name="Strategem" characteristicTypeId="1250-a611-a8a1-287d" value="Forced March"/>
+                              </characteristics>
+                            </profile>
+                            <profile id="5ae3-46b1-51f3-9b9b" name="24-26" hidden="false" profileTypeId="341f-0e93-bc23-fb03" profileTypeName="D66">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <characteristics>
+                                <characteristic name="Strategem" characteristicTypeId="1250-a611-a8a1-287d" value="Firestarter"/>
+                              </characteristics>
+                            </profile>
+                            <profile id="efe6-8278-ccc1-a7c2" name="14-16" hidden="false" profileTypeId="341f-0e93-bc23-fb03" profileTypeName="D66">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <characteristics>
+                                <characteristic name="Strategem" characteristicTypeId="1250-a611-a8a1-287d" value="Ambush"/>
+                              </characteristics>
+                            </profile>
+                            <profile id="3a51-1ade-d055-adad" name="21-23" hidden="false" profileTypeId="341f-0e93-bc23-fb03" profileTypeName="D66">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <characteristics>
+                                <characteristic name="Strategem" characteristicTypeId="1250-a611-a8a1-287d" value="Feigned Retreat"/>
+                              </characteristics>
+                            </profile>
+                            <profile id="1e3b-8b80-2880-4426" name="64-66" hidden="false" profileTypeId="341f-0e93-bc23-fb03" profileTypeName="D66">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <characteristics>
+                                <characteristic name="Strategem" characteristicTypeId="1250-a611-a8a1-287d" value="Reinforcements"/>
+                              </characteristics>
+                            </profile>
+                          </profiles>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50c3-317d-e4e1-52b7" type="max"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="367e-2c94-aa26-f47b" type="min"/>
+                          </constraints>
+                          <categoryLinks/>
+                          <selectionEntries/>
+                          <selectionEntryGroups/>
+                          <entryLinks/>
+                          <costs>
+                            <cost name="pts" costTypeId="points" value="0.0"/>
+                          </costs>
+                        </selectionEntry>
+                      </selectionEntries>
+                      <selectionEntryGroups/>
+                      <entryLinks/>
+                      <costs>
+                        <cost name="pts" costTypeId="points" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
               <entryLinks/>
               <costs>
                 <cost name="pts" costTypeId="points" value="0.0"/>
@@ -895,7 +1079,7 @@
         <cost name="pts" costTypeId="points" value="170.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="182d-d1bc-030a-6091" name="Battalion: Brawl" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="182d-d1bc-030a-6091" name="Super Battalion: Brawl" hidden="false" collective="false" type="upgrade">
       <profiles>
         <profile id="3937-cc30-6d58-a5c0" name="Big Waaagh!" hidden="false" profileTypeId="f71f-b0a4-730e-ced3">
           <profiles/>
@@ -1069,7 +1253,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="A BRUTEFIST is a living tide of destruction that can pulverise even the toughest of foes. In your hero phase, units from the battalion within 10&quot; of its BRUTE BIG BOSS (including his own unit) can make a charge move as if it were the charge phase. If the charge is successful, pick one enemy unit within 3&quot; of the unit that charged; it suffers D3 mortal wounds."/>
+            <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="In your hero phase, units from the battalion within 10&quot; of its BRUTE BIG BOSS (including his own unit) can make a charge move as if it were the charge phase. If the charge is successful, pick one enemy unit within 3&quot; of the unit that charged; it suffers D3 mortal wounds."/>
           </characteristics>
         </profile>
       </profiles>
@@ -1080,7 +1264,7 @@
       <categoryLinks/>
       <selectionEntries/>
       <selectionEntryGroups>
-        <selectionEntryGroup id="eb12-57ef-1e47-2aaf" name="Brutefist" hidden="false" collective="false" defaultSelectionEntryId="438d-8ccb-c17f-7ef4">
+        <selectionEntryGroup id="eb12-57ef-1e47-2aaf" name="Brutes (3 to 5)" hidden="false" collective="false" defaultSelectionEntryId="438d-8ccb-c17f-7ef4">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1134,7 +1318,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="GORE GRUNTA BIG BOSS often come up with cunning formations, like the Tusks of Gork or the Snorting Snout Spear. You can tell your opponent that this battalion is in such a formation when you set it up if all of the units are within 10&quot; of the BIG BOSS&apos; unit (you should also come up with a name for the formation!). The formation allows all of the units in the battalion to make a move of 15&quot; in the hero phase of their first turn. The move is made as if it were the movement phase, except that the units cannot run. It does not stop the units from moving again normally later in the turn. After the first turn is over, the formation dissolves into anarchy and the normal rules apply for the rest of the battle."/>
+            <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="You can tell your opponent that this battalion is in a formation when you set it up if all of the units are within 10&quot; of the BIG BOSS&apos;s unit. This formation allows all of the units in the battalion to make a move of 15&quot; in the hero phase of their first turn. The move is made as if it were the movement phase, except that the units cannot run. It does not stop the units from moving again normally later in the turn. After the first turn is over, the normal rules apply for the rest of the battle."/>
           </characteristics>
         </profile>
       </profiles>
@@ -1145,7 +1329,7 @@
       <categoryLinks/>
       <selectionEntries/>
       <selectionEntryGroups>
-        <selectionEntryGroup id="a863-da10-a9c6-5c19" name="Gorefist" hidden="false" collective="false" defaultSelectionEntryId="590b-75b1-552e-ae5f">
+        <selectionEntryGroup id="a863-da10-a9c6-5c19" name="Gore-gruntas (3 to 5)" hidden="false" collective="false" defaultSelectionEntryId="590b-75b1-552e-ae5f">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2337,20 +2521,6 @@
           </conditions>
           <conditionGroups/>
         </modifier>
-        <modifier type="decrement" field="points" value="160">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="6c50-1d09-e785-f11e" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d05a-773e-1d60-9d53" type="greaterThan"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-        <modifier type="increment" field="points" value="160">
-          <repeats>
-            <repeat field="selections" scope="6c50-1d09-e785-f11e" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d05a-773e-1d60-9d53" repeats="1" roundUp="false"/>
-          </repeats>
-          <conditions/>
-          <conditionGroups/>
-        </modifier>
       </modifiers>
       <constraints/>
       <categoryLinks>
@@ -2398,7 +2568,7 @@
           <selectionEntryGroups/>
           <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" costTypeId="points" value="160.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="7ff1-128d-6225-a48a" name="Standard Bearer (Orruk)" hidden="false" collective="false" type="upgrade">
@@ -2574,20 +2744,35 @@
             <cost name="pts" costTypeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups/>
-      <entryLinks>
-        <entryLink id="84a1-cb61-8195-f98a" name="Waaagh! Drummer" hidden="false" targetId="b974-9531-b959-d27e" type="selectionEntry">
+        <selectionEntry id="70ec-15b6-bb47-3bb8" name="Waaagh! Drummer" hidden="false" collective="false" type="upgrade">
           <profiles/>
-          <rules/>
+          <rules>
+            <rule id="e8d1-b389-20e4-edb8" name="Waaagh! Drummer" hidden="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <description>Models in this unit may be Waaagh! Drummers. Add 2 to charge rolls for a unit that includes any Waaagh! Drummers.</description>
+            </rule>
+          </rules>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="dc0f-12dc-56c5-f6c3" type="max"/>
+          </constraints>
           <categoryLinks/>
-        </entryLink>
-      </entryLinks>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="160.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6e56-eef2-e6a3-f622" name="Orruk Brutes" hidden="false" collective="false" type="unit">
@@ -2640,22 +2825,7 @@
         </rule>
       </rules>
       <infoLinks/>
-      <modifiers>
-        <modifier type="increment" field="points" value="180">
-          <repeats>
-            <repeat field="selections" scope="6e56-eef2-e6a3-f622" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0873-dbd9-0f07-71aa" repeats="1" roundUp="false"/>
-          </repeats>
-          <conditions/>
-          <conditionGroups/>
-        </modifier>
-        <modifier type="decrement" field="points" value="180">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="6e56-eef2-e6a3-f622" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0873-dbd9-0f07-71aa" type="greaterThan"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
+      <modifiers/>
       <constraints/>
       <categoryLinks>
         <categoryLink id="b476-4228-6d03-9c06" name="New CategoryLink" hidden="false" targetId="d963-a5fb-c348-2371" primary="false">
@@ -2702,7 +2872,7 @@
           <selectionEntryGroups/>
           <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" costTypeId="points" value="180.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -2935,7 +3105,7 @@
       </selectionEntryGroups>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="180.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9c10-f99b-878b-0ecc" name="Orruk Gore-Gruntas" hidden="false" collective="false" type="unit">
@@ -2994,22 +3164,7 @@
         </rule>
       </rules>
       <infoLinks/>
-      <modifiers>
-        <modifier type="decrement" field="points" value="140">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="9c10-f99b-878b-0ecc" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="32a4-72ca-15cd-fd08" type="greaterThan"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-        <modifier type="increment" field="points" value="140">
-          <repeats>
-            <repeat field="selections" scope="9c10-f99b-878b-0ecc" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="32a4-72ca-15cd-fd08" repeats="1" roundUp="false"/>
-          </repeats>
-          <conditions/>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
+      <modifiers/>
       <constraints/>
       <categoryLinks>
         <categoryLink id="4bc6-079e-48ec-fe29" name="New CategoryLink" hidden="false" targetId="d963-a5fb-c348-2371" primary="false">
@@ -3056,7 +3211,7 @@
           <selectionEntryGroups/>
           <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" costTypeId="points" value="140.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -3143,7 +3298,7 @@
       </selectionEntryGroups>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="140.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a45c-cdf2-9c3e-b9ad" name="Orruk Megaboss" hidden="false" collective="false" type="model">
@@ -3719,30 +3874,6 @@
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="120.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="b974-9531-b959-d27e" name="Waaagh! Drummer" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules>
-        <rule id="b4dc-691e-29bc-b196" name="Waaagh! Drummer" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>Models in this unit may be Waaagh! Drummers. Add 2 to charge rolls for a unit that includes any Waaagh! Drummers.</description>
-        </rule>
-      </rules>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8d73-9c72-4d56-ff4a" name="Ironskull&apos;z Boyz" hidden="false" collective="false" type="unit">


### PR DESCRIPTION
Laundry List:

1. Gloomspite Gitz, Bonesplitterz, Ironjawz, & Beastclaw Raiders
- Added Stoneklaw's Gutstompaz to GsG, BS, and IJ
- Overhauled units, removing antiquated increment/decrement system for allies and bringing formatting up to modern standards
- Fixed battalions to be more user-friendly and accurate (BCR didn't even have proper battalions)