### PR TITLE
Fixed Issue #745 + additional Ironjawz oversights

### DIFF
--- a/Death - Legions of Nagash and Nighthaunt.cat
+++ b/Death - Legions of Nagash and Nighthaunt.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="e320-d5ec-ac8e-03dd" name="Death: Legions of Nagash and Nighthaunt" book="Battletome: Legions of Nagash and Battletome: Nighthaunt" revision="38" battleScribeVersion="2.01" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="7" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="e320-d5ec-ac8e-03dd" name="Death: Legions of Nagash and Nighthaunt" book="Battletome: Legions of Nagash and Battletome: Nighthaunt" revision="39" battleScribeVersion="2.01" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="7" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules>
     <rule id="c7d8-4531-1671-0e10" name="Returning Slain Models - Nighthaunt" book="Battletome: Nighthaunt" hidden="false">
@@ -18634,7 +18634,7 @@ The slain models you return to a unit can only be set up withi 3&quot; of an ene
             <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="Add 1 to the wound rolls for melee weapons wielded by friendly NIGHTHAUNT models that are within 9&quot; of this model."/>
           </characteristics>
         </profile>
-        <profile id="3bf2-1a1c-378a-c121" name="Guardian of Soul" hidden="false" profileTypeId="1960-ca8e-67ce-2014" profileTypeName="Unit">
+        <profile id="3bf2-1a1c-378a-c121" name="Guardian of Souls" hidden="false" profileTypeId="1960-ca8e-67ce-2014" profileTypeName="Unit">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -24396,6 +24396,262 @@ The slain models you return to a unit can only be set up withi 3&quot; of an ene
       <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e916-902b-3352-1f2d" name="Guardian of Souls with Mortality Glass" book="Soul Wars" hidden="false" collective="false" type="unit">
+      <profiles>
+        <profile id="a3de-1936-430f-244d" name="Magic" hidden="false" profileTypeId="f55d-ee3a-1597-110f" profileTypeName="Magic">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Cast/Unbind" characteristicTypeId="8294-f605-2c0f-8f92" value="1/1"/>
+            <characteristic name="Spells Known" characteristicTypeId="dc9c-47d3-6931-859c" value="Arcane Bolt, Mystic Shield, Temporal Translocation"/>
+          </characteristics>
+        </profile>
+        <profile id="0cb1-5b5e-d1d8-e865" name="Mortality Glass" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="Unit Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="When enemy units within 9&apos; of this model charge, roll a D6 instead of 2D6 when determining the distance they can move."/>
+          </characteristics>
+        </profile>
+        <profile id="3556-b15c-c578-9772" name="Guardian of Souls" hidden="false" profileTypeId="1960-ca8e-67ce-2014" profileTypeName="Unit">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Move" characteristicTypeId="8655-6213-2824-1752" value="6&quot;"/>
+            <characteristic name="Wounds" characteristicTypeId="cd0e-fea6-411f-904d" value="5"/>
+            <characteristic name="Bravery" characteristicTypeId="0c85-bf79-836b-759e" value="10"/>
+            <characteristic name="Save" characteristicTypeId="f8dd-4f2a-8543-4f36" value="4+"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="8b97-4186-dc56-c340" name="Ethereal" hidden="false" targetId="2cf0-8194-2a24-cf92" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="4da5-3b3c-a303-6547" name="Fly" hidden="false" targetId="8e0c-cbe4-27be-8a30" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="e50e-b092-b9a7-0d45" name="Arcane Bolt" hidden="false" targetId="ae02-a84f-a903-1ff8" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="49a9-5cf7-b6a1-3e2a" name="Mystic Shield" hidden="false" targetId="b41f-f1ce-7aa5-4f81" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="662c-dbb5-5e5f-c24e" name="New CategoryLink" hidden="false" targetId="6cdf-dd4f-0e91-e9c4" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="5503-bdf1-8a07-2315" name="New CategoryLink" hidden="false" targetId="c21c-0e74-70a9-18bb" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="fa7f-0eaa-34c0-d843" name="New CategoryLink" hidden="false" targetId="c352-dff7-7050-6f8d" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="513e-cf2b-2cfc-ede8" name="New CategoryLink" hidden="false" targetId="4e0e-664d-51ea-0929" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="c36b-eeca-a1fa-1de1" name="New CategoryLink" hidden="false" targetId="4f53-8230-2f02-9639" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="3ef4-08fe-a82f-d0ef" name="New CategoryLink" hidden="false" targetId="d4fa-feac-6db1-0da7" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="b0f5-93e3-2fc0-6449" name="Temporal Translocation" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="1cd3-1a9e-40b2-f928" name="Temporal Translocation" hidden="false" profileTypeId="2e81-5e22-c6e1-73cb" profileTypeName="Spell">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Casting Value" characteristicTypeId="2508-b604-1258-a920" value="6"/>
+                <characteristic name="Description" characteristicTypeId="76ff-781d-b8e6-5f27" value="If successfullly cast, pick a friendly NIGHTHAUNT unit wholly within 24&apos; of the caster. You can make a normal move of up to 6&quot; with that unit. If that unit retreats as part of this move, it can still charge in the same turn."/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ae2-11b7-7f64-1c7c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1889-eb15-8381-b3f1" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="8568-628c-d20c-db26" name="Maul or Blade" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9df4-d6a3-dab4-162f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b0d9-a23e-1fbb-6646" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="4916-4698-403b-280d" name="Maul of Judgement" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="cffe-30af-6d30-098b" name="Maul of Judgement" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                    <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
+                    <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="2"/>
+                    <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="3+"/>
+                    <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+                    <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-"/>
+                    <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="2"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ffb1-9d3a-7c51-05e6" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0516-a195-4ed8-ef94" name="Chill Blade" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="7f99-722e-3ff7-3c06" name="Chill Blade" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                    <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
+                    <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="3"/>
+                    <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="3+"/>
+                    <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+                    <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-1"/>
+                    <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91ab-56f1-4d68-2754" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="7f03-4782-562d-e03f" name="Artefacts" hidden="false" targetId="a2c1-3fba-5acb-d560" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="39a4-42bf-2ec4-ce42" name="Command Traits" hidden="false" targetId="eda1-7945-4fea-a145" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="1470-3254-18b8-918c" name="General" hidden="false" targetId="88d2-d540-0573-3402" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="365d-93a1-fc4f-9130" name="Lore of the Underworld" hidden="false" targetId="1d74-9116-3b63-3ea2" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="140.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Destruction - Ironjawz.cat
+++ b/Destruction - Ironjawz.cat
@@ -1011,7 +1011,7 @@
       <categoryLinks/>
       <selectionEntries/>
       <selectionEntryGroups>
-        <selectionEntryGroup id="3112-4dcc-f6f5-aa37" name="Ardfist" hidden="false" collective="false" defaultSelectionEntryId="ff01-046a-5fb0-7163">
+        <selectionEntryGroup id="3112-4dcc-f6f5-aa37" name="2. Ardboys (3 to 5)" hidden="false" collective="false" defaultSelectionEntryId="ff01-046a-5fb0-7163">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1042,7 +1042,7 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="704e-b85b-5670-9efc" name="Orruk Warchanter" hidden="false" collective="false" defaultSelectionEntryId="669c-ed28-b051-4fe2">
+        <selectionEntryGroup id="704e-b85b-5670-9efc" name="1. Orruk Warchanter" hidden="false" collective="false" defaultSelectionEntryId="669c-ed28-b051-4fe2">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1098,7 +1098,7 @@
       <categoryLinks/>
       <selectionEntries/>
       <selectionEntryGroups>
-        <selectionEntryGroup id="4b16-61bb-aec0-0f83" name="Brawl" hidden="false" collective="false">
+        <selectionEntryGroup id="4b16-61bb-aec0-0f83" name="4. 5 battalions in any combination of the following:" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1119,7 +1119,7 @@
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="1cf7-1713-67cb-1608" hidden="false" targetId="5516-d2b6-0e5d-6f21" type="selectionEntry">
+            <entryLink id="1cf7-1713-67cb-1608" name="Battalion: Ironfist" hidden="false" targetId="5516-d2b6-0e5d-6f21" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -1153,7 +1153,7 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="4946-1bd6-5f62-54e9" name="Megaboss" hidden="false" collective="false">
+        <selectionEntryGroup id="4946-1bd6-5f62-54e9" name="1. Megaboss" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1184,7 +1184,7 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="0cef-9f40-4b78-9c23" name="Warchanter" hidden="false" collective="false" defaultSelectionEntryId="b11a-57a3-c09e-7e7c">
+        <selectionEntryGroup id="0cef-9f40-4b78-9c23" name="2. Warchanter" hidden="false" collective="false" defaultSelectionEntryId="b11a-57a3-c09e-7e7c">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1207,7 +1207,7 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="c7a9-067d-2bec-eaaa" name="Orruk Weirdnob Shaman" hidden="false" collective="false" defaultSelectionEntryId="ff1a-d2ea-6549-3009">
+        <selectionEntryGroup id="c7a9-067d-2bec-eaaa" name="3. Weirdnob Shaman" hidden="false" collective="false" defaultSelectionEntryId="ff1a-d2ea-6549-3009">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1264,7 +1264,7 @@
       <categoryLinks/>
       <selectionEntries/>
       <selectionEntryGroups>
-        <selectionEntryGroup id="eb12-57ef-1e47-2aaf" name="Brutes (3 to 5)" hidden="false" collective="false" defaultSelectionEntryId="438d-8ccb-c17f-7ef4">
+        <selectionEntryGroup id="eb12-57ef-1e47-2aaf" name="1. Brutes (3 to 5)" hidden="false" collective="false" defaultSelectionEntryId="438d-8ccb-c17f-7ef4">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1329,7 +1329,7 @@
       <categoryLinks/>
       <selectionEntries/>
       <selectionEntryGroups>
-        <selectionEntryGroup id="a863-da10-a9c6-5c19" name="Gore-gruntas (3 to 5)" hidden="false" collective="false" defaultSelectionEntryId="590b-75b1-552e-ae5f">
+        <selectionEntryGroup id="a863-da10-a9c6-5c19" name="1. Gore-gruntas (3 to 5)" hidden="false" collective="false" defaultSelectionEntryId="590b-75b1-552e-ae5f">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1402,7 +1402,7 @@
       </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups>
-        <selectionEntryGroup id="cdfa-d968-622b-fa4d" name="Ironfist" hidden="false" collective="false">
+        <selectionEntryGroup id="cdfa-d968-622b-fa4d" name="1. Brutes, Gore-gruntas, Ardboys (3 to 5)" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1608,7 +1608,7 @@
       <categoryLinks/>
       <selectionEntries/>
       <selectionEntryGroups>
-        <selectionEntryGroup id="e339-9d6a-fd63-0572" name="Weirdfist" hidden="false" collective="false">
+        <selectionEntryGroup id="e339-9d6a-fd63-0572" name="2. Brutes, Gore-gruntas, Ardboys (3 to 5)" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1671,7 +1671,7 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="61c0-09df-b91c-edd4" name="Orruk Weirdnob Shaman" hidden="false" collective="false" defaultSelectionEntryId="1278-ae2f-c358-9a11">
+        <selectionEntryGroup id="61c0-09df-b91c-edd4" name="1. Orruk Weirdnob Shaman" hidden="false" collective="false" defaultSelectionEntryId="1278-ae2f-c358-9a11">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2038,6 +2038,79 @@
             <cost name="pts" costTypeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
+        <selectionEntry id="1068-c6b2-8119-49f0" name="Maw-Krusha Damage Table" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="d345-041d-846b-3f12" name="00-03" hidden="false" profileTypeId="8723-8105-d20d-f04c" profileTypeName="Maw-Krusha">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Move" characteristicTypeId="85cc-4c75-0058-b8f6" value="12&quot;"/>
+                <characteristic name="Mighty Fists" characteristicTypeId="89c3-c419-d973-8625" value="2+"/>
+                <characteristic name="Destructive Bulk" characteristicTypeId="51f4-7738-ea97-df2b" value="8"/>
+              </characteristics>
+            </profile>
+            <profile id="4834-a373-27d4-237e" name="04-06" hidden="false" profileTypeId="8723-8105-d20d-f04c" profileTypeName="Maw-Krusha">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Move" characteristicTypeId="85cc-4c75-0058-b8f6" value="10&quot;"/>
+                <characteristic name="Mighty Fists" characteristicTypeId="89c3-c419-d973-8625" value="3+"/>
+                <characteristic name="Destructive Bulk" characteristicTypeId="51f4-7738-ea97-df2b" value="7"/>
+              </characteristics>
+            </profile>
+            <profile id="7c11-3307-48b4-a8a3" name="13+" hidden="false" profileTypeId="8723-8105-d20d-f04c" profileTypeName="Maw-Krusha">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Move" characteristicTypeId="85cc-4c75-0058-b8f6" value="4&quot;"/>
+                <characteristic name="Mighty Fists" characteristicTypeId="89c3-c419-d973-8625" value="6"/>
+                <characteristic name="Destructive Bulk" characteristicTypeId="51f4-7738-ea97-df2b" value="4"/>
+              </characteristics>
+            </profile>
+            <profile id="7969-075e-e166-8600" name="10-12" hidden="false" profileTypeId="8723-8105-d20d-f04c" profileTypeName="Maw-Krusha">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Move" characteristicTypeId="85cc-4c75-0058-b8f6" value="6&quot;"/>
+                <characteristic name="Mighty Fists" characteristicTypeId="89c3-c419-d973-8625" value="5+"/>
+                <characteristic name="Destructive Bulk" characteristicTypeId="51f4-7738-ea97-df2b" value="5"/>
+              </characteristics>
+            </profile>
+            <profile id="08bc-21bc-69ff-a0ed" name="07-09" hidden="false" profileTypeId="8723-8105-d20d-f04c" profileTypeName="Maw-Krusha">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Move" characteristicTypeId="85cc-4c75-0058-b8f6" value="8&quot;"/>
+                <characteristic name="Mighty Fists" characteristicTypeId="89c3-c419-d973-8625" value="4+"/>
+                <characteristic name="Destructive Bulk" characteristicTypeId="51f4-7738-ea97-df2b" value="6"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec86-f421-02d4-18f8" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e01c-2df8-e253-8dcd" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>
       <entryLinks>
@@ -2058,14 +2131,6 @@
           <categoryLinks/>
         </entryLink>
         <entryLink id="1207-4fd2-ab79-4516" name="Command Traits" hidden="false" targetId="121f-1a0c-a06b-d45c" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="51d6-1587-05b6-bef3" name="Maw-Krusha Damage Table" hidden="false" targetId="9854-4b3f-9edd-bd46" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2322,6 +2387,79 @@
             <cost name="pts" costTypeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
+        <selectionEntry id="e935-0aa3-3acf-34ae" name="Maw-Krusha Damage Table" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="58c0-e8f4-88d4-649b" name="00-03" hidden="false" profileTypeId="8723-8105-d20d-f04c" profileTypeName="Maw-Krusha">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Move" characteristicTypeId="85cc-4c75-0058-b8f6" value="12&quot;"/>
+                <characteristic name="Mighty Fists" characteristicTypeId="89c3-c419-d973-8625" value="2+"/>
+                <characteristic name="Destructive Bulk" characteristicTypeId="51f4-7738-ea97-df2b" value="8"/>
+              </characteristics>
+            </profile>
+            <profile id="029c-add0-fb24-70e9" name="04-06" hidden="false" profileTypeId="8723-8105-d20d-f04c" profileTypeName="Maw-Krusha">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Move" characteristicTypeId="85cc-4c75-0058-b8f6" value="10&quot;"/>
+                <characteristic name="Mighty Fists" characteristicTypeId="89c3-c419-d973-8625" value="3+"/>
+                <characteristic name="Destructive Bulk" characteristicTypeId="51f4-7738-ea97-df2b" value="7"/>
+              </characteristics>
+            </profile>
+            <profile id="fb0e-9e2a-7307-fd6f" name="13+" hidden="false" profileTypeId="8723-8105-d20d-f04c" profileTypeName="Maw-Krusha">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Move" characteristicTypeId="85cc-4c75-0058-b8f6" value="4&quot;"/>
+                <characteristic name="Mighty Fists" characteristicTypeId="89c3-c419-d973-8625" value="6"/>
+                <characteristic name="Destructive Bulk" characteristicTypeId="51f4-7738-ea97-df2b" value="4"/>
+              </characteristics>
+            </profile>
+            <profile id="6ec4-ca09-c28f-6497" name="10-12" hidden="false" profileTypeId="8723-8105-d20d-f04c" profileTypeName="Maw-Krusha">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Move" characteristicTypeId="85cc-4c75-0058-b8f6" value="6&quot;"/>
+                <characteristic name="Mighty Fists" characteristicTypeId="89c3-c419-d973-8625" value="5+"/>
+                <characteristic name="Destructive Bulk" characteristicTypeId="51f4-7738-ea97-df2b" value="5"/>
+              </characteristics>
+            </profile>
+            <profile id="b507-bd14-1eb1-7a3b" name="07-09" hidden="false" profileTypeId="8723-8105-d20d-f04c" profileTypeName="Maw-Krusha">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Move" characteristicTypeId="85cc-4c75-0058-b8f6" value="8&quot;"/>
+                <characteristic name="Mighty Fists" characteristicTypeId="89c3-c419-d973-8625" value="4+"/>
+                <characteristic name="Destructive Bulk" characteristicTypeId="51f4-7738-ea97-df2b" value="6"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="75ca-2e3b-c962-8d09" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f47c-a889-5bd8-56ec" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="bfb6-9ba5-afca-70a3" name="Weapon Options" hidden="false" collective="false" defaultSelectionEntryId="72cb-452e-d68d-3d8b">
@@ -2452,14 +2590,6 @@
           <categoryLinks/>
         </entryLink>
         <entryLink id="ff9a-8638-80b6-8b59" name="General" hidden="false" targetId="d388-c05c-5bbe-f867" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="2c3a-4d0a-c159-b7ae" name="Maw-Krusha Damage Table" hidden="false" targetId="9854-4b3f-9edd-bd46" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3724,13 +3854,13 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="308c-73d2-6d7e-0932" hidden="false" targetId="09f4-1910-9246-31c6" type="profile">
+        <infoLink id="308c-73d2-6d7e-0932" name="Foot of Gork" hidden="false" targetId="09f4-1910-9246-31c6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="d0c9-8f2e-e03e-b93c" hidden="false" targetId="c8f0-1d8f-ec06-2a61" type="profile">
+        <infoLink id="d0c9-8f2e-e03e-b93c" name="Green Puke" hidden="false" targetId="c8f0-1d8f-ec06-2a61" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4086,79 +4216,6 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9854-4b3f-9edd-bd46" name="Maw-Krusha Damage Table" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="5e49-1874-66cd-d0d8" name="00-03" hidden="false" profileTypeId="8723-8105-d20d-f04c" profileTypeName="Maw-Krusha">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Move" characteristicTypeId="85cc-4c75-0058-b8f6" value="12&quot;"/>
-            <characteristic name="Mighty Fists" characteristicTypeId="89c3-c419-d973-8625" value="2+"/>
-            <characteristic name="Destructive Bulk" characteristicTypeId="51f4-7738-ea97-df2b" value="8"/>
-          </characteristics>
-        </profile>
-        <profile id="764d-558f-8e61-466d" name="04-06" hidden="false" profileTypeId="8723-8105-d20d-f04c" profileTypeName="Maw-Krusha">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Move" characteristicTypeId="85cc-4c75-0058-b8f6" value="10&quot;"/>
-            <characteristic name="Mighty Fists" characteristicTypeId="89c3-c419-d973-8625" value="3+"/>
-            <characteristic name="Destructive Bulk" characteristicTypeId="51f4-7738-ea97-df2b" value="7"/>
-          </characteristics>
-        </profile>
-        <profile id="35f0-f033-1eef-3b74" name="13+" hidden="false" profileTypeId="8723-8105-d20d-f04c" profileTypeName="Maw-Krusha">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Move" characteristicTypeId="85cc-4c75-0058-b8f6" value="4&quot;"/>
-            <characteristic name="Mighty Fists" characteristicTypeId="89c3-c419-d973-8625" value="6"/>
-            <characteristic name="Destructive Bulk" characteristicTypeId="51f4-7738-ea97-df2b" value="4"/>
-          </characteristics>
-        </profile>
-        <profile id="33dc-5432-0b5e-5403" name="10-12" hidden="false" profileTypeId="8723-8105-d20d-f04c" profileTypeName="Maw-Krusha">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Move" characteristicTypeId="85cc-4c75-0058-b8f6" value="6&quot;"/>
-            <characteristic name="Mighty Fists" characteristicTypeId="89c3-c419-d973-8625" value="5+"/>
-            <characteristic name="Destructive Bulk" characteristicTypeId="51f4-7738-ea97-df2b" value="5"/>
-          </characteristics>
-        </profile>
-        <profile id="d90f-f3cd-616a-af25" name="07-09" hidden="false" profileTypeId="8723-8105-d20d-f04c" profileTypeName="Maw-Krusha">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Move" characteristicTypeId="85cc-4c75-0058-b8f6" value="8&quot;"/>
-            <characteristic name="Mighty Fists" characteristicTypeId="89c3-c419-d973-8625" value="4+"/>
-            <characteristic name="Destructive Bulk" characteristicTypeId="51f4-7738-ea97-df2b" value="6"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="acad-19cc-dc11-9ffa" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="283e-c125-2d23-2cf0" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="5c67-994e-3892-5797" name="Battalion: Bloodtoofs" book="" hidden="false" collective="false" type="upgrade">
       <profiles>
         <profile id="1dd9-5905-8386-e004" name="Get Da Realmgate!" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
@@ -4201,107 +4258,7 @@
       <constraints/>
       <categoryLinks/>
       <selectionEntries>
-        <selectionEntry id="2b63-8976-252d-37ca" name="5 Unit Ironfist" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="7a17-8506-25fc-d382" name="&apos;Ere We Go! &apos;Ere We Go! &apos;Ere We Go!" hidden="false" profileTypeId="c924-5a68-471a-2fd5">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="Urged on by their BIG BOSS, the mobs in this battalion are forever rushing forwards to get stuck into the fight. As long as the battalion&apos;s BIG BOSS has not been slain, in your hero phase each unit in this battalion can move D6&quot;. Roll separately for each unit and then make its move in the same manner as a move in the movement phase except that the unit cannot run."/>
-              </characteristics>
-            </profile>
-            <profile id="204b-c6f4-cad1-9772" name="Ironfist Big Boss" hidden="false" profileTypeId="c924-5a68-471a-2fd5">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="Pick a BRUTE BOSS or GORE-GRUNTA BOSS from the battalion to be it&apos;s BIG BOSS and add 2 to their Wounds characteristic."/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="784e-4684-e3d8-d16b" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1556-3355-f808-b485" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="9cef-303a-ce54-febb" name="Ironfist" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7be6-9025-6c90-30df" type="min"/>
-                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="104d-dd00-973e-8212" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="db43-58c7-d7b5-b3cb" name="Orruk Brutes" hidden="false" targetId="6e56-eef2-e6a3-f622" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks>
-                    <categoryLink id="ca05-522e-37e3-a0fa" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="false">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </categoryLink>
-                  </categoryLinks>
-                </entryLink>
-                <entryLink id="3efc-0d66-09c2-5147" name="Orruk Gore-Gruntas" hidden="false" targetId="9c10-f99b-878b-0ecc" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks>
-                    <categoryLink id="1e4c-9e8d-3be1-161c" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="false">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </categoryLink>
-                  </categoryLinks>
-                </entryLink>
-                <entryLink id="5265-5e33-cb7d-6f5a" name="Orruk Ardboys" hidden="false" targetId="6c50-1d09-e785-f11e" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks>
-                    <categoryLink id="694e-c90e-7681-0a3d" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="false">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </categoryLink>
-                  </categoryLinks>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="180.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="4957-21b3-ccd2-863c" name="Zogbak Realmrippa" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="4957-21b3-ccd2-863c" name="1. Zogbak Realmrippa" hidden="false" collective="false" type="upgrade">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4330,9 +4287,109 @@
             <cost name="pts" costTypeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
+        <selectionEntry id="6464-e0fa-d357-6ee9" name="2. Ironfist (5 unit minimum)" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="df28-e969-fd9d-35a3" name="&apos;Ere We Go! &apos;Ere We Go! &apos;Ere We Go!" hidden="false" profileTypeId="c924-5a68-471a-2fd5">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="Urged on by their BIG BOSS, the mobs in this battalion are forever rushing forwards to get stuck into the fight. As long as the battalion&apos;s BIG BOSS has not been slain, in your hero phase each unit in this battalion can move D6&quot;. Roll separately for each unit and then make its move in the same manner as a move in the movement phase except that the unit cannot run."/>
+              </characteristics>
+            </profile>
+            <profile id="37d7-00f3-cdf7-5a60" name="Ironfist Big Boss" hidden="false" profileTypeId="c924-5a68-471a-2fd5">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="Pick a BRUTE BOSS or GORE-GRUNTA BOSS from the battalion to be it&apos;s BIG BOSS and add 2 to their Wounds characteristic."/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5633-074c-e7b5-a45f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bcea-33a6-c89f-9029" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="0729-5980-90e2-271b" name="1. Brutes, Gore-gruntas, Ardboys" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="67f9-a332-6fca-8b50" type="min"/>
+                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bbdd-788e-9e25-1209" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="9e55-ea19-1cd6-692d" name="Orruk Brutes" hidden="false" targetId="6e56-eef2-e6a3-f622" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks>
+                    <categoryLink id="78b8-97f9-3f78-47c3" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+                <entryLink id="e81a-5c56-0ac7-645d" name="Orruk Gore-Gruntas" hidden="false" targetId="9c10-f99b-878b-0ecc" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks>
+                    <categoryLink id="4b18-cc63-cea2-eacd" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+                <entryLink id="10ec-0758-16b3-eb44" name="Orruk Ardboys" hidden="false" targetId="6c50-1d09-e785-f11e" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks>
+                    <categoryLink id="2eb4-f803-0c88-7399" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="180.0"/>
+          </costs>
+        </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="5647-2b23-612f-56c3" name="Other Battalions" hidden="false" collective="false">
+        <selectionEntryGroup id="5647-2b23-612f-56c3" name="3.Other Battalions" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4369,6 +4426,90 @@
               <categoryLinks/>
             </entryLink>
             <entryLink id="f7d8-8b6e-8aa5-f567" name="Battalion: Gorefist" hidden="false" targetId="16de-2af6-77ff-a850" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="37b8-48da-afb8-da6f" name="4. Additional Ironjawz Units" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="b2aa-678b-8ebc-72f3" name="Gordrakk, the Fist of Gork" hidden="false" targetId="d7b6-32d5-bf10-7026" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="421e-682a-301f-8ebc" name="Ironskull&apos;z Boyz" hidden="false" targetId="8d73-9c72-4d56-ff4a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="1a95-94a5-49e4-47e5" name="Megaboss on Maw-krusha" hidden="false" targetId="a7f6-2f47-2e18-dca0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="b0dc-52a3-85ef-f31b" name="Orruk Ardboys" hidden="false" targetId="6c50-1d09-e785-f11e" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="9982-b22e-707c-8c1d" name="Orruk Brutes" hidden="false" targetId="6e56-eef2-e6a3-f622" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="dfb2-295c-2abe-e7a5" name="Orruk Gore-Gruntas" hidden="false" targetId="9c10-f99b-878b-0ecc" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="d778-bb0c-09ac-b381" name="Orruk Megaboss" hidden="false" targetId="a45c-cdf2-9c3e-b9ad" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="0484-0bbe-caa9-77f9" name="Orruk Warchanter" hidden="false" targetId="2b44-282f-0f92-c751" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="4bab-60d6-ada8-1be5" name="Orruk Weirdnob Shaman" hidden="false" targetId="e7ca-9ac1-3ca2-d83c" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -4426,7 +4567,7 @@
       <constraints/>
       <categoryLinks/>
       <selectionEntries>
-        <selectionEntry id="3653-5fad-7d3b-afec" name="Dakkbad Grotkicker" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="3653-5fad-7d3b-afec" name="1. Dakkbad Grotkicker" hidden="false" collective="false" type="upgrade">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4455,7 +4596,7 @@
             <cost name="pts" costTypeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="38e6-78d5-dcd9-2472" name="5 Unit Ironfist" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="38e6-78d5-dcd9-2472" name="2. Ironfist (5 unit minimum)" hidden="false" collective="false" type="upgrade">
           <profiles>
             <profile id="1dde-c6f6-0646-0820" name="&apos;Ere We Go! &apos;Ere We Go! &apos;Ere We Go!" hidden="false" profileTypeId="c924-5a68-471a-2fd5">
               <profiles/>
@@ -4486,7 +4627,7 @@
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups>
-            <selectionEntryGroup id="0bd3-72e0-4c3a-63ee" name="Ironfist" hidden="false" collective="false">
+            <selectionEntryGroup id="0bd3-72e0-4c3a-63ee" name="1. Brutes, Gore-gruntas, Ardboys" hidden="false" collective="false">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -4557,7 +4698,7 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="c19a-7613-050b-dfa4" name="Other Battalions" hidden="false" collective="false">
+        <selectionEntryGroup id="c19a-7613-050b-dfa4" name="3. Other Battalions" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4594,6 +4735,90 @@
               <categoryLinks/>
             </entryLink>
             <entryLink id="a30f-66d2-cf95-a704" name="Battalion: Gorefist" hidden="false" targetId="16de-2af6-77ff-a850" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="90f3-faaf-cddd-efcc" name="4. Additional Ironjawz Units" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="befe-1b2a-33f2-35da" name="Gordrakk, the Fist of Gork" hidden="false" targetId="d7b6-32d5-bf10-7026" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="b667-f79e-0129-68a6" name="Ironskull&apos;z Boyz" hidden="false" targetId="8d73-9c72-4d56-ff4a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="66c4-8cb8-adf3-84ae" name="Megaboss on Maw-krusha" hidden="false" targetId="a7f6-2f47-2e18-dca0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="ac19-6840-f8ea-6d09" name="Orruk Ardboys" hidden="false" targetId="6c50-1d09-e785-f11e" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="8004-b182-ee39-777a" name="Orruk Brutes" hidden="false" targetId="6e56-eef2-e6a3-f622" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="fa43-ff7a-9d43-831c" name="Orruk Gore-Gruntas" hidden="false" targetId="9c10-f99b-878b-0ecc" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="21c9-1af7-c66c-413d" name="Orruk Megaboss" hidden="false" targetId="a45c-cdf2-9c3e-b9ad" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="6525-20cf-ba9e-8d98" name="Orruk Warchanter" hidden="false" targetId="2b44-282f-0f92-c751" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="e049-559e-4836-4c7e" name="Orruk Weirdnob Shaman" hidden="false" targetId="e7ca-9ac1-3ca2-d83c" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>


### PR DESCRIPTION
Fixed Issue #745 (added GoS with Mortality Glass as a unit) while also formatting Ironjawz in the same way as Bonesplitterz, GsG, and BCR. I don't know why it wasn't before cause I could swear I did them all the same, but I might've lost some data and not realized it.