### PR TITLE
 Issues #806, #810, #811 fixed 

### DIFF
--- a/Death - Legions of Nagash and Nighthaunt.cat
+++ b/Death - Legions of Nagash and Nighthaunt.cat
@@ -5755,6 +5755,70 @@ The slain models you return to a unit can only be set up withi 3&quot; of an ene
         </categoryLink>
       </categoryLinks>
     </entryLink>
+    <entryLink id="8fb5-ab9a-d0a7-b380" name="Guardian of Souls with Mortality Glass" hidden="false" targetId="e916-902b-3352-1f2d" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <repeats/>
+          <conditions/>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1d5c-8cc0-8082-e822" type="equalTo"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d3be-c685-2896-35f8" type="equalTo"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6b35-0508-c6cc-6592" type="equalTo"/>
+              </conditions>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="notInstanceOf"/>
+                  </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59ec-1803-f129-8830" type="equalTo"/>
+                        <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0395-882a-0826-8ab8" type="equalTo"/>
+                        <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d935-8702-2198-a55d" type="equalTo"/>
+                        <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d285-0a74-a36b-e277" type="equalTo"/>
+                        <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b38e-4752-5708-d73c" type="equalTo"/>
+                        <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7b65-f69b-f915-00d3" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+                <conditionGroup type="and">
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59ec-1803-f129-8830" type="equalTo"/>
+                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0395-882a-0826-8ab8" type="equalTo"/>
+                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d935-8702-2198-a55d" type="equalTo"/>
+                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d285-0a74-a36b-e277" type="equalTo"/>
+                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b38e-4752-5708-d73c" type="equalTo"/>
+                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7b65-f69b-f915-00d3" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="7f4c-7d4b-6b8e-575b" name="Alliegiance" hidden="false" collective="false" type="upgrade">

--- a/Destruction - Bonesplitterz.cat
+++ b/Destruction - Bonesplitterz.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="7e25-33bb-f612-bfca" name="Destruction - Bonesplitterz" book="Destruction Battletome: Bonesplitterz" revision="10" battleScribeVersion="2.01" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="6" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="7e25-33bb-f612-bfca" name="Destruction - Bonesplitterz" book="Destruction Battletome: Bonesplitterz" revision="11" battleScribeVersion="2.01" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="6" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -3579,11 +3579,11 @@
             <cost name="pts" costTypeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="7be6-df44-f223-caa7" name="Choppa" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="7be6-df44-f223-caa7" name="Chompa" hidden="false" collective="false" type="upgrade">
           <profiles/>
           <rules/>
           <infoLinks>
-            <infoLink id="bea1-24cd-2cea-e44f" name="Choppa" hidden="false" targetId="0b24-24d0-8dba-5d4d" type="profile">
+            <infoLink id="bea1-24cd-2cea-e44f" name="Chompa" hidden="false" targetId="0b24-24d0-8dba-5d4d" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -3743,11 +3743,11 @@
           </constraints>
           <categoryLinks/>
           <selectionEntries>
-            <selectionEntry id="c0a4-ec3c-a606-bd5e" name="Choppa" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="c0a4-ec3c-a606-bd5e" name="Chompa" hidden="false" collective="false" type="upgrade">
               <profiles/>
               <rules/>
               <infoLinks>
-                <infoLink id="ebdf-b406-bbe5-7d85" name="Choppa" hidden="false" targetId="0b24-24d0-8dba-5d4d" type="profile">
+                <infoLink id="ebdf-b406-bbe5-7d85" name="Chompa" hidden="false" targetId="0b24-24d0-8dba-5d4d" type="profile">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -4217,7 +4217,7 @@
             <cost name="pts" costTypeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="ca79-ea5d-1d19-76a0" name="Choppa" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="ca79-ea5d-1d19-76a0" name="Chompa" hidden="false" collective="false" type="upgrade">
           <profiles/>
           <rules/>
           <infoLinks>
@@ -6265,8 +6265,8 @@
         <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
         <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="1"/>
         <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="4+"/>
-        <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="4+"/>
-        <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-1"/>
+        <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+        <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-"/>
         <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
       </characteristics>
     </profile>

--- a/Order - Sylvaneth.cat
+++ b/Order - Sylvaneth.cat
@@ -10,6 +10,18 @@
         <characteristicType id="43f7-3a57-7d60-98a0" name="Result"/>
       </characteristicTypes>
     </profileType>
+    <profileType id="d7d9-eaac-6963-eea0" name="Alarielle Wounds Suffered">
+      <characteristicTypes>
+        <characteristicType id="4419-5b61-25bd-7721" name="Move"/>
+        <characteristicType id="305d-3c37-1f1e-3fb1" name="Spear of Kurnoth"/>
+        <characteristicType id="b425-4c0e-3446-42a8" name="Great Antlers"/>
+      </characteristicTypes>
+    </profileType>
+    <profileType id="f23f-51bd-763b-9b08" name="Subterfuge Strategem">
+      <characteristicTypes>
+        <characteristicType id="4be8-8501-c9da-6650" name="Description"/>
+      </characteristicTypes>
+    </profileType>
   </profileTypes>
   <categoryEntries>
     <categoryEntry id="805c-672e-9a89-4b73" name="ALARIELLE THE EVERQUEEN" hidden="false">
@@ -97,6 +109,41 @@
       <constraints/>
     </categoryEntry>
     <categoryEntry id="bf71-ebb4-2c88-00e8" name="SYLVANETH WYLDWOOD" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="8d51-f119-1a14-e947" name="WARGROVE GNARLROOT" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="fc74-5007-3ac8-3b19" name="WARGROVE OAKENBROW" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="9499-680b-d7f9-c2b4" name="WARGROVE IRONBARK" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="36f8-6827-6ec9-c876" name="WARGROVE HARVESTBOON" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="48d1-ef89-4d11-ef1c" name="WARGROVE FOREST SPIRIT" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -878,6 +925,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="0b03-f6d6-80f0-e537" name="Leader" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="1e9f-1a4d-205f-8667" name="Spear of Kurnoth" hidden="false" collective="false" type="upgrade">
@@ -1151,7 +1205,7 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="a19b-7f5d-65d5-62be" name="Battalion: Dreadwood Wargrove" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="a19b-7f5d-65d5-62be" name="Super Battalion: Dreadwood Wargrove" hidden="false" collective="false" type="upgrade">
       <profiles>
         <profile id="5641-193c-3930-ce42" name="Malicious Tormentors" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>
@@ -1162,48 +1216,117 @@
             <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="You can re-roll wound rolls of 1 for attacks made by Dreadwood Spite-Revenants."/>
           </characteristics>
         </profile>
-        <profile id="23b6-670d-7b09-2418" name="Subterfuge" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Roll a dice at the start of the first battle round; on a 1 or 2 you can use one of the following stratagems, on a 3 or 4 you can use two of them, and on a 5 or 6 you can use all three:  Ambush: A Dreadwood unit can be redeployed anywhere on the battlefield that is more than 6&quot; from an enemy unit.  Hidden Attackers: The maximum range of enemy attacks, abilities and spells against Dreadwood units is limited to 12&quot; during the first round of the battle.  Sneak Attack: Up to 3 Dreadwood units can immediately move as if it were the movement phase (they cannot run)."/>
-          </characteristics>
-        </profile>
       </profiles>
-      <rules>
-        <rule id="e7f9-0c9a-653d-bf94" name="Maximum Battalion" hidden="false">
+      <rules/>
+      <infoLinks>
+        <infoLink id="4e3f-2f4c-9705-9c77" name="Mighty Wildwood" hidden="false" targetId="e69e-ffc7-e031-9478" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <description>If a Dreadwood Wargrove contains the maximum number of battalions, it gains the Mighty Wyldwood ability.</description>
-        </rule>
-      </rules>
-      <infoLinks/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
       <constraints/>
       <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="0c6d-ca53-a5bf-d6ed" name="1 Outcasts battalion" hidden="false" collective="false">
-          <profiles/>
+      <selectionEntries>
+        <selectionEntry id="a22f-a23d-5e20-4789" name="Subterfuge" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="8dda-03d6-7df8-678c" name="Subterfuge" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Roll a dice at the start of the first battle round; on a 1 or 2 you can use one of the listed stratagems, on a 3 or 4 you can use two of them, and on a 5 or 6 you can use all three."/>
+              </characteristics>
+            </profile>
+          </profiles>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="62fc-88d6-92ac-8005" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2339-7a1e-e073-b4ef" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df92-0023-1ef1-0abe" type="min"/>
           </constraints>
           <categoryLinks/>
           <selectionEntries>
+            <selectionEntry id="bbf4-7708-f9ce-ea02" name="Stratagems" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="47bd-069f-239d-844a" name="Hidden Attackers" hidden="false" profileTypeId="f23f-51bd-763b-9b08" profileTypeName="Subterfuge Strategem">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Description" characteristicTypeId="4be8-8501-c9da-6650" value="The maximum range of enemy attacks, abilities and spells against Dreadwood units is limited to 12&quot; during the first round of the battle."/>
+                  </characteristics>
+                </profile>
+                <profile id="e729-901b-a685-3883" name="Sneak Attack" hidden="false" profileTypeId="f23f-51bd-763b-9b08" profileTypeName="Subterfuge Strategem">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Description" characteristicTypeId="4be8-8501-c9da-6650" value="Up to 3 Dreadwood units can immediately move as if it were the movement phase (they cannot run)."/>
+                  </characteristics>
+                </profile>
+                <profile id="29cc-05af-3638-fc09" name="Ambush" hidden="false" profileTypeId="f23f-51bd-763b-9b08" profileTypeName="Subterfuge Table">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Description" characteristicTypeId="4be8-8501-c9da-6650" value="A Dreadwood unit can be redeployed anywhere on the battlefield that is more than 6&quot; from an enemy unit."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="257d-542d-9fa2-b75e" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8163-7a25-b317-69ad" type="min"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs/>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs/>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="0c6d-ca53-a5bf-d6ed" name="1. Outcasts" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries>
             <selectionEntry id="b99a-5497-6b0d-8edc" name="Battalion: Outcasts" hidden="false" collective="false" type="upgrade">
-              <profiles/>
+              <profiles>
+                <profile id="48f6-d90b-5b2a-d0a1" name="Fear the Forest-kin" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="In your hero phase, roll two dice for each enemy unit that is within 8&quot; of at least two units from this battalion. For each point by which the total dice roll exceeds the unit’s Bravery, the unit suffers a mortal wound."/>
+                  </characteristics>
+                </profile>
+              </profiles>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad9d-b960-2dc4-fb30" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a279-6d9a-4620-b8ae" type="min"/>
               </constraints>
               <categoryLinks>
                 <categoryLink id="cb9f-f177-ac6b-5932" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="false">
@@ -1214,37 +1337,9 @@
                   <constraints/>
                 </categoryLink>
               </categoryLinks>
-              <selectionEntries>
-                <selectionEntry id="028e-f1d0-0c0b-1281" name="Outcasts" hidden="false" collective="false" type="upgrade">
-                  <profiles>
-                    <profile id="d9e8-81d7-cab5-1444" name="Fear the Forest-kin" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <characteristics>
-                        <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="In your hero phase, roll two dice for each enemy unit that is within 8&quot; of at least two units from this battalion. For each point by which the total dice roll exceeds the unit’s Bravery, the unit suffers a mortal wound."/>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a769-25fe-462f-0d8a" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1874-bd21-680b-ce1b" type="max"/>
-                  </constraints>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="90.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
+              <selectionEntries/>
               <selectionEntryGroups>
-                <selectionEntryGroup id="c8de-d70a-e462-13fd" name="4-6 units of Spite-Revenants" hidden="false" collective="false">
+                <selectionEntryGroup id="c8de-d70a-e462-13fd" name="1. Spite Revenants (4 to 6)" hidden="false" collective="false">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -1270,7 +1365,9 @@
                           <conditionGroups/>
                         </modifier>
                       </modifiers>
-                      <constraints/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e276-17c5-cbdb-349c" type="max"/>
+                      </constraints>
                       <categoryLinks>
                         <categoryLink id="2b53-6b39-ee9f-3221" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
                           <profiles/>
@@ -1294,7 +1391,9 @@
                           <conditionGroups/>
                         </modifier>
                       </modifiers>
-                      <constraints/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87fe-69f5-011c-fb8a" type="max"/>
+                      </constraints>
                       <categoryLinks>
                         <categoryLink id="d56b-336a-6292-36ee" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
                           <profiles/>
@@ -1326,7 +1425,7 @@
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups>
-            <selectionEntryGroup id="ea51-33a9-4cc5-c2a4" name="0-3:" hidden="false" collective="false">
+            <selectionEntryGroup id="893c-f24e-c7e7-918d" name="1. Lords of Clan" hidden="false" collective="false">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -1336,16 +1435,16 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="5b36-a346-a1d4-8578" name="Battalion: Forest Folk" hidden="false" targetId="756d-d96e-e298-5558" type="selectionEntry">
+                <entryLink id="2376-45b5-1ee5-c3c3" name="*Battalion: Lords of the Clan" hidden="false" targetId="3388-e687-3bd2-98a8" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b31-50a6-2399-5dff" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9cec-d6aa-5333-94d6" type="max"/>
                   </constraints>
                   <categoryLinks>
-                    <categoryLink id="193f-41d8-6262-3a69" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                    <categoryLink id="4556-df61-9eba-0c1f" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -1356,7 +1455,7 @@
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="0ae9-30f4-b7d2-66a5" name="0-3:" hidden="false" collective="false">
+            <selectionEntryGroup id="5dd9-31f7-0dc4-0676" name="2. Households (0 to 3)" hidden="false" collective="false">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -1366,16 +1465,16 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="8584-35a8-9b8d-ee11" name="Battalion: Household" hidden="false" targetId="d141-06d7-9c9e-d410" type="selectionEntry">
+                <entryLink id="5f60-db3a-224d-450f" name="*Battalion: Household" hidden="false" targetId="d141-06d7-9c9e-d410" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="977a-4684-ed38-f20b" type="max"/>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e0d-dd35-1f5a-ce8b" type="max"/>
                   </constraints>
                   <categoryLinks>
-                    <categoryLink id="6791-d78a-b22a-9d81" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                    <categoryLink id="9f73-ff5b-311b-6f83" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -1383,56 +1482,55 @@
                       <constraints/>
                     </categoryLink>
                   </categoryLinks>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="9507-c2f7-cef1-a2c5" name="3. Forest Folk (0 to 3)" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="f9db-9485-ec95-216e" name="*Battalion: Forest Folk" hidden="false" targetId="756d-d96e-e298-5558" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c818-ed61-9b2b-7f7f" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="2109-57f7-df91-862f" name="4. Free Spirits" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="a921-6200-e3a1-169c" name="*Battalion: Free Spirits" hidden="false" targetId="f852-7524-198b-2957" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3318-754d-8a87-4153" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
-          <entryLinks>
-            <entryLink id="186d-f93a-386f-dcdf" name="Battalion: Free Spirits" hidden="false" targetId="f852-7524-198b-2957" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04f5-df41-37a2-4b74" type="max"/>
-              </constraints>
-              <categoryLinks>
-                <categoryLink id="b6ab-f693-b32a-11ce" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </categoryLink>
-              </categoryLinks>
-            </entryLink>
-            <entryLink id="dbfc-b589-426a-dd8d" name="Battalion: Lords of the Clan" hidden="false" targetId="3388-e687-3bd2-98a8" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1bee-b432-26c4-ecc0" type="max"/>
-              </constraints>
-              <categoryLinks>
-                <categoryLink id="d7ab-750b-5f27-3fba" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </categoryLink>
-              </categoryLinks>
-            </entryLink>
-            <entryLink id="7a6b-5f1c-400e-f8e0" name="Any number of Additional Sylvaneth Units" hidden="false" targetId="2f01-3499-14c8-1107" type="selectionEntryGroup">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
+          <entryLinks/>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks/>
@@ -1441,43 +1539,25 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="756d-d96e-e298-5558" name="Battalion: Forest Folk" hidden="false" collective="false" type="upgrade">
-      <profiles/>
+      <profiles>
+        <profile id="f722-6541-53af-92e3" name="Fade from View" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Once per game, in your hero phase, the Forest Folk can vanish along the spirit paths. Remove all of the models in the battalion from the battlefield and set them to one side. Then set up each of the units anywhere within your territory, or within 3&quot; of a Sylvaneth Wyldwood. They must be set up at least 9&quot; from the enemy, and cannot move in the following movement phase."/>
+          </characteristics>
+        </profile>
+      </profiles>
       <rules/>
       <infoLinks/>
       <modifiers/>
       <constraints/>
       <categoryLinks/>
-      <selectionEntries>
-        <selectionEntry id="cd6e-1a7d-5c55-814e" name="Forest Folk" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="5777-4b55-c69f-e005" name="Fade from View" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Once per game, in your hero phase, the Forest Folk can vanish along the spirit paths. Remove all of the models in the battalion from the battlefield and set them to one side. Then set up each of the units anywhere within your territory, or within 3&quot; of a Sylvaneth Wyldwood. They must be set up at least 9&quot; from the enemy, and cannot move in the following movement phase."/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="488d-ddc8-96e6-a72b" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2307-e338-3fd2-88b7" type="min"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="140.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+      <selectionEntries/>
       <selectionEntryGroups>
-        <selectionEntryGroup id="acde-5411-66f4-566d" name="3 units of Dryads" hidden="false" collective="false">
+        <selectionEntryGroup id="acde-5411-66f4-566d" name="2. Dryads" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1554,21 +1634,14 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="bcf3-8e2b-396e-2b30" name="1 Branchwraith" book="" hidden="false" collective="false">
+        <selectionEntryGroup id="bcf3-8e2b-396e-2b30" name="1. Branchwraith" book="" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <repeats/>
-              <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c2e4-c2d1-fc57-a8fc" type="instanceOf"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
+          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6011-1cd8-6647-ea6e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3491-b681-f19f-d16f" type="max"/>
           </constraints>
           <categoryLinks/>
           <selectionEntries/>
@@ -1578,17 +1651,10 @@
               <profiles/>
               <rules/>
               <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="8623-f406-12df-29f5" value="2">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c2e4-c2d1-fc57-a8fc" type="instanceOf"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
+              <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8623-f406-12df-29f5" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e14-5869-91b8-9965" type="min"/>
               </constraints>
               <categoryLinks>
                 <categoryLink id="03e0-0455-badf-3e9c" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
@@ -1602,106 +1668,54 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="ea3a-bd2a-9d43-51fa" name="1-2 Branchwraiths" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <repeats/>
-              <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c2e4-c2d1-fc57-a8fc" type="notInstanceOf"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ce9-41cb-69cb-a6c7" type="min"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="839e-3f36-9ad8-6f17" name="Branchwraith" hidden="false" targetId="67ae-bbfe-04fe-0e20" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a79-602e-616c-1b11" type="max"/>
-              </constraints>
-              <categoryLinks>
-                <categoryLink id="1ccd-8df0-6b3b-f7cd" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </categoryLink>
-              </categoryLinks>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="140.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="578c-618a-95ec-9693" name="Battalion: Forest Spirit Wargrove" book="Grand Alliance: Order" hidden="false" collective="false" type="upgrade">
-      <profiles/>
+    <selectionEntry id="578c-618a-95ec-9693" name="Super Battalion: Forest Spirit Wargrove" book="Grand Alliance: Order" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="3dfa-dc81-9a98-c840" name="Hidden Sanctuaries" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Instead of setting up a unit from this battalion on the battlefield, you can place it to one side and say that it is set up in the hidden santuaries. In any of your movement phases, you can transport the unit to the battlefield.  When you do so, set it up so that all models are within 3&quot; of a table edge or a SYLVANETH WYLDWOOD, and more than 9&quot; from any enemy models.  This is its move for that movement phase."/>
+          </characteristics>
+        </profile>
+        <profile id="3d91-6ab1-4ed1-adbf" name="Wargrove Ability" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="WIZARDS in this battalion know the Alarielle&apos;s Blessing spell in addition to any other spells they know."/>
+          </characteristics>
+        </profile>
+      </profiles>
       <rules/>
       <infoLinks/>
       <modifiers/>
       <constraints/>
-      <categoryLinks/>
-      <selectionEntries>
-        <selectionEntry id="cd92-afe3-4045-f7ad" name="Forest Spirit Wargrove" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="c42b-1b6c-6181-2953" name="Alarielle&apos;s Blessing" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="WIZARDS in this battalion know the Alarielle&apos;s Blessing spell in addition to any other spells they know.  Alarielle&apos;s Blessing has a casting value of 5.  If successfully cast, pick a model from the battalion that is within 18&quot; of the caster.  The model you pick heals D3 wounds."/>
-              </characteristics>
-            </profile>
-            <profile id="b1e4-7d74-d20e-84fb" name="Hidden Sanctuaries" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Instead of setting up a unit from this battalion on the battlefield, you can place it to one side and say that it is set up in the hidden santuaries. In any of your movement phases, you can transport the unit to the battlefield.  When you do so, set it up so that all models are within 3&quot; of a table edge or a SYLVANETH WYLDWOOD, and more than 9&quot; from any enemy models.  This is its move for that movement phase."/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41f5-b34e-ea5e-dd5f" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a02e-7a08-f45b-a6ee" type="min"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="140.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="5c3d-aa48-a9e7-315a" name="1 Branchwraith" book="" hidden="false" collective="false">
+      <categoryLinks>
+        <categoryLink id="1df9-9342-35af-20c7" name="WARGROVE FOREST SPIRIT" hidden="false" targetId="48d1-ef89-4d11-ef1c" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a39-1ea5-b275-af56" type="min"/>
-          </constraints>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="5c3d-aa48-a9e7-315a" name="4. Branchwraith" book="" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups/>
@@ -1713,6 +1727,7 @@
               <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17e1-6f1c-d7ac-89a2" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f34-d452-b93f-46fa" type="min"/>
               </constraints>
               <categoryLinks>
                 <categoryLink id="d87d-5a9d-3b11-a19c" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
@@ -1726,13 +1741,13 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="c8f3-ec3d-6deb-38e5" name="3 units of Dryads" hidden="false" collective="false">
+        <selectionEntryGroup id="c8f3-ec3d-6deb-38e5" name="3. Dryads" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="429c-67fd-0249-5b6b" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b47a-6730-eeeb-f0b4" type="max"/>
           </constraints>
           <categoryLinks/>
           <selectionEntries/>
@@ -1758,9 +1773,7 @@
                   </conditionGroups>
                 </modifier>
               </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e78-8501-a010-f9e0" type="max"/>
-              </constraints>
+              <constraints/>
               <categoryLinks>
                 <categoryLink id="4df9-4632-4c2b-482d" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
                   <profiles/>
@@ -1791,9 +1804,7 @@
                   </conditionGroups>
                 </modifier>
               </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="05eb-f731-468a-9e59" type="max"/>
-              </constraints>
+              <constraints/>
               <categoryLinks>
                 <categoryLink id="9a2f-79b2-f38c-ec08" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
                   <profiles/>
@@ -1806,15 +1817,12 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="7516-218f-2197-e59b" name="2 Treelords" hidden="false" collective="false">
+        <selectionEntryGroup id="7516-218f-2197-e59b" name="2. Treelords" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f41-630c-af42-0602" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc57-b7b4-9694-dc8b" type="max"/>
-          </constraints>
+          <constraints/>
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups/>
@@ -1824,7 +1832,10 @@
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b7c-4844-af39-0c5a" type="min"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b111-7ceb-f9f5-b04a" type="max"/>
+              </constraints>
               <categoryLinks>
                 <categoryLink id="6229-a248-e348-c1c1" hidden="false" targetId="fa0c-9044-2568-fa02" primary="true">
                   <profiles/>
@@ -1837,14 +1848,12 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="adeb-fb1d-45e6-dad8" name="1 Treelord Ancient" hidden="false" collective="false">
+        <selectionEntryGroup id="adeb-fb1d-45e6-dad8" name="1. Treelord Ancient" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f531-3aea-aef3-dab8" type="min"/>
-          </constraints>
+          <constraints/>
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups/>
@@ -1856,6 +1865,7 @@
               <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a25e-f793-94b9-25a5" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b6e2-8141-e250-13eb" type="min"/>
               </constraints>
               <categoryLinks>
                 <categoryLink id="d772-570b-9d09-6a2b" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
@@ -1879,54 +1889,34 @@
       </selectionEntryGroups>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="140.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f852-7524-198b-2957" name="Battalion: Free Spirits" hidden="false" collective="false" type="upgrade">
-      <profiles/>
+      <profiles>
+        <profile id="a7de-5a06-4c3b-9386" name="Swift Vengeance" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="In your hero phase, you can pick either an enemy unit or a terrain feature, and then move each unit from the Free Spirits as though it were the movement phase (they cannot run). They must end their move closer to the chosen unit or terrain feature than they were before they moved."/>
+          </characteristics>
+        </profile>
+      </profiles>
       <rules/>
       <infoLinks/>
       <modifiers/>
       <constraints/>
       <categoryLinks/>
-      <selectionEntries>
-        <selectionEntry id="364f-3411-6253-9744" name="Free Spirits" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="fc08-9817-a596-b91a" name="Swift Vengeance" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="In your hero phase, you can pick either an enemy unit or a terrain feature, and then move each unit from the Free Spirits as though it were the movement phase (they cannot run). They must end their move closer to the chosen unit or terrain feature than they were before they moved."/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9a1-a9f7-94d0-0a91" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fddc-b740-6a87-4771" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="120.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+      <selectionEntries/>
       <selectionEntryGroups>
-        <selectionEntryGroup id="bd43-1a3d-d8d8-5b40" name="1 Spirit of Durthu" hidden="false" collective="false">
+        <selectionEntryGroup id="bd43-1a3d-d8d8-5b40" name="1. Spirit of Durthu" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09f3-0577-46d3-d4b0" type="min"/>
-          </constraints>
+          <constraints/>
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups/>
@@ -1938,6 +1928,7 @@
               <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="67e1-2b15-c909-67ff" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8009-6084-d931-4fa4" type="min"/>
               </constraints>
               <categoryLinks>
                 <categoryLink id="1208-da78-386f-2d95" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
@@ -1958,19 +1949,11 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="72ce-b6b3-5d37-f757" name="3 units of Kurnoth Hunters" hidden="false" collective="false">
+        <selectionEntryGroup id="72ce-b6b3-5d37-f757" name="2. Kurnoth Hunters" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <repeats/>
-              <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea19-9675-828d-9c83" type="instanceOf"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
+          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="841b-59a4-cc3e-41bf" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d72-18cf-fa4d-9021" type="max"/>
@@ -1984,7 +1967,10 @@
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb74-f7b1-4adf-9876" type="max"/>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a238-111d-8129-e39d" type="min"/>
+              </constraints>
               <categoryLinks>
                 <categoryLink id="d261-96b7-27d0-1389" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
                   <profiles/>
@@ -1997,97 +1983,54 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="d791-9256-331d-38ff" name="4-6 units of Kurnoth Hunters" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <repeats/>
-              <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea19-9675-828d-9c83" type="notInstanceOf"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c75a-c4a7-c1c4-3249" type="min"/>
-            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="454e-783d-fa14-1cd1" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="2edd-499b-ee13-d8b9" name="Kurnoth Hunters" hidden="false" targetId="e14d-00c2-5ed8-220a" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks>
-                <categoryLink id="6be0-0742-b248-0c5d" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </categoryLink>
-              </categoryLinks>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="3c42-9603-e06c-2a97" name="Battalion: Gnarlroot Wargrove" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries>
-        <selectionEntry id="efed-cb3b-c0d9-3191" name="Gnarlroot Wargrove" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="e73c-2454-57cb-0137" name="Seekers of Knowledge" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="A Gnarlroot Treelord Ancient, Branchwych or Branchwraith is allowed to attempt to cast one extra spell in each of their hero phases, and unbind one extra spell in each enemy hero phase."/>
-              </characteristics>
-            </profile>
-            <profile id="ac5f-637b-a180-c06e" name="Verdurous Harmony" hidden="false" profileTypeId="2e81-5e22-c6e1-73cb" profileTypeName="Spell">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Casting Value" characteristicTypeId="2508-b604-1258-a920" value="7"/>
-                <characteristic name="Description" characteristicTypeId="76ff-781d-b8e6-5f27" value="If successfully cast, select a friendly SYLVANETH unit within 18&quot;. One model in that unit that has been slain earlier during the battle is returned to life. Return D3 slain models to the unit instead if they are Dryads or Tree-Revenants."/>
-              </characteristics>
-            </profile>
-          </profiles>
+    <selectionEntry id="3c42-9603-e06c-2a97" name="Super Battalion: Gnarlroot Wargrove" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="ac04-6a35-7dd1-8a9b" name="Seekers of Knowledge" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+          <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a92f-6403-7335-7c20" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2fa8-4be0-df83-4a4e" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="130.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+          <characteristics>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="A Gnarlroot Treelord Ancient, Branchwych or Branchwraith is allowed to attempt to cast one extra spell in each of their hero phases, and unbind one extra spell in each enemy hero phase."/>
+          </characteristics>
+        </profile>
+        <profile id="5333-6403-3a0b-f730" name="Wargrove Abilities" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Each Gnarlroot WIZARD knows the Verdurous Harmony spell in addition to their other spells."/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="b4d7-b0c5-1437-6233" name="Mighty Wildwood" hidden="false" targetId="e69e-ffc7-e031-9478" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="7dc0-7b48-cac3-3a06" name="WARGROVE GNARLROOT" hidden="false" targetId="8d51-f119-1a14-e947" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries/>
       <selectionEntryGroups>
         <selectionEntryGroup id="764f-c8f1-089e-eedb" name="May also contain:" hidden="false" collective="false">
           <profiles/>
@@ -2096,275 +2039,79 @@
           <modifiers/>
           <constraints/>
           <categoryLinks/>
-          <selectionEntries>
-            <selectionEntry id="95b1-0821-f4f0-efe8" name="0-1: ORDER WIZARD" hidden="false" collective="false" type="upgrade">
-              <profiles>
-                <profile id="54de-dc9d-f390-a5d8" name="ORDER WIZARD" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <characteristics>
-                    <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="0-1"/>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="name" value="ORDER WIZARD">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="3c42-9603-e06c-2a97" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="95b1-0821-f4f0-efe8" type="greaterThan"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d91-a0cf-f911-24fe" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="c2e4-c2d1-fc57-a8fc" name="0-3:(Each can contain 1 additional Branchwraith)" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="f996-2b0d-60a3-ad3f" name="Battalion: Forest Folk" hidden="false" targetId="756d-d96e-e298-5558" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6048-9a2d-bfac-4871" type="max"/>
-                  </constraints>
-                  <categoryLinks>
-                    <categoryLink id="154d-ed3b-395a-31f7" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </categoryLink>
-                  </categoryLinks>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="a7b4-c52d-7e2f-55af" name="0-2:" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="8970-565b-2bb5-91e2" name="Battalion: Household" hidden="false" targetId="d141-06d7-9c9e-d410" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3e8-30b2-16f2-3600" type="max"/>
-                  </constraints>
-                  <categoryLinks>
-                    <categoryLink id="6992-6b43-21f0-9668" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </categoryLink>
-                  </categoryLinks>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks>
-            <entryLink id="d9c0-7ce9-56da-1f69" name="Any number of Additional Sylvaneth Units" hidden="false" targetId="2f01-3499-14c8-1107" type="selectionEntryGroup">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="1a9e-32ac-befa-71ef" name="Battalion: Lords of the Clan" hidden="false" targetId="3388-e687-3bd2-98a8" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39c9-1268-f258-f0bd" type="max"/>
-              </constraints>
-              <categoryLinks>
-                <categoryLink id="c19d-2dd1-6d77-9533" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </categoryLink>
-              </categoryLinks>
-            </entryLink>
-            <entryLink id="dc95-cab5-50bc-ad4b" name="Battalion: Outcasts" hidden="false" targetId="471d-38f0-5388-84a0" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb27-7168-94ee-ff7a" type="max"/>
-              </constraints>
-              <categoryLinks>
-                <categoryLink id="f85a-8e1b-3739-72bc" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </categoryLink>
-              </categoryLinks>
-            </entryLink>
-            <entryLink id="a337-34e7-ab0e-d935" name="Battalion: Free Spirits" hidden="false" targetId="f852-7524-198b-2957" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e4e9-a017-987c-593e" type="max"/>
-              </constraints>
-              <categoryLinks>
-                <categoryLink id="be2a-7f23-ba95-a6b4" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </categoryLink>
-              </categoryLinks>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="7749-96a8-f53a-47dd" name="1 Household battalion (Must contain Treelord Ancient instead of Treelord)" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3f1-ecdd-5c03-911c" type="min"/>
-          </constraints>
-          <categoryLinks/>
           <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="4537-bd4f-071c-3315" name="Battalion: Household" hidden="false" targetId="d141-06d7-9c9e-d410" type="selectionEntry">
+          <selectionEntryGroups>
+            <selectionEntryGroup id="f826-cae7-b48a-8f12" name="1. Lords of Clan" hidden="false" collective="false">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0760-c7cf-a800-64a2" type="max"/>
-              </constraints>
-              <categoryLinks>
-                <categoryLink id="7181-2a09-71a1-38b9" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="f77a-59e8-bdb9-8ee1" name="*Battalion: Lords of the Clan" hidden="false" targetId="3388-e687-3bd2-98a8" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
-                  <constraints/>
-                </categoryLink>
-              </categoryLinks>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="8a0f-4a95-ed0e-33cd" name="Battalion: Harvestboon Wargrove" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="823c-3e58-f6d6-6b39" name="Chorus of Magic" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Add 1 to casting rolls for Harvestboon Branchwraiths."/>
-          </characteristics>
-        </profile>
-        <profile id="dc04-537e-24cb-7ac1" name="Vibrant Surge" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Add 1 to any run or charge rolls made for Harvestboon units."/>
-          </characteristics>
-        </profile>
-        <profile id="90c0-438e-5042-da2f" name="Tear of Grace" hidden="false" profileTypeId="0ac4-aacb-2481-8e72" profileTypeName="Artefact">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Artefact Details" characteristicTypeId="0918-c47a-d84e-c0cf" value="One Harvestboon Branchwraith can have the following artefact of power instead of one chosen from the Sylvaneth artefacts.  The bearer of the Tear of Grace knows an extra spell, which is always generated from the Deepwood spell lore. In addition, the bearer can add 3&quot; to the range of all of their spells."/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="c5a0-6fae-0bef-53fd" name="1 Forest Folk battalion" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47f3-2f06-f76a-c53a" type="min"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries>
-            <selectionEntry id="fd4a-fdcb-2fe0-1b4c" name="Battalion: Forest Folk" hidden="false" collective="false" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6eb7-bbef-3b04-74a6" type="max"/>
+                  </constraints>
+                  <categoryLinks>
+                    <categoryLink id="29ea-fdaf-76b1-0274" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="ab95-37d7-3f1f-e16f" name="2. Households (0 to 2)" hidden="false" collective="false">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f650-9dfc-4f6c-aaf7" type="max"/>
-              </constraints>
-              <categoryLinks>
-                <categoryLink id="bcd7-9912-b4bf-5959" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="false">
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="2504-5b9a-fd15-5811" name="*Battalion: Household" hidden="false" targetId="d141-06d7-9c9e-d410" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
-                  <constraints/>
-                </categoryLink>
-              </categoryLinks>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ea1-4ecb-7e14-4b93" type="max"/>
+                  </constraints>
+                  <categoryLinks>
+                    <categoryLink id="0426-2507-d383-45a6" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="44f8-77d7-4003-2248" name="3. Forest Folk (0 to 3, can each contain an additional Branchwraith)" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
               <selectionEntries>
-                <selectionEntry id="2da3-5544-d626-d2b7" name="Forest Folk" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="d685-f6ff-53cf-4715" name="*Battalion: Forest Folk" hidden="false" collective="false" type="upgrade">
                   <profiles>
-                    <profile id="fb85-6499-0874-e158" name="Fade from View" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+                    <profile id="9af0-f87b-621d-10e1" name="Fade from View" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -2378,216 +2125,25 @@
                   <infoLinks/>
                   <modifiers/>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e6b-4cc8-2abb-db15" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="253a-9248-7a4f-0138" type="min"/>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10bf-b850-07d2-6c4b" type="max"/>
                   </constraints>
                   <categoryLinks/>
                   <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="110.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups>
-                <selectionEntryGroup id="0e99-6d3f-7a9e-bc0c" name="3 units of Dryads" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85e9-3a54-6e1f-9085" type="min"/>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39f3-6eb7-fee9-f92e" type="max"/>
-                  </constraints>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="2ecf-c2ed-a345-43f2" name="Dryads" hidden="false" targetId="0a14-90fc-1335-3c79" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers>
-                        <modifier type="set" field="hidden" value="true">
-                          <repeats/>
-                          <conditions/>
-                          <conditionGroups>
-                            <conditionGroup type="or">
-                              <conditions>
-                                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
-                                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
-                                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
-                              </conditions>
-                              <conditionGroups/>
-                            </conditionGroup>
-                          </conditionGroups>
-                        </modifier>
-                      </modifiers>
-                      <constraints/>
-                      <categoryLinks>
-                        <categoryLink id="b475-0321-3ec7-8266" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                          <constraints/>
-                        </categoryLink>
-                      </categoryLinks>
-                    </entryLink>
-                    <entryLink id="c769-ccd5-d25b-bcfe" name="Dryads" hidden="false" targetId="0a14-90fc-1335-3c79" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers>
-                        <modifier type="set" field="hidden" value="true">
-                          <repeats/>
-                          <conditions/>
-                          <conditionGroups>
-                            <conditionGroup type="and">
-                              <conditions>
-                                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="notInstanceOf"/>
-                                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="notInstanceOf"/>
-                                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="notInstanceOf"/>
-                              </conditions>
-                              <conditionGroups/>
-                            </conditionGroup>
-                          </conditionGroups>
-                        </modifier>
-                      </modifiers>
-                      <constraints/>
-                      <categoryLinks>
-                        <categoryLink id="fd62-1fc0-7380-0c95" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                          <constraints/>
-                        </categoryLink>
-                      </categoryLinks>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="9c6b-e5c2-16c3-6dd8" name="2 Branchwraiths" book="" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0cc3-c38c-39fd-110d" type="min"/>
-                  </constraints>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="8435-a3e9-0999-6b2f" name="Branchwraith" hidden="false" targetId="67ae-bbfe-04fe-0e20" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e18c-79c5-0031-4d4e" type="max"/>
-                      </constraints>
-                      <categoryLinks>
-                        <categoryLink id="0027-d4ab-22a1-00df" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                          <constraints/>
-                        </categoryLink>
-                      </categoryLinks>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="f0e9-6c92-ad68-b4af" name="May also contain:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="0294-1607-8cd7-6ad3" name="0-2:" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-              <selectionEntries>
-                <selectionEntry id="3bee-45e3-c67f-2cfc" name="Battalion: Forest Folk" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="153c-59d5-b531-7aba" type="max"/>
-                  </constraints>
-                  <categoryLinks>
-                    <categoryLink id="9b37-d58a-6bc4-47b8" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="false">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </categoryLink>
-                  </categoryLinks>
-                  <selectionEntries>
-                    <selectionEntry id="0989-6880-e784-904f" name="Forest Folk" hidden="false" collective="false" type="upgrade">
-                      <profiles>
-                        <profile id="01cf-6603-3f58-9b95" name="Fade from View" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                          <characteristics>
-                            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Once per game, in your hero phase, the Forest Folk can vanish along the spirit paths. Remove all of the models in the battalion from the battlefield and set them to one side. Then set up each of the units anywhere within your territory, or within 3&quot; of a Sylvaneth Wyldwood. They must be set up at least 9&quot; from the enemy, and cannot move in the following movement phase."/>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c46-7e47-3aee-bcd9" type="max"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5820-3509-9b39-2bda" type="min"/>
-                      </constraints>
-                      <categoryLinks/>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="110.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
                   <selectionEntryGroups>
-                    <selectionEntryGroup id="5195-8430-ef2f-d5ad" name="3 units of Dryads" hidden="false" collective="false">
+                    <selectionEntryGroup id="ffad-39a0-88fb-e2e1" name="2. Dryads" hidden="false" collective="false">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
                       <modifiers/>
                       <constraints>
-                        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8102-6cc0-57bd-d7a0" type="min"/>
-                        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab33-791b-d3e7-4c65" type="max"/>
+                        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd98-6c2b-d042-7200" type="min"/>
+                        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c54d-b413-0d61-81ab" type="max"/>
                       </constraints>
                       <categoryLinks/>
                       <selectionEntries/>
                       <selectionEntryGroups/>
                       <entryLinks>
-                        <entryLink id="2856-a8c3-06b4-fcad" name="Dryads" hidden="false" targetId="0a14-90fc-1335-3c79" type="selectionEntry">
+                        <entryLink id="ecf9-f279-5e93-2c6c" name="Dryads" hidden="false" targetId="0a14-90fc-1335-3c79" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -2609,7 +2165,7 @@
                           </modifiers>
                           <constraints/>
                           <categoryLinks>
-                            <categoryLink id="aea5-8eab-04aa-9210" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                            <categoryLink id="a53b-f3ef-804f-42fb" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
                               <profiles/>
                               <rules/>
                               <infoLinks/>
@@ -2618,7 +2174,7 @@
                             </categoryLink>
                           </categoryLinks>
                         </entryLink>
-                        <entryLink id="fb4d-1ef5-ace2-1702" name="Dryads" hidden="false" targetId="0a14-90fc-1335-3c79" type="selectionEntry">
+                        <entryLink id="2f6e-bded-e3de-ba9a" name="Dryads" hidden="false" targetId="0a14-90fc-1335-3c79" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -2640,7 +2196,7 @@
                           </modifiers>
                           <constraints/>
                           <categoryLinks>
-                            <categoryLink id="c870-7b26-9beb-257f" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                            <categoryLink id="1bb1-c77b-521c-53cf" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
                               <profiles/>
                               <rules/>
                               <infoLinks/>
@@ -2651,28 +2207,27 @@
                         </entryLink>
                       </entryLinks>
                     </selectionEntryGroup>
-                    <selectionEntryGroup id="1e02-2b2e-8383-0a03" name="1-2 Branchwraiths" book="" hidden="false" collective="false">
+                    <selectionEntryGroup id="a05a-bb38-a3b1-0e31" name="1. Branchwraiths (1 to 2)" book="" hidden="false" collective="false">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
                       <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d39-81f2-e354-05bd" type="min"/>
-                      </constraints>
+                      <constraints/>
                       <categoryLinks/>
                       <selectionEntries/>
                       <selectionEntryGroups/>
                       <entryLinks>
-                        <entryLink id="d78c-4428-eb49-8b98" name="Branchwraith" hidden="false" targetId="67ae-bbfe-04fe-0e20" type="selectionEntry">
+                        <entryLink id="f013-8c31-4fb6-1b1d" name="Branchwraith" hidden="false" targetId="67ae-bbfe-04fe-0e20" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
                           <modifiers/>
                           <constraints>
-                            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2303-13a6-013f-eca3" type="max"/>
+                            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8bb-a43e-63ca-eea4" type="max"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0aa8-9c8a-ea76-15de" type="min"/>
                           </constraints>
                           <categoryLinks>
-                            <categoryLink id="a1f9-1f21-a8ab-1adc" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                            <categoryLink id="b776-7a4c-4846-fbf4" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
                               <profiles/>
                               <rules/>
                               <infoLinks/>
@@ -2686,14 +2241,14 @@
                   </selectionEntryGroups>
                   <entryLinks/>
                   <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
+                    <cost name="pts" costTypeId="points" value="140.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
               <selectionEntryGroups/>
               <entryLinks/>
             </selectionEntryGroup>
-            <selectionEntryGroup id="7dec-bb2f-01af-be13" name="0-3:" hidden="false" collective="false">
+            <selectionEntryGroup id="4caf-ef64-45f0-dc6e" name="4. Free Spirits" hidden="false" collective="false">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -2703,16 +2258,16 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="d9e2-3e3d-b208-79fe" name="Battalion: Household" hidden="false" targetId="d141-06d7-9c9e-d410" type="selectionEntry">
+                <entryLink id="203a-e56e-8535-7f7d" name="*Battalion: Free Spirits" hidden="false" targetId="f852-7524-198b-2957" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="711a-80f5-cd29-7639" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e38-9c01-30f9-935e" type="max"/>
                   </constraints>
                   <categoryLinks>
-                    <categoryLink id="c2fe-cdd3-d42e-a9e5" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                    <categoryLink id="4506-34fe-0744-ce17" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -2723,45 +2278,61 @@
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
+            <selectionEntryGroup id="add6-194e-85bb-3317" name="5. Outcasts" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="7052-4b44-3942-0795" name="*Battalion: Outcasts" hidden="false" targetId="471d-38f0-5388-84a0" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d4a8-ecbc-e203-4cf7" type="max"/>
+                  </constraints>
+                  <categoryLinks>
+                    <categoryLink id="8b69-a1d5-3a36-143a" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="7682-aff8-ffcc-f102" name="6. Order Wizard" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d6d-f0b5-138a-de8e" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="4925-8a1d-eb67-a57a" name="Order Wizards" hidden="false" targetId="f99e-36cd-f48a-0435" type="selectionEntryGroup">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="8b9b-8370-8bc7-e075" name="Battalion: Free Spirits" hidden="false" targetId="f852-7524-198b-2957" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ead-491a-4bd8-08f7" type="max"/>
-              </constraints>
-              <categoryLinks>
-                <categoryLink id="9628-fd20-d483-29d3" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </categoryLink>
-              </categoryLinks>
-            </entryLink>
-            <entryLink id="8629-a48b-2688-62b0" name="Battalion: Lords of the Clan" hidden="false" targetId="3388-e687-3bd2-98a8" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bdbc-6454-1f0a-5c8a" type="max"/>
-              </constraints>
-              <categoryLinks>
-                <categoryLink id="89ab-5f89-c773-d5f5" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </categoryLink>
-              </categoryLinks>
-            </entryLink>
-            <entryLink id="4316-9609-e775-2066" name="Any number of Additional Sylvaneth Units" hidden="false" targetId="2f01-3499-14c8-1107" type="selectionEntryGroup">
+            <entryLink id="d9c0-7ce9-56da-1f69" name="Any number of Additional Sylvaneth Units" hidden="false" targetId="2f01-3499-14c8-1107" type="selectionEntryGroup">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -2769,23 +2340,675 @@
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="9a4a-4abf-b450-bed2" name="Battalion: Outcasts" hidden="false" targetId="471d-38f0-5388-84a0" type="selectionEntry">
-              <profiles/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="7749-96a8-f53a-47dd" name="1. Household (must contain Treelord Ancient instead of Treelord)" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="2d60-9bc7-aee3-a6db" name="Battalion: Household" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="f37f-3c4f-6b35-445f" name="Discipline of the Ages" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Enemy units cannot choose to retreat if they are within 3&quot; of a Household unit. In addition, units from this battalion add 1 to their Bravery in the battleshock phase if they are within 3&quot; of an enemy unit."/>
+                  </characteristics>
+                </profile>
+              </profiles>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1aad-65d7-fd13-3545" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf13-1f2f-0ff9-0a3b" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="094b-72f0-1cbe-7d0d" type="max"/>
               </constraints>
-              <categoryLinks>
-                <categoryLink id="0e41-c9a2-2748-5651" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="586e-cf67-e688-a996" name="2. Branchwych" book="" hidden="false" collective="false">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                   <constraints/>
-                </categoryLink>
-              </categoryLinks>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="a9af-08b4-fb90-ef82" name="Branchwych" hidden="false" targetId="d65c-84f8-43bf-d534" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe50-dffd-c817-0c88" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f45a-f1e1-7f07-e43e" type="min"/>
+                      </constraints>
+                      <categoryLinks>
+                        <categoryLink id="769b-83cd-e93f-0393" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </categoryLink>
+                      </categoryLinks>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="43ec-57a3-7018-9c10" name="1. Treelord Ancient" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="c08f-02bc-aac3-eca8" name="Treelord Ancient" hidden="false" targetId="524f-f49b-0bfd-9414" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4aa7-40e1-1540-55ad" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f42d-d0a0-86de-1339" type="min"/>
+                      </constraints>
+                      <categoryLinks>
+                        <categoryLink id="6cf0-1569-5cfa-4d54" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </categoryLink>
+                        <categoryLink id="e6c4-7688-bb6f-90a9" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </categoryLink>
+                      </categoryLinks>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="08d1-a1cd-4f6e-d360" name="3. Tree-Revenants" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="deb3-4b65-0842-7769" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1bd0-5fad-dd78-8e65" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="eced-005d-769b-3844" name="Tree-Revenants" hidden="false" targetId="a74a-7377-3ed9-0f5e" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers>
+                        <modifier type="set" field="hidden" value="true">
+                          <repeats/>
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cc2e-a897-99a2-353f" type="equalTo"/>
+                          </conditions>
+                          <conditionGroups/>
+                        </modifier>
+                      </modifiers>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65e5-0f65-ab5f-d02c" type="max"/>
+                      </constraints>
+                      <categoryLinks>
+                        <categoryLink id="1fb8-6dfd-cdb9-314e" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </categoryLink>
+                      </categoryLinks>
+                    </entryLink>
+                    <entryLink id="7a76-d0fa-d53a-2ed3" name="Tree-Revenants" hidden="false" targetId="a74a-7377-3ed9-0f5e" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers>
+                        <modifier type="set" field="hidden" value="true">
+                          <repeats/>
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cc2e-a897-99a2-353f" type="equalTo"/>
+                          </conditions>
+                          <conditionGroups/>
+                        </modifier>
+                      </modifiers>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="19a6-3b96-44e7-8e0f" type="max"/>
+                      </constraints>
+                      <categoryLinks>
+                        <categoryLink id="c98d-f0b9-d701-9530" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </categoryLink>
+                      </categoryLinks>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="130.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8a0f-4a95-ed0e-33cd" name="Super Battalion: Harvestboon Wargrove" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="823c-3e58-f6d6-6b39" name="Chorus of Magic" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Add 1 to casting rolls for Harvestboon Branchwraiths."/>
+          </characteristics>
+        </profile>
+        <profile id="dc04-537e-24cb-7ac1" name="Vibrant Surge" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Add 1 to any run or charge rolls made for Harvestboon units."/>
+          </characteristics>
+        </profile>
+        <profile id="2be5-eae6-222a-ac77" name="Wargrove Ability" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="One Harvestboon Branchwraith can select the Tear of Grace artefact instead of any other Arcane Treasure."/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="085e-4d66-d040-a531" name="Mighty Wildwood" hidden="false" targetId="e69e-ffc7-e031-9478" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="0cdc-ad76-92e6-9e74" name="WARGROVE HARVESTBORN" hidden="false" targetId="36f8-6827-6ec9-c876" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="c5a0-6fae-0bef-53fd" name="1. Forest Folk (must contain 1 additional Branchwraith)" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="f0ca-03f0-3183-d2ed" name="Battalion: Forest Folk" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="cbe3-a5d1-3ca4-ffdf" name="Fade from View" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Once per game, in your hero phase, the Forest Folk can vanish along the spirit paths. Remove all of the models in the battalion from the battlefield and set them to one side. Then set up each of the units anywhere within your territory, or within 3&quot; of a Sylvaneth Wyldwood. They must be set up at least 9&quot; from the enemy, and cannot move in the following movement phase."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba45-7d1a-e957-cd27" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b09-7ad6-1717-1a76" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="0149-1780-c937-e81b" name="2. Dryads" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8800-91bf-3235-ac2c" type="min"/>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e12-007f-c77a-92aa" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="7e38-f4d3-f51d-f977" name="Dryads" hidden="false" targetId="0a14-90fc-1335-3c79" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers>
+                        <modifier type="set" field="hidden" value="true">
+                          <repeats/>
+                          <conditions/>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
+                                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
+                                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
+                              </conditions>
+                              <conditionGroups/>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </modifier>
+                      </modifiers>
+                      <constraints/>
+                      <categoryLinks>
+                        <categoryLink id="3f7b-ccd3-29f5-5e13" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </categoryLink>
+                      </categoryLinks>
+                    </entryLink>
+                    <entryLink id="4e93-1397-f235-b5f1" name="Dryads" hidden="false" targetId="0a14-90fc-1335-3c79" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers>
+                        <modifier type="set" field="hidden" value="true">
+                          <repeats/>
+                          <conditions/>
+                          <conditionGroups>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="notInstanceOf"/>
+                                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="notInstanceOf"/>
+                                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="notInstanceOf"/>
+                              </conditions>
+                              <conditionGroups/>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </modifier>
+                      </modifiers>
+                      <constraints/>
+                      <categoryLinks>
+                        <categoryLink id="233e-f0a2-95c7-8ec2" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </categoryLink>
+                      </categoryLinks>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="5ef4-03b9-47e4-2e75" name="1. Branchwraiths" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="dec0-a35c-b8e0-d0ec" name="Branchwraith" hidden="false" targetId="67ae-bbfe-04fe-0e20" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1753-3585-1a60-4252" type="max"/>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cefc-362f-1481-0878" type="min"/>
+                      </constraints>
+                      <categoryLinks>
+                        <categoryLink id="926a-4569-e5e0-9e95" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </categoryLink>
+                      </categoryLinks>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="140.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="f0e9-6c92-ad68-b4af" name="May also contain:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="b08a-880f-d741-8449" name="1. Lords of Clan" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="7d72-79ef-cb1c-92f4" name="*Battalion: Lords of the Clan" hidden="false" targetId="3388-e687-3bd2-98a8" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4087-7468-6fc1-d1df" type="max"/>
+                  </constraints>
+                  <categoryLinks>
+                    <categoryLink id="d860-3008-cf83-ecc5" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="a74b-e6a1-0d7b-7252" name="2. Households (0 to 3)" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="c9b4-cde4-7456-6d5b" name="*Battalion: Household" hidden="false" targetId="d141-06d7-9c9e-d410" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0091-ddb2-1caa-672c" type="max"/>
+                  </constraints>
+                  <categoryLinks>
+                    <categoryLink id="d8a1-3d2e-a0bb-ec13" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="7dc8-c988-38a5-46f9" name="4. Free Spirits" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="b406-a142-d5b6-2fa1" name="*Battalion: Free Spirits" hidden="false" targetId="f852-7524-198b-2957" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b58-4d5d-0f14-fd8f" type="max"/>
+                  </constraints>
+                  <categoryLinks>
+                    <categoryLink id="39eb-ff33-41bd-0ce8" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="2641-c671-8900-657c" name="5. Outcasts" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="995e-46ce-eed6-c0d9" name="*Battalion: Outcasts" hidden="false" targetId="471d-38f0-5388-84a0" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6be-3653-57bc-5270" type="max"/>
+                  </constraints>
+                  <categoryLinks>
+                    <categoryLink id="9698-a27f-d701-205f" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="4c56-807f-818c-1229" name="3. Forest Folk (0 to 2, can each contain an additional Branchwraith)" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries>
+                <selectionEntry id="d5b0-5d0f-bcf8-959b" name="*Battalion: Forest Folk" hidden="false" collective="false" type="upgrade">
+                  <profiles>
+                    <profile id="b87d-a51c-765e-da6c" name="Fade from View" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Once per game, in your hero phase, the Forest Folk can vanish along the spirit paths. Remove all of the models in the battalion from the battlefield and set them to one side. Then set up each of the units anywhere within your territory, or within 3&quot; of a Sylvaneth Wyldwood. They must be set up at least 9&quot; from the enemy, and cannot move in the following movement phase."/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e0f-37f5-97b7-2a07" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups>
+                    <selectionEntryGroup id="357e-199e-3d14-3aa8" name="2. Dryads" hidden="false" collective="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2155-c119-ce24-a35e" type="min"/>
+                        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da0a-9148-e111-6337" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks>
+                        <entryLink id="0972-82a9-2a0c-13a3" name="Dryads" hidden="false" targetId="0a14-90fc-1335-3c79" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers>
+                            <modifier type="set" field="hidden" value="true">
+                              <repeats/>
+                              <conditions/>
+                              <conditionGroups>
+                                <conditionGroup type="or">
+                                  <conditions>
+                                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
+                                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
+                                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
+                                  </conditions>
+                                  <conditionGroups/>
+                                </conditionGroup>
+                              </conditionGroups>
+                            </modifier>
+                          </modifiers>
+                          <constraints/>
+                          <categoryLinks>
+                            <categoryLink id="32bb-2459-72a8-bbaa" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <constraints/>
+                            </categoryLink>
+                          </categoryLinks>
+                        </entryLink>
+                        <entryLink id="1774-45d7-7dd6-1f14" name="Dryads" hidden="false" targetId="0a14-90fc-1335-3c79" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers>
+                            <modifier type="set" field="hidden" value="true">
+                              <repeats/>
+                              <conditions/>
+                              <conditionGroups>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="notInstanceOf"/>
+                                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="notInstanceOf"/>
+                                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="notInstanceOf"/>
+                                  </conditions>
+                                  <conditionGroups/>
+                                </conditionGroup>
+                              </conditionGroups>
+                            </modifier>
+                          </modifiers>
+                          <constraints/>
+                          <categoryLinks>
+                            <categoryLink id="bf38-cabe-8f37-4bda" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <constraints/>
+                            </categoryLink>
+                          </categoryLinks>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                    <selectionEntryGroup id="4e1f-83be-a0a8-64cb" name="1. Branchwraiths (1 to 2)" book="" hidden="false" collective="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks/>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks>
+                        <entryLink id="f789-60bb-6dd1-a631" name="Branchwraith" hidden="false" targetId="67ae-bbfe-04fe-0e20" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b677-e4fa-e064-3098" type="max"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cfea-1c82-5d86-8de1" type="min"/>
+                          </constraints>
+                          <categoryLinks>
+                            <categoryLink id="bf82-d5a1-756c-aa9a" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <constraints/>
+                            </categoryLink>
+                          </categoryLinks>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                  </selectionEntryGroups>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="140.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="4316-9609-e775-2066" name="Any number of Additional Sylvaneth Units" hidden="false" targetId="2f01-3499-14c8-1107" type="selectionEntryGroup">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
@@ -2795,83 +3018,149 @@
         <cost name="pts" costTypeId="points" value="100.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="ea19-9675-828d-9c83" name="Battalion: Heartwood Wargrove" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries>
-        <selectionEntry id="b65c-92dc-46e6-aa73" name="Heartwood Wargrove" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="357e-68a6-f75f-cd2a" name="Followers of the Wild Hunt" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Roll a dice in each of your hero phases, adding 1 to the roll if there are any friendly units of Kurnoth Hunters on the battlefield. On a roll of 6 or more you can replace a unit of Heartwood Dryads, Tree-Revenants, or Spite-Revenants that has been completely destroyed with an identical unit. Set up the replacement unit within 6&quot; of the edge of the battlefield or within a Sylvaneth Wyldwood, and more than 9&quot; from any enemy units. This counts as its move for the following movement phase."/>
-              </characteristics>
-            </profile>
-            <profile id="0fb2-7956-0bb6-977a" name="Worshippers of Kurnoth" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Add 1 to the Bravery of any Heartwood units that are within 6&quot; of a friendly unit of Kurnoth Hunters. This bonus does not apply to units of Kurnoth Hunters themselves."/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bdf5-80fd-244d-dd69" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4741-f7e7-80c4-4b05" type="min"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="d4b0-b350-faa0-845c" name="1 Free Spirits Battalion" hidden="false" collective="false">
+    <selectionEntry id="ea19-9675-828d-9c83" name="Super Battalion: Heartwood Wargrove" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="c188-86b6-90f0-6f04" name="Followers of the Wild Hunt" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d6dc-e7c4-271d-a1ca" type="min"/>
-          </constraints>
+          <characteristics>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Roll a dice in each of your hero phases, adding 1 to the roll if there are any friendly units of Kurnoth Hunters on the battlefield. On a roll of 6 or more you can replace a unit of Heartwood Dryads, Tree-Revenants, or Spite-Revenants that has been completely destroyed with an identical unit. Set up the replacement unit within 6&quot; of the edge of the battlefield or within a Sylvaneth Wyldwood, and more than 9&quot; from any enemy units. This counts as its move for the following movement phase."/>
+          </characteristics>
+        </profile>
+        <profile id="2c6b-9261-1bff-4bf3" name="Worshippers of Kurnoth" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Add 1 to the Bravery of any Heartwood units that are within 6&quot; of a friendly unit of Kurnoth Hunters. This bonus does not apply to units of Kurnoth Hunters themselves."/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="5439-f9d6-bda8-94e2" name="Mighty Wildwood" hidden="false" targetId="e69e-ffc7-e031-9478" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="d4b0-b350-faa0-845c" name="1. Free Spirits Battalion" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
           <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="a5ce-0f46-58b8-8c7f" name="Battalion: Free Spirits" hidden="false" targetId="f852-7524-198b-2957" type="selectionEntry">
-              <profiles/>
+          <selectionEntries>
+            <selectionEntry id="bc34-3d8b-b8b0-3485" name="Battalion: Free Spirits" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="647e-c841-0adf-63da" name="Swift Vengeance" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="In your hero phase, you can pick either an enemy unit or a terrain feature, and then move each unit from the Free Spirits as though it were the movement phase (they cannot run). They must end their move closer to the chosen unit or terrain feature than they were before they moved."/>
+                  </characteristics>
+                </profile>
+              </profiles>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48c9-662c-744c-76d6" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="05a5-0c9b-2cf5-ed23" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12fa-e863-1bd2-bd36" type="max"/>
               </constraints>
-              <categoryLinks>
-                <categoryLink id="34bf-86a0-c286-5346" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="1d08-e850-9335-5046" name="1. Spirit of Durthu" hidden="false" collective="false">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                   <constraints/>
-                </categoryLink>
-              </categoryLinks>
-            </entryLink>
-          </entryLinks>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="21a5-af66-4f35-5b18" name="Spirit of Durthu" hidden="false" targetId="ef77-af66-26da-3a02" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e2f-a0de-77b1-8c14" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="53c8-dd79-c8e0-60c5" type="min"/>
+                      </constraints>
+                      <categoryLinks>
+                        <categoryLink id="f56d-8f32-73f5-975b" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </categoryLink>
+                        <categoryLink id="fab2-d605-b388-b0b0" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </categoryLink>
+                      </categoryLinks>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="3250-a2f2-06cc-9f9f" name="2. Kurnoth Hunters (4 to 6)" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="44c8-c42d-2c17-60d8" name="Kurnoth Hunters" hidden="false" targetId="e14d-00c2-5ed8-220a" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a27-c944-cca8-e8d7" type="min"/>
+                        <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e67-9e03-10d5-fdba" type="max"/>
+                      </constraints>
+                      <categoryLinks>
+                        <categoryLink id="0d2d-5d93-4745-8c22" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </categoryLink>
+                      </categoryLinks>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
         </selectionEntryGroup>
         <selectionEntryGroup id="be48-4775-8896-e315" name="May also contain:" hidden="false" collective="false">
           <profiles/>
@@ -2882,7 +3171,7 @@
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups>
-            <selectionEntryGroup id="7770-fc10-80d9-551a" name="0-3:" hidden="false" collective="false">
+            <selectionEntryGroup id="e795-f16c-c1c8-973a" name="1. Lords of Clan" hidden="false" collective="false">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -2892,16 +3181,16 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="4d36-f88e-f15b-e9a4" name="Battalion: Forest Folk" hidden="false" targetId="756d-d96e-e298-5558" type="selectionEntry">
+                <entryLink id="aab6-d3eb-8578-97c2" name="*Battalion: Lords of the Clan" hidden="false" targetId="3388-e687-3bd2-98a8" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1be7-d4cf-0567-0b8f" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ae4-b29d-2871-70b6" type="max"/>
                   </constraints>
                   <categoryLinks>
-                    <categoryLink id="fb6e-e8c9-25df-4bbd" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                    <categoryLink id="717a-bddb-bb9f-bbfd" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -2912,7 +3201,7 @@
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="8e30-8884-afac-8835" name="0-3:" hidden="false" collective="false">
+            <selectionEntryGroup id="ddd3-e442-85da-ed56" name="2. Households (0 to 3)" hidden="false" collective="false">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -2922,16 +3211,16 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="88d4-04d3-33a6-655b" name="Battalion: Household" hidden="false" targetId="d141-06d7-9c9e-d410" type="selectionEntry">
+                <entryLink id="7af8-c7e3-33ae-8be5" name="*Battalion: Household" hidden="false" targetId="d141-06d7-9c9e-d410" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ac8-2485-3db5-e34a" type="max"/>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="694d-3d65-9cb2-2940" type="max"/>
                   </constraints>
                   <categoryLinks>
-                    <categoryLink id="5fc4-1fac-1e42-79b2" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                    <categoryLink id="a8f4-e9c6-3c31-2327" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -2939,47 +3228,63 @@
                       <constraints/>
                     </categoryLink>
                   </categoryLinks>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="f55d-e11f-4dbc-b080" name="4. Outcasts" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="e6b4-62c1-8ac8-00f1" name="*Battalion: Outcasts" hidden="false" targetId="471d-38f0-5388-84a0" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b6aa-efff-4f7e-733a" type="max"/>
+                  </constraints>
+                  <categoryLinks>
+                    <categoryLink id="d155-2e3e-37cf-ae51" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="42ff-538a-80ac-0291" name="3. Forest Folk (0 to 3)" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="119e-7c1a-66bb-6600" name="*Battalion: Forest Folk" hidden="false" targetId="756d-d96e-e298-5558" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d612-4983-7ec9-3aae" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="ad6f-796e-ccd5-f8f7" name="Battalion: Lords of the Clan" hidden="false" targetId="3388-e687-3bd2-98a8" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="843b-19ca-2a3e-a3b4" type="max"/>
-              </constraints>
-              <categoryLinks>
-                <categoryLink id="beee-a9a5-a72e-edff" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </categoryLink>
-              </categoryLinks>
-            </entryLink>
-            <entryLink id="816c-6578-d729-f625" name="Battalion: Outcasts" hidden="false" targetId="471d-38f0-5388-84a0" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff88-6e92-8dcc-88b0" type="max"/>
-              </constraints>
-              <categoryLinks>
-                <categoryLink id="01f8-f078-7ed2-4bea" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </categoryLink>
-              </categoryLinks>
-            </entryLink>
             <entryLink id="8d1d-b066-a9a5-5b1f" name="Any number of Additional Sylvaneth Units" hidden="false" targetId="2f01-3499-14c8-1107" type="selectionEntryGroup">
               <profiles/>
               <rules/>
@@ -2997,58 +3302,30 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="d141-06d7-9c9e-d410" name="Battalion: Household" hidden="false" collective="false" type="upgrade">
-      <profiles/>
+      <profiles>
+        <profile id="4ace-9902-4344-7a60" name="Discipline of the Ages" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Enemy units cannot choose to retreat if they are within 3&quot; of a Household unit. In addition, units from this battalion add 1 to their Bravery in the battleshock phase if they are within 3&quot; of an enemy unit."/>
+          </characteristics>
+        </profile>
+      </profiles>
       <rules/>
       <infoLinks/>
       <modifiers/>
       <constraints/>
       <categoryLinks/>
-      <selectionEntries>
-        <selectionEntry id="9676-e7a8-463e-9318" name="Household" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="fd6c-b3a5-72ba-0888" name="Discipline of the Ages" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Enemy units cannot choose to retreat if they are within 3&quot; of a Household unit. In addition, units from this battalion add 1 to their Bravery in the battleshock phase if they are within 3&quot; of an enemy unit."/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2a6-a67e-34d2-7677" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="749a-7a0c-49bc-d11d" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="100.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+      <selectionEntries/>
       <selectionEntryGroups>
-        <selectionEntryGroup id="5e09-6e10-bd24-d190" name="1 Treelord" hidden="false" collective="false">
+        <selectionEntryGroup id="5e09-6e10-bd24-d190" name="1. Treelord" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <repeats/>
-              <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7749-96a8-f53a-47dd" type="instanceOf"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f14f-b200-8c60-ce15" type="min"/>
-          </constraints>
+          <modifiers/>
+          <constraints/>
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups/>
@@ -3060,6 +3337,7 @@
               <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="598a-1e1d-ee5d-7725" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf06-be44-3321-a507" type="min"/>
               </constraints>
               <categoryLinks>
                 <categoryLink id="8458-eebe-a45c-0f75" hidden="false" targetId="fa0c-9044-2568-fa02" primary="true">
@@ -3073,14 +3351,12 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="8336-643d-7c1e-da7b" name="1 Branchwych" book="" hidden="false" collective="false">
+        <selectionEntryGroup id="8336-643d-7c1e-da7b" name="2. Branchwych" book="" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="216d-bf73-5588-43ef" type="min"/>
-          </constraints>
+          <constraints/>
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups/>
@@ -3092,6 +3368,7 @@
               <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e05-a05e-85d9-6b4e" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6305-ace0-6b89-2225" type="min"/>
               </constraints>
               <categoryLinks>
                 <categoryLink id="f3e0-6512-94c6-98b9" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
@@ -3105,60 +3382,14 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="85ca-6275-6da2-4dbd" name="1 Treelord Ancient" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <repeats/>
-              <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7749-96a8-f53a-47dd" type="notInstanceOf"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a7e-cf3a-94e2-b839" type="min"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="ee31-e1f5-fdf6-690a" name="Treelord Ancient" hidden="false" targetId="524f-f49b-0bfd-9414" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e0eb-08cf-04ee-4d40" type="max"/>
-              </constraints>
-              <categoryLinks>
-                <categoryLink id="70bf-4101-a561-61d9" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </categoryLink>
-                <categoryLink id="f379-f19e-eec8-4470" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </categoryLink>
-              </categoryLinks>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="f3aa-de1a-5ba7-0fc2" name="1 unit of Tree-Revenants" hidden="false" collective="false">
+        <selectionEntryGroup id="f3aa-de1a-5ba7-0fc2" name="3. Tree-Revenants" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="253f-bf83-a574-d32d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de77-defc-0dea-55e8" type="max"/>
           </constraints>
           <categoryLinks/>
           <selectionEntries/>
@@ -3177,9 +3408,7 @@
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="75ca-7e76-6e7b-e506" type="max"/>
-              </constraints>
+              <constraints/>
               <categoryLinks>
                 <categoryLink id="a81c-5a0d-b0ff-85dc" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
                   <profiles/>
@@ -3203,9 +3432,7 @@
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="516a-f252-e171-7a77" type="max"/>
-              </constraints>
+              <constraints/>
               <categoryLinks>
                 <categoryLink id="b6fa-455f-9f35-738d" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
                   <profiles/>
@@ -3224,7 +3451,7 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="27be-17b6-39ff-0e4c" name="Battalion: Ironbark Wargrove" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="27be-17b6-39ff-0e4c" name="Super Battalion: Ironbark Wargrove" hidden="false" collective="false" type="upgrade">
       <profiles>
         <profile id="9137-9044-87d3-8f64" name="Stubborn and Taciturn" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>
@@ -3244,110 +3471,92 @@
             <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="You can re-roll wound rolls of 1 for the enchanted blades, protector glaives or greenwood scythes used by Ironbark Tree-Revenants and Branchwyches."/>
           </characteristics>
         </profile>
-        <profile id="1bcf-4d1f-0584-ba1a" name="Ironbark Talisman" hidden="false" profileTypeId="0ac4-aacb-2481-8e72" profileTypeName="Artefact">
+        <profile id="5177-ed1a-13fc-c4e3" name="Wargrove Ability" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Artefact Details" characteristicTypeId="0918-c47a-d84e-c0cf" value="One Ironbark HERO can have the Ironbark Talisman artefact of power rather than the Sylvaneth artefacts.  You can add 1 to all wound rolls made for the bearer’s melee weapons."/>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="One Ironbark HERO can select the Ironbark Talisman artefact instead of any other selection."/>
           </characteristics>
         </profile>
       </profiles>
       <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="34c1-00fd-02e7-f461" name="1 Household battalion" hidden="false" collective="false">
+      <infoLinks>
+        <infoLink id="e096-aeaa-ee10-71ff" name="Mighty Wildwood" hidden="false" targetId="e69e-ffc7-e031-9478" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8825-dede-2cd1-0bc0" type="min"/>
-          </constraints>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="e2aa-f22d-2c7d-05c8" name="WARGROVE IRONBARK" hidden="false" targetId="9499-680b-d7f9-c2b4" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="34c1-00fd-02e7-f461" name="1. Household" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
           <categoryLinks/>
           <selectionEntries>
-            <selectionEntry id="9f3f-122d-27d6-70af" name="Battalion: Household" hidden="false" collective="false" type="upgrade">
-              <profiles/>
+            <selectionEntry id="f28c-271a-4fe8-fbb4" name="*Battalion: Household" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="5924-2838-1c3c-8cc4" name="Discipline of the Ages" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Enemy units cannot choose to retreat if they are within 3&quot; of a Household unit. In addition, units from this battalion add 1 to their Bravery in the battleshock phase if they are within 3&quot; of an enemy unit."/>
+                  </characteristics>
+                </profile>
+              </profiles>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf8c-9225-0b43-8584" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="74c3-3a4d-8816-4ae9" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8875-6e17-1170-a649" type="max"/>
               </constraints>
-              <categoryLinks>
-                <categoryLink id="0626-0829-ad60-9b85" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </categoryLink>
-              </categoryLinks>
-              <selectionEntries>
-                <selectionEntry id="c2dd-b84f-e0a4-a924" name="Household" hidden="false" collective="false" type="upgrade">
-                  <profiles>
-                    <profile id="fca6-5d19-9f33-a40f" name="Discipline of the Ages" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <characteristics>
-                        <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Enemy units cannot choose to retreat if they are within 3&quot; of a Household unit. In addition, units from this battalion add 1 to their Bravery in the battleshock phase if they are within 3&quot; of an enemy unit."/>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9246-332f-dfd6-ebd2" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0043-e6b3-a780-3f10" type="max"/>
-                  </constraints>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="70.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
+              <categoryLinks/>
+              <selectionEntries/>
               <selectionEntryGroups>
-                <selectionEntryGroup id="b66c-ecd3-cb84-16c4" name="1 Treelord" hidden="false" collective="false">
+                <selectionEntryGroup id="d766-f0aa-7db3-b776" name="1. Treelord" hidden="false" collective="false">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="true">
-                      <repeats/>
-                      <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7749-96a8-f53a-47dd" type="instanceOf"/>
-                      </conditions>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
+                  <modifiers/>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="701a-49ee-2e65-8270" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e924-7a07-5669-f289" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="504d-8910-6af2-6cc1" type="max"/>
                   </constraints>
                   <categoryLinks/>
                   <selectionEntries/>
                   <selectionEntryGroups/>
                   <entryLinks>
-                    <entryLink id="1642-d7aa-a7ce-1c57" name="Treelord" hidden="false" targetId="0861-c6bd-bf12-f2f4" type="selectionEntry">
+                    <entryLink id="5cfc-a80e-ffee-7ea6" name="Treelord" hidden="false" targetId="0861-c6bd-bf12-f2f4" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
                       <modifiers/>
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f42d-259d-ac89-b68c" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c7a5-5380-b485-3649" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae78-1978-4b68-a4c1" type="min"/>
                       </constraints>
                       <categoryLinks>
-                        <categoryLink id="4bfc-a598-9962-ea94" hidden="false" targetId="fa0c-9044-2568-fa02" primary="true">
+                        <categoryLink id="fad3-161a-2f19-b586" hidden="false" targetId="fa0c-9044-2568-fa02" primary="true">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -3358,28 +3567,30 @@
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
-                <selectionEntryGroup id="9a55-8fad-0f2e-ba03" name="1 Branchwych" book="" hidden="false" collective="false">
+                <selectionEntryGroup id="d03e-074c-2cd5-4447" name="2. Branchwych" book="" hidden="false" collective="false">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b0c1-1c95-0939-93f4" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11e7-30a1-9363-2954" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="101d-d3a0-cce2-cee9" type="max"/>
                   </constraints>
                   <categoryLinks/>
                   <selectionEntries/>
                   <selectionEntryGroups/>
                   <entryLinks>
-                    <entryLink id="1894-a6b0-183e-12ca" name="Branchwych" hidden="false" targetId="d65c-84f8-43bf-d534" type="selectionEntry">
+                    <entryLink id="fb60-0955-e460-0555" name="Branchwych" hidden="false" targetId="d65c-84f8-43bf-d534" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
                       <modifiers/>
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d4b-6dc7-6d1f-ac6e" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6026-15af-ae33-a0a7" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2406-b4c9-7c7a-8b93" type="min"/>
                       </constraints>
                       <categoryLinks>
-                        <categoryLink id="70ea-0ec0-7dff-fed3" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                        <categoryLink id="dcb3-9354-2c90-7783" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -3390,19 +3601,20 @@
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
-                <selectionEntryGroup id="c585-d6a8-2808-86fc" name="2 units of Tree-Revenants" hidden="false" collective="false">
+                <selectionEntryGroup id="e117-decc-b6a2-ecf0" name="3. Tree-Revenants" hidden="false" collective="false">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f125-b7be-baa5-74aa" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c7c4-359b-4a18-f018" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a956-e3c3-f8ae-a06b" type="max"/>
                   </constraints>
                   <categoryLinks/>
                   <selectionEntries/>
                   <selectionEntryGroups/>
                   <entryLinks>
-                    <entryLink id="1cf9-870a-71a8-051c" name="Tree-Revenants" hidden="false" targetId="a74a-7377-3ed9-0f5e" type="selectionEntry">
+                    <entryLink id="1c48-4369-530d-8bb1" name="Tree-Revenants" hidden="false" targetId="a74a-7377-3ed9-0f5e" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -3416,10 +3628,10 @@
                         </modifier>
                       </modifiers>
                       <constraints>
-                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c8c-6535-633d-efd3" type="max"/>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87b0-db0f-7c88-f454" type="max"/>
                       </constraints>
                       <categoryLinks>
-                        <categoryLink id="181c-1936-7750-f333" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                        <categoryLink id="ce45-d271-bcc9-0b91" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -3428,7 +3640,7 @@
                         </categoryLink>
                       </categoryLinks>
                     </entryLink>
-                    <entryLink id="72bd-e07c-fced-a341" name="Tree-Revenants" hidden="false" targetId="a74a-7377-3ed9-0f5e" type="selectionEntry">
+                    <entryLink id="0888-0c4d-9610-57d3" name="Tree-Revenants" hidden="false" targetId="a74a-7377-3ed9-0f5e" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -3442,10 +3654,10 @@
                         </modifier>
                       </modifiers>
                       <constraints>
-                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="765d-d685-d7cc-9206" type="max"/>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6f0-6bf1-c8e3-dc8c" type="max"/>
                       </constraints>
                       <categoryLinks>
-                        <categoryLink id="8b6c-ea63-1f0b-335a" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                        <categoryLink id="ae22-57f5-e1b2-e533" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -3473,63 +3685,28 @@
           <modifiers/>
           <constraints/>
           <categoryLinks/>
-          <selectionEntries>
-            <selectionEntry id="2228-92d1-e168-d3bf" name="0-2: DUARDIN UNITS" hidden="false" collective="false" type="upgrade">
-              <profiles>
-                <profile id="31f0-83ee-0602-8795" name="DUARDIN Units" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <characteristics>
-                    <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="0-2"/>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="name" value="DUARDIN Units">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="27be-17b6-39ff-0e4c" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2228-92d1-e168-d3bf" type="greaterThan"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f5c-610b-9316-844c" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
+          <selectionEntries/>
           <selectionEntryGroups>
-            <selectionEntryGroup id="e405-a9bd-e9b7-9ebb" name="0-2 Household battalions" hidden="false" collective="false">
+            <selectionEntryGroup id="9cc9-df10-5997-481b" name="1. Lords of Clan" hidden="false" collective="false">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0bb4-03bb-e405-a0a4" type="min"/>
-              </constraints>
+              <constraints/>
               <categoryLinks/>
-              <selectionEntries>
-                <selectionEntry id="df97-e981-97fa-540e" name="Battalion: Household" hidden="false" collective="false" type="upgrade">
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="e635-17d0-32d2-9308" name="*Battalion: Lords of the Clan" hidden="false" targetId="3388-e687-3bd2-98a8" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="947e-4688-9bae-99d1" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a2d0-e45d-028f-5609" type="max"/>
                   </constraints>
                   <categoryLinks>
-                    <categoryLink id="4428-8326-b98a-b046" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="false">
+                    <categoryLink id="4063-8263-d9bf-630e" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -3537,66 +3714,59 @@
                       <constraints/>
                     </categoryLink>
                   </categoryLinks>
-                  <selectionEntries>
-                    <selectionEntry id="184b-509b-42d5-b1a5" name="Household" hidden="false" collective="false" type="upgrade">
-                      <profiles>
-                        <profile id="ccd3-b6e7-176d-6c68" name="Discipline of the Ages" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                          <characteristics>
-                            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Enemy units cannot choose to retreat if they are within 3&quot; of a Household unit. In addition, units from this battalion add 1 to their Bravery in the battleshock phase if they are within 3&quot; of an enemy unit."/>
-                          </characteristics>
-                        </profile>
-                      </profiles>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="f20d-08df-7592-ce59" name="2. Households (0 to 2, can each contain 1 additional unit of Tree-Revenants)" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries>
+                <selectionEntry id="c3ec-961f-3cf6-a2af" name="*Battalion: Household" hidden="false" collective="false" type="upgrade">
+                  <profiles>
+                    <profile id="2403-7529-a731-c87b" name="Discipline of the Ages" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+                      <profiles/>
                       <rules/>
                       <infoLinks/>
                       <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5ed-a14d-39f0-328b" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e0ec-9ed6-cef3-a77c" type="max"/>
-                      </constraints>
-                      <categoryLinks/>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="70.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
+                      <characteristics>
+                        <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Enemy units cannot choose to retreat if they are within 3&quot; of a Household unit. In addition, units from this battalion add 1 to their Bravery in the battleshock phase if they are within 3&quot; of an enemy unit."/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a22-8078-958f-6c38" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
                   <selectionEntryGroups>
-                    <selectionEntryGroup id="5511-dbb9-c69f-4b85" name="1 Treelord" hidden="false" collective="false">
+                    <selectionEntryGroup id="9e4b-79fa-49a6-f242" name="1. Treelord" hidden="false" collective="false">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
-                      <modifiers>
-                        <modifier type="set" field="hidden" value="true">
-                          <repeats/>
-                          <conditions>
-                            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7749-96a8-f53a-47dd" type="instanceOf"/>
-                          </conditions>
-                          <conditionGroups/>
-                        </modifier>
-                      </modifiers>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f0a-3eb1-17f7-787d" type="min"/>
-                      </constraints>
+                      <modifiers/>
+                      <constraints/>
                       <categoryLinks/>
                       <selectionEntries/>
                       <selectionEntryGroups/>
                       <entryLinks>
-                        <entryLink id="07bd-84f5-f6b5-7adf" name="Treelord" hidden="false" targetId="0861-c6bd-bf12-f2f4" type="selectionEntry">
+                        <entryLink id="d5c8-3b16-d855-6389" name="Treelord" hidden="false" targetId="0861-c6bd-bf12-f2f4" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
                           <modifiers/>
                           <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d909-9847-3e2b-464a" type="max"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ece2-6399-64cc-8651" type="max"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91c3-422b-3fd4-c2d8" type="min"/>
                           </constraints>
                           <categoryLinks>
-                            <categoryLink id="01ae-c789-0741-213f" hidden="false" targetId="fa0c-9044-2568-fa02" primary="true">
+                            <categoryLink id="ad99-d7fe-2451-cf2e" hidden="false" targetId="fa0c-9044-2568-fa02" primary="true">
                               <profiles/>
                               <rules/>
                               <infoLinks/>
@@ -3607,28 +3777,27 @@
                         </entryLink>
                       </entryLinks>
                     </selectionEntryGroup>
-                    <selectionEntryGroup id="88e9-1281-03c4-4ba1" name="1 Branchwych" book="" hidden="false" collective="false">
+                    <selectionEntryGroup id="7e04-85d9-8135-d062" name="2. Branchwych" book="" hidden="false" collective="false">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
                       <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2aa6-20bc-67d7-aacd" type="min"/>
-                      </constraints>
+                      <constraints/>
                       <categoryLinks/>
                       <selectionEntries/>
                       <selectionEntryGroups/>
                       <entryLinks>
-                        <entryLink id="92c2-7853-69fb-969a" name="Branchwych" hidden="false" targetId="d65c-84f8-43bf-d534" type="selectionEntry">
+                        <entryLink id="01ee-cac4-372b-fb6b" name="Branchwych" hidden="false" targetId="d65c-84f8-43bf-d534" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
                           <modifiers/>
                           <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a102-07b1-5cde-f977" type="max"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8eba-572e-4aef-a747" type="max"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="61e5-5277-7e3e-e281" type="min"/>
                           </constraints>
                           <categoryLinks>
-                            <categoryLink id="3c3e-7427-2a32-a419" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                            <categoryLink id="ccb4-30b5-ad98-dba9" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
                               <profiles/>
                               <rules/>
                               <infoLinks/>
@@ -3639,19 +3808,20 @@
                         </entryLink>
                       </entryLinks>
                     </selectionEntryGroup>
-                    <selectionEntryGroup id="da27-f16a-35a7-607b" name="1-2 units of Tree-Revenants" hidden="false" collective="false">
+                    <selectionEntryGroup id="99c9-eada-a666-b43d" name="3. Tree-Revenants (1 to 2)" hidden="false" collective="false">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
                       <modifiers/>
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e4d-b381-00ad-7133" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9bd-e2ab-4af2-e292" type="min"/>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9bed-e863-3a98-de7f" type="max"/>
                       </constraints>
                       <categoryLinks/>
                       <selectionEntries/>
                       <selectionEntryGroups/>
                       <entryLinks>
-                        <entryLink id="ee96-9034-0580-8ebd" name="Tree-Revenants" hidden="false" targetId="a74a-7377-3ed9-0f5e" type="selectionEntry">
+                        <entryLink id="d470-f577-73ed-d564" name="Tree-Revenants" hidden="false" targetId="a74a-7377-3ed9-0f5e" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -3665,10 +3835,10 @@
                             </modifier>
                           </modifiers>
                           <constraints>
-                            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="79ff-cdf2-4834-7d87" type="max"/>
+                            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c185-f572-37da-5a65" type="max"/>
                           </constraints>
                           <categoryLinks>
-                            <categoryLink id="d7bb-d00f-d122-3aa1" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                            <categoryLink id="eee4-8693-b553-52f4" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
                               <profiles/>
                               <rules/>
                               <infoLinks/>
@@ -3677,7 +3847,7 @@
                             </categoryLink>
                           </categoryLinks>
                         </entryLink>
-                        <entryLink id="45bf-a195-4c15-c2f2" name="Tree-Revenants" hidden="false" targetId="a74a-7377-3ed9-0f5e" type="selectionEntry">
+                        <entryLink id="86da-149e-aa01-3db0" name="Tree-Revenants" hidden="false" targetId="a74a-7377-3ed9-0f5e" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -3691,10 +3861,10 @@
                             </modifier>
                           </modifiers>
                           <constraints>
-                            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="55cf-dd0b-2c17-3f5e" type="max"/>
+                            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85b7-c2fa-2488-950c" type="max"/>
                           </constraints>
                           <categoryLinks>
-                            <categoryLink id="fc5a-16b1-244c-1831" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                            <categoryLink id="b65b-e806-11e9-d922" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
                               <profiles/>
                               <rules/>
                               <infoLinks/>
@@ -3715,7 +3885,7 @@
               <selectionEntryGroups/>
               <entryLinks/>
             </selectionEntryGroup>
-            <selectionEntryGroup id="ec4f-73be-53ff-2108" name="0-3 Forest Folk battalions" hidden="false" collective="false">
+            <selectionEntryGroup id="4907-1766-ad38-68a1" name="3. Forest Folk (0 to 3,can contain Branchwyches instead of Branchwraiths)" hidden="false" collective="false">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -3723,67 +3893,41 @@
               <constraints/>
               <categoryLinks/>
               <selectionEntries>
-                <selectionEntry id="8204-0f3e-643e-5a13" name="Battalion: Forest Folk" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
+                <selectionEntry id="97ab-7b25-c4bf-d77d" name="*Battalion: Forest Folk" hidden="false" collective="false" type="upgrade">
+                  <profiles>
+                    <profile id="bf3d-9ba7-02ea-c717" name="Fade from View" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Once per game, in your hero phase, the Forest Folk can vanish along the spirit paths. Remove all of the models in the battalion from the battlefield and set them to one side. Then set up each of the units anywhere within your territory, or within 3&quot; of a Sylvaneth Wyldwood. They must be set up at least 9&quot; from the enemy, and cannot move in the following movement phase."/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5518-a439-dedd-864b" type="max"/>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1643-6ed7-f01f-90a5" type="max"/>
                   </constraints>
-                  <categoryLinks>
-                    <categoryLink id="4d95-6c0d-bb34-2950" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="false">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </categoryLink>
-                  </categoryLinks>
-                  <selectionEntries>
-                    <selectionEntry id="a2f2-1e8a-10c0-adfb" name="Forest Folk" hidden="false" collective="false" type="upgrade">
-                      <profiles>
-                        <profile id="4c05-1404-3b7d-bd29" name="Fade from View" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                          <characteristics>
-                            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Once per game, in your hero phase, the Forest Folk can vanish along the spirit paths. Remove all of the models in the battalion from the battlefield and set them to one side. Then set up each of the units anywhere within your territory, or within 3&quot; of a Sylvaneth Wyldwood. They must be set up at least 9&quot; from the enemy, and cannot move in the following movement phase."/>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0aa-e7f0-8841-c35a" type="max"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f868-2b93-9576-bf13" type="min"/>
-                      </constraints>
-                      <categoryLinks/>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="110.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
+                  <categoryLinks/>
+                  <selectionEntries/>
                   <selectionEntryGroups>
-                    <selectionEntryGroup id="c3ff-6aa1-19f1-485b" name="3 units of Dryads" hidden="false" collective="false">
+                    <selectionEntryGroup id="ceb1-ccd5-8354-75d0" name="2. Dryads" hidden="false" collective="false">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
                       <modifiers/>
                       <constraints>
-                        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8bc4-c262-d94b-718f" type="min"/>
-                        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c68e-7b80-3c55-4fa5" type="max"/>
+                        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3c2-af37-681a-2a0c" type="min"/>
+                        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5bf7-3ff4-aa96-fe74" type="max"/>
                       </constraints>
                       <categoryLinks/>
                       <selectionEntries/>
                       <selectionEntryGroups/>
                       <entryLinks>
-                        <entryLink id="2953-5d2f-1c00-c598" name="Dryads" hidden="false" targetId="0a14-90fc-1335-3c79" type="selectionEntry">
+                        <entryLink id="bc32-d841-0d18-5d91" name="Dryads" hidden="false" targetId="0a14-90fc-1335-3c79" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -3803,9 +3947,11 @@
                               </conditionGroups>
                             </modifier>
                           </modifiers>
-                          <constraints/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="857a-431a-905f-a59f" type="max"/>
+                          </constraints>
                           <categoryLinks>
-                            <categoryLink id="4bdf-dfe1-b373-0c24" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                            <categoryLink id="da97-9745-04c3-d373" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
                               <profiles/>
                               <rules/>
                               <infoLinks/>
@@ -3814,7 +3960,7 @@
                             </categoryLink>
                           </categoryLinks>
                         </entryLink>
-                        <entryLink id="d40a-824a-f03e-c454" name="Dryads" hidden="false" targetId="0a14-90fc-1335-3c79" type="selectionEntry">
+                        <entryLink id="33e0-db1b-b02b-3397" name="Dryads" hidden="false" targetId="0a14-90fc-1335-3c79" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -3834,9 +3980,11 @@
                               </conditionGroups>
                             </modifier>
                           </modifiers>
-                          <constraints/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="119d-a6e1-da0b-a95e" type="max"/>
+                          </constraints>
                           <categoryLinks>
-                            <categoryLink id="15fb-a807-d023-1e18" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                            <categoryLink id="3719-d2ea-66b4-e2ba" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
                               <profiles/>
                               <rules/>
                               <infoLinks/>
@@ -3847,29 +3995,30 @@
                         </entryLink>
                       </entryLinks>
                     </selectionEntryGroup>
-                    <selectionEntryGroup id="8d21-76d2-82f4-77fb" name="1 Branchwych or Branchwraith" hidden="false" collective="false">
+                    <selectionEntryGroup id="314c-54bb-5642-cf86" name="1. Branchwraith or Branchwych" book="" hidden="false" collective="false">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
                       <modifiers/>
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f34-8afc-16dc-bf48" type="max"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4201-7149-e704-bcfe" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1801-5685-1e82-3513" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6db5-08d2-7bd5-5686" type="max"/>
                       </constraints>
                       <categoryLinks/>
                       <selectionEntries/>
                       <selectionEntryGroups/>
                       <entryLinks>
-                        <entryLink id="21ef-a78a-71e7-d23f" name="Branchwraith" hidden="false" targetId="67ae-bbfe-04fe-0e20" type="selectionEntry">
+                        <entryLink id="bf7a-f09d-dc94-9b59" name="Branchwraith" hidden="false" targetId="67ae-bbfe-04fe-0e20" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
                           <modifiers/>
                           <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="672a-4b7a-5444-d6c4" type="max"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e00b-b1c8-0c5e-0f14" type="max"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aaa8-9347-dc16-32c2" type="min"/>
                           </constraints>
                           <categoryLinks>
-                            <categoryLink id="3f97-4655-de4a-a6e8" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                            <categoryLink id="fb5e-2dad-c3f9-484a" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
                               <profiles/>
                               <rules/>
                               <infoLinks/>
@@ -3878,16 +4027,608 @@
                             </categoryLink>
                           </categoryLinks>
                         </entryLink>
-                        <entryLink id="e66b-74a8-231f-7180" name="Branchwych" hidden="false" targetId="d65c-84f8-43bf-d534" type="selectionEntry">
+                        <entryLink id="cd4a-0bca-9045-b60d" name="Branchwych" hidden="false" targetId="d65c-84f8-43bf-d534" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
                           <modifiers/>
                           <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d8eb-cd94-dcce-f42e" type="max"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e36-8542-8cb0-ee2e" type="min"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2343-98ae-eac5-8216" type="max"/>
+                          </constraints>
+                          <categoryLinks/>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                  </selectionEntryGroups>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="140.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="fa3f-8e84-5aa0-213f" name="5. Free Spirits" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="4c01-8541-a4af-fc99" name="*Battalion: Outcasts" hidden="false" targetId="471d-38f0-5388-84a0" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abfe-e90b-8bc7-c144" type="max"/>
+                  </constraints>
+                  <categoryLinks>
+                    <categoryLink id="1f1f-9811-5f51-a8cd" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="8f86-a0ed-e9cb-8681" name="4. Outcasts" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="202e-f89e-ceac-05f4" name="*Battalion: Free Spirits" hidden="false" targetId="f852-7524-198b-2957" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d617-a5a9-cc1d-7108" type="max"/>
+                  </constraints>
+                  <categoryLinks>
+                    <categoryLink id="740c-5501-2e68-f840" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="86a7-07d4-e1d5-2a7c" name="6. Duardin Units" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bbe4-bfe1-21ea-3ba6" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="3692-1bae-3593-bec7" name="Duardin Units" hidden="false" targetId="156d-0e27-2951-7be1" type="selectionEntryGroup">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="31f7-76ef-aeff-f3e1" name="Any number of Additional Sylvaneth Units" hidden="false" targetId="2f01-3499-14c8-1107" type="selectionEntryGroup">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="80.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3388-e687-3bd2-98a8" name="Battalion: Lords of the Clan" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="d9d6-1a82-0118-2688" name="Deadly Chorus" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="In the hero phase, the Head of the Clan can unleash a great chorus. Roll a dice for each enemy unit within 10&quot; of him, adding 1 to the result for each other model from this battalion that is also within 10&quot; of the enemy unit being rolled for. If the result is 6-9, that enemy unit suffers D3 mortal wounds. If the result is 10 or more, that enemy unit suffers D6 mortal wounds instead."/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="17ca-10fb-e781-0363" name="3. 1-3 Treelords" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="f589-5a92-bbf5-b7ae" name="Treelord" hidden="false" targetId="0861-c6bd-bf12-f2f4" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4de3-c88f-4d34-ce16" type="min"/>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33dc-b278-9efd-0f71" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="6bf7-45c9-a6cc-941b" hidden="false" targetId="fa0c-9044-2568-fa02" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="bf2e-a947-959c-512d" name="1. Treelord Ancient (Head of the Clan)" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="59bd-62cd-b5b8-3fba" name="Treelord Ancient (Head of the Clan)" hidden="false" targetId="a70a-a23d-860a-8dce" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b82b-26ea-dc39-d154" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb44-5385-ef76-ee06" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6099-87e7-eeec-1f76" name="2. 1-3 Treelord Ancients" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="f3e7-e350-ef98-f402" name="Treelord Ancient" hidden="false" targetId="524f-f49b-0bfd-9414" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d059-47d5-b53f-080c" type="min"/>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a457-b3ca-d837-5b01" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="8d5a-b9b4-fe82-d2b5" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="5209-ba34-b837-80ca" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f31c-582d-0cca-9210" name="Super Battalion: Oakenbrow Wargrove" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="7481-657f-4893-6eaf" name="Noble Spirits" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Oakenbrow Treelords and Treelord Ancients have a Wounds characteristic of 13."/>
+          </characteristics>
+        </profile>
+        <profile id="9ff7-7946-2559-9a04" name="Mighty Hosts" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Once during the battle, in your hero phase, you can replace a unit of Oakenbrow Dryads or Tree-Revenants that has been completely destroyed with an identical unit. Set up the replacement unit within 6&quot; of the edge of the battlefield or within a Sylvaneth Wyldwood, and more than 9&quot; from any enemy models. This counts as its move for the following movement phase."/>
+          </characteristics>
+        </profile>
+        <profile id="c00f-b25d-a4c4-2b4f" name="Wargrove Abilities" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="An Oakenbrow general can select the Ancient Nobility command trait instead of any other selection."/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="5738-7ed8-5195-2896" name="Mighty Wildwood" hidden="false" targetId="e69e-ffc7-e031-9478" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="099f-1afc-9f39-14f4" name="WARGROVE OAKENBROW" hidden="false" targetId="fc74-5007-3ac8-3b19" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="7c2d-e67e-c71e-ba33" name="May also contain:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="c44c-b703-d4ca-3432" name="2. Forest Folk (0 to 3)" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries>
+                <selectionEntry id="a082-35d0-6491-28eb" name="*Battalion: Forest Folk" hidden="false" collective="false" type="upgrade">
+                  <profiles>
+                    <profile id="7d06-6e6c-6ff9-c919" name="Fade from View" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Once per game, in your hero phase, the Forest Folk can vanish along the spirit paths. Remove all of the models in the battalion from the battlefield and set them to one side. Then set up each of the units anywhere within your territory, or within 3&quot; of a Sylvaneth Wyldwood. They must be set up at least 9&quot; from the enemy, and cannot move in the following movement phase."/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="86d3-25df-8af7-f367" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups>
+                    <selectionEntryGroup id="f018-cc03-f73e-0212" name="2. Dryads (3 to 4)" hidden="false" collective="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3dbe-728b-b6e6-41d0" type="min"/>
+                        <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50b6-61ff-fa24-1851" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks>
+                        <entryLink id="12a9-3b22-81e0-86d6" name="Dryads" hidden="false" targetId="0a14-90fc-1335-3c79" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers>
+                            <modifier type="set" field="hidden" value="true">
+                              <repeats/>
+                              <conditions/>
+                              <conditionGroups>
+                                <conditionGroup type="or">
+                                  <conditions>
+                                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
+                                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
+                                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
+                                  </conditions>
+                                  <conditionGroups/>
+                                </conditionGroup>
+                              </conditionGroups>
+                            </modifier>
+                          </modifiers>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1543-5d86-68eb-fa7c" type="max"/>
                           </constraints>
                           <categoryLinks>
-                            <categoryLink id="5e53-ee92-bf03-5246" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                            <categoryLink id="89eb-4623-113a-469d" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <constraints/>
+                            </categoryLink>
+                          </categoryLinks>
+                        </entryLink>
+                        <entryLink id="6704-1e2c-4a2d-82fb" name="Dryads" hidden="false" targetId="0a14-90fc-1335-3c79" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers>
+                            <modifier type="set" field="hidden" value="true">
+                              <repeats/>
+                              <conditions/>
+                              <conditionGroups>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="notInstanceOf"/>
+                                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="notInstanceOf"/>
+                                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="notInstanceOf"/>
+                                  </conditions>
+                                  <conditionGroups/>
+                                </conditionGroup>
+                              </conditionGroups>
+                            </modifier>
+                          </modifiers>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4980-6948-12e2-ec86" type="max"/>
+                          </constraints>
+                          <categoryLinks>
+                            <categoryLink id="9902-9c30-3ea6-f26c" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <constraints/>
+                            </categoryLink>
+                          </categoryLinks>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                    <selectionEntryGroup id="a723-5183-8e8c-d455" name="1. Branchwraith" book="" hidden="false" collective="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4bc5-8fb4-cf48-431d" type="min"/>
+                      </constraints>
+                      <categoryLinks/>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks>
+                        <entryLink id="1f74-90a0-a79d-52f3" name="Branchwraith" hidden="false" targetId="67ae-bbfe-04fe-0e20" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44c1-3e7b-da15-21fd" type="max"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9adc-2477-ecf4-767d" type="min"/>
+                          </constraints>
+                          <categoryLinks>
+                            <categoryLink id="e5d4-c359-8bfc-9021" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <constraints/>
+                            </categoryLink>
+                          </categoryLinks>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                  </selectionEntryGroups>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="140.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="0144-aea6-16c0-38fd" name="1. Household (0 to 3)" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries>
+                <selectionEntry id="506d-09f2-8553-c1c4" name="*Battalion: Household" hidden="false" collective="false" type="upgrade">
+                  <profiles>
+                    <profile id="07b5-8158-82cc-7b3a" name="Discipline of the Ages" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Enemy units cannot choose to retreat if they are within 3&quot; of a Household unit. In addition, units from this battalion add 1 to their Bravery in the battleshock phase if they are within 3&quot; of an enemy unit."/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b16-a434-b365-1b48" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups>
+                    <selectionEntryGroup id="52ac-965f-02be-db4c" name="1. Treelord (1 to 2)" hidden="false" collective="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks/>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks>
+                        <entryLink id="a9fa-1bb4-80c1-6a7f" name="Treelord" hidden="false" targetId="0861-c6bd-bf12-f2f4" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="854a-6d66-2e31-10b7" type="max"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09c9-0de4-ae3c-966e" type="min"/>
+                          </constraints>
+                          <categoryLinks>
+                            <categoryLink id="86a8-8ae1-0de1-cdd4" hidden="false" targetId="fa0c-9044-2568-fa02" primary="true">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <constraints/>
+                            </categoryLink>
+                          </categoryLinks>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                    <selectionEntryGroup id="8e2a-0290-a6f1-84dc" name="2. Branchwych" book="" hidden="false" collective="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks/>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks>
+                        <entryLink id="65c3-e08a-3445-18eb" name="Branchwych" hidden="false" targetId="d65c-84f8-43bf-d534" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2474-48c5-a6b7-a885" type="max"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e145-917b-f1b6-d19d" type="min"/>
+                          </constraints>
+                          <categoryLinks>
+                            <categoryLink id="64ff-2683-b231-a10d" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <constraints/>
+                            </categoryLink>
+                          </categoryLinks>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                    <selectionEntryGroup id="cf02-8d47-e28d-e627" name="3. Tree-Revenants (1 to 2)" hidden="false" collective="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e408-3e04-f053-126d" type="min"/>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3fdf-ddcd-6f5c-0c71" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks>
+                        <entryLink id="2ef3-8aad-55e9-04d0" name="Tree-Revenants" hidden="false" targetId="a74a-7377-3ed9-0f5e" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers>
+                            <modifier type="set" field="hidden" value="true">
+                              <repeats/>
+                              <conditions>
+                                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cc2e-a897-99a2-353f" type="equalTo"/>
+                              </conditions>
+                              <conditionGroups/>
+                            </modifier>
+                          </modifiers>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c41e-1ce6-8b2b-03ad" type="max"/>
+                          </constraints>
+                          <categoryLinks>
+                            <categoryLink id="4898-3176-19e3-3b50" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <constraints/>
+                            </categoryLink>
+                          </categoryLinks>
+                        </entryLink>
+                        <entryLink id="11cd-764d-45d1-1c90" name="Tree-Revenants" hidden="false" targetId="a74a-7377-3ed9-0f5e" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers>
+                            <modifier type="set" field="hidden" value="true">
+                              <repeats/>
+                              <conditions>
+                                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cc2e-a897-99a2-353f" type="equalTo"/>
+                              </conditions>
+                              <conditionGroups/>
+                            </modifier>
+                          </modifiers>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45cf-9114-4be1-33b1" type="max"/>
+                          </constraints>
+                          <categoryLinks>
+                            <categoryLink id="7158-ab0b-9a04-aa5b" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
                               <profiles/>
                               <rules/>
                               <infoLinks/>
@@ -3908,388 +4649,7 @@
               <selectionEntryGroups/>
               <entryLinks/>
             </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks>
-            <entryLink id="e8c0-4920-f595-3bd0" name="Battalion: Free Spirits" hidden="false" targetId="f852-7524-198b-2957" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff13-18b1-8aad-bffa" type="max"/>
-              </constraints>
-              <categoryLinks>
-                <categoryLink id="6b73-9e00-f923-e019" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </categoryLink>
-              </categoryLinks>
-            </entryLink>
-            <entryLink id="c16f-b166-d9d0-7bd2" name="Battalion: Lords of the Clan" hidden="false" targetId="3388-e687-3bd2-98a8" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="887e-df6c-ec55-dd18" type="max"/>
-              </constraints>
-              <categoryLinks>
-                <categoryLink id="96bf-8657-73ab-dc02" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </categoryLink>
-              </categoryLinks>
-            </entryLink>
-            <entryLink id="140a-4c7f-12af-637e" name="Battalion: Outcasts" hidden="false" targetId="471d-38f0-5388-84a0" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84b2-e5a1-2da5-bc42" type="max"/>
-              </constraints>
-              <categoryLinks>
-                <categoryLink id="73f4-cbe6-db59-93f1" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </categoryLink>
-              </categoryLinks>
-            </entryLink>
-            <entryLink id="31f7-76ef-aeff-f3e1" name="Any number of Additional Sylvaneth Units" hidden="false" targetId="2f01-3499-14c8-1107" type="selectionEntryGroup">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="80.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="3388-e687-3bd2-98a8" name="Battalion: Lords of the Clan" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries>
-        <selectionEntry id="7d68-c2f9-8368-b44d" name="Lords of the Clan" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="89d3-ef3c-1380-7728" name="Deadly Chorus" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="In the hero phase, the Head of the Clan can unleash a great chorus. Roll a dice for each enemy unit within 10&quot; of him, adding 1 to the result for each other model from this battalion that is also within 10&quot; of the enemy unit being rolled for. If the result is 6-9, that enemy unit suffers D3 mortal wounds. If the result is 10 or more, that enemy unit suffers D6 mortal wounds instead."/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d86b-9079-f81d-ca2c" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d85b-d297-4834-4167" type="min"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="100.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="17ca-10fb-e781-0363" name="1-3 Treelords" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <repeats/>
-              <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d644-8514-58ac-da0c" type="instanceOf"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="018a-6225-9511-9577" type="min"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e307-7633-f44d-bcf9" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="f589-5a92-bbf5-b7ae" name="Treelord" hidden="false" targetId="0861-c6bd-bf12-f2f4" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks>
-                <categoryLink id="6bf7-45c9-a6cc-941b" hidden="false" targetId="fa0c-9044-2568-fa02" primary="true">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </categoryLink>
-              </categoryLinks>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="bf2e-a947-959c-512d" name="1 Treelord Ancient (Head of the Clan)" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cdd7-f78d-650f-610e" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e1a-6ed5-5c43-f4cb" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="4d67-f1ea-e755-e80b" name="Treelord Ancient" hidden="false" targetId="524f-f49b-0bfd-9414" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="append" field="name" value="(the Head of the Clan)">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-              <categoryLinks>
-                <categoryLink id="8819-f10d-f0dd-fbf9" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </categoryLink>
-                <categoryLink id="607b-43db-c1b3-d124" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </categoryLink>
-              </categoryLinks>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="6099-87e7-eeec-1f76" name="1-3 Treelord Ancients" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0522-8d6f-d558-941b" type="min"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aebb-c99c-301d-6d19" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="f3e7-e350-ef98-f402" name="Treelord Ancient" hidden="false" targetId="524f-f49b-0bfd-9414" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks>
-                <categoryLink id="8d5a-b9b4-fe82-d2b5" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </categoryLink>
-                <categoryLink id="5209-ba34-b837-80ca" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </categoryLink>
-              </categoryLinks>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="7060-fac8-b9ff-59f9" name="2-6 Treelords" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <repeats/>
-              <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d644-8514-58ac-da0c" type="notInstanceOf"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="488b-7aaf-8821-5029" type="min"/>
-            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b27-cf01-e515-2775" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="fa8c-4720-756e-ab57" name="Treelord" hidden="false" targetId="0861-c6bd-bf12-f2f4" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks>
-                <categoryLink id="f7b3-4f02-54e1-0ed2" hidden="false" targetId="fa0c-9044-2568-fa02" primary="true">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </categoryLink>
-              </categoryLinks>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="f31c-582d-0cca-9210" name="Battalion: Oakenbrow Wargrove" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="7481-657f-4893-6eaf" name="Noble Spirits" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Oakenbrow Treelords and Treelord Ancients have a Wounds characteristic of 13."/>
-          </characteristics>
-        </profile>
-        <profile id="9ff7-7946-2559-9a04" name="Mighty Hosts" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Once during the battle, in your hero phase, you can replace a unit of Oakenbrow Dryads or Tree-Revenants that has been completely destroyed with an identical unit. Set up the replacement unit within 6&quot; of the edge of the battlefield or within a Sylvaneth Wyldwood, and more than 9&quot; from any enemy models. This counts as its move for the following movement phase."/>
-          </characteristics>
-        </profile>
-        <profile id="dc3b-2d8d-bdf2-9f38" name="Ancient Nobility" hidden="false" profileTypeId="c749-bae4-71a8-0c36" profileTypeName="Command Trait">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Command Trait Details" characteristicTypeId="ee96-6f3a-e5ca-2350" value="An Oakenbrow general can have this command trait instead of on of the standard Sylvaneth Command Traits.  All friendly SYLVANETH units within 15&quot; of your general in the battleshock phase add 1 to their Bravery."/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="7c2d-e67e-c71e-ba33" name="May also contain:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="c44c-b703-d4ca-3432" name="0-3:" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec08-9332-af86-42a6" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="fde9-035c-a043-896c" name="Battalion: Forest Folk" hidden="false" targetId="756d-d96e-e298-5558" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks>
-                    <categoryLink id="029b-83ff-6b22-4787" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </categoryLink>
-                  </categoryLinks>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="0144-aea6-16c0-38fd" name="0-3:" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3b6-6177-ca4c-c0bf" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="a1ee-c07a-30a4-1978" name="Battalion: Household" hidden="false" targetId="d141-06d7-9c9e-d410" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks>
-                    <categoryLink id="0e50-a394-9b81-f8fe" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </categoryLink>
-                  </categoryLinks>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="787e-33ef-201b-5288" name="0-1:" hidden="false" collective="false">
+            <selectionEntryGroup id="787e-33ef-201b-5288" name="3. Free Spirits" hidden="false" collective="false">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -4319,7 +4679,7 @@
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="29b4-afea-e504-aed6" name="0-1:" hidden="false" collective="false">
+            <selectionEntryGroup id="29b4-afea-e504-aed6" name="4. Outcasts" hidden="false" collective="false">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -4361,36 +4721,137 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="d644-8514-58ac-da0c" name="1 Lords of the Clan battalion (must contain 2-6 Treelords, instead of 1-3)" hidden="false" collective="false">
+        <selectionEntryGroup id="d644-8514-58ac-da0c" name="1. Lords of the Clan " hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21d2-beac-2013-6867" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="732f-d599-a17e-1f19" type="min"/>
-          </constraints>
+          <constraints/>
           <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="43d2-deab-3e31-02ec" name="Battalion: Lords of the Clan" hidden="false" targetId="3388-e687-3bd2-98a8" type="selectionEntry">
-              <profiles/>
+          <selectionEntries>
+            <selectionEntry id="5f4e-e285-6c20-6aae" name="*Battalion: Lords of the Clan" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="15ac-884f-4388-74ac" name="Deadly Chorus" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="In the hero phase, the Head of the Clan can unleash a great chorus. Roll a dice for each enemy unit within 10&quot; of him, adding 1 to the result for each other model from this battalion that is also within 10&quot; of the enemy unit being rolled for. If the result is 6-9, that enemy unit suffers D3 mortal wounds. If the result is 10 or more, that enemy unit suffers D6 mortal wounds instead."/>
+                  </characteristics>
+                </profile>
+              </profiles>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints/>
-              <categoryLinks>
-                <categoryLink id="c354-e8b8-6e8c-0ede" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11f5-2155-0bed-f6f6" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf0e-51ea-d53c-36b5" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="6481-ecd6-ddf2-1398" name="1. Treelord Ancient (Head of the Clan)" hidden="false" collective="false">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                   <constraints/>
-                </categoryLink>
-              </categoryLinks>
-            </entryLink>
-          </entryLinks>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="0358-6a01-3f2d-a018" name="Treelord Ancient (Head of the Clan)" hidden="false" targetId="a70a-a23d-860a-8dce" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="83a0-e33e-c4d4-6f2a" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="586b-5714-6451-f59d" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="85f1-db30-211c-512d" name="2. 1-3 Treelord Ancients" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="1634-83f1-2f17-9bbc" name="Treelord Ancient" hidden="false" targetId="524f-f49b-0bfd-9414" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e29b-3314-6912-d007" type="min"/>
+                        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01c1-6250-582a-49e1" type="max"/>
+                      </constraints>
+                      <categoryLinks>
+                        <categoryLink id="b562-daaa-7e74-635f" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </categoryLink>
+                        <categoryLink id="ff12-03f9-9e02-b6d1" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </categoryLink>
+                      </categoryLinks>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="6bf0-e43b-4dac-c764" name="3. 2-6 Treelords" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="4244-e694-cabe-beb0" name="Treelord" hidden="false" targetId="0861-c6bd-bf12-f2f4" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd80-d1a2-6615-b010" type="min"/>
+                        <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f17f-e4e5-410d-a293" type="max"/>
+                      </constraints>
+                      <categoryLinks>
+                        <categoryLink id="bc27-819a-3a74-1ee6" hidden="false" targetId="fa0c-9044-2568-fa02" primary="true">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </categoryLink>
+                      </categoryLinks>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks/>
@@ -4399,43 +4860,25 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="471d-38f0-5388-84a0" name="Battalion: Outcasts" hidden="false" collective="false" type="upgrade">
-      <profiles/>
+      <profiles>
+        <profile id="95c7-3d09-084a-b02b" name="Fear the Forest-kin" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="In your hero phase, roll two dice for each enemy unit that is within 8&quot; of at least two units from this battalion. For each point by which the total dice roll exceeds the unit’s Bravery, the unit suffers a mortal wound."/>
+          </characteristics>
+        </profile>
+      </profiles>
       <rules/>
       <infoLinks/>
       <modifiers/>
       <constraints/>
       <categoryLinks/>
-      <selectionEntries>
-        <selectionEntry id="3cc2-b329-1a9f-6bc3" name="Outcasts" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="4887-0b43-8add-2c3d" name="Fear the Forest-kin" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="In your hero phase, roll two dice for each enemy unit that is within 8&quot; of at least two units from this battalion. For each point by which the total dice roll exceeds the unit’s Bravery, the unit suffers a mortal wound."/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a6c-f705-77e7-1888" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6512-baa8-5aa3-e4c1" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="90.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+      <selectionEntries/>
       <selectionEntryGroups>
-        <selectionEntryGroup id="b9ea-fa55-0289-7ece" name="3 Spite-Revenants" hidden="false" collective="false">
+        <selectionEntryGroup id="b9ea-fa55-0289-7ece" name="1. Spite-Revenants" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4504,7 +4947,7 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c51e-82bf-3c24-b8f6" name="Battalion: Sylvaneth Wargrove" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="c51e-82bf-3c24-b8f6" name="Super Battalion: Sylvaneth Wargrove" hidden="false" collective="false" type="upgrade">
       <profiles>
         <profile id="e5b1-beec-ee0d-96c1" name="Mighty Wildwood" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>
@@ -4522,104 +4965,164 @@
       <constraints/>
       <categoryLinks/>
       <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks>
-        <entryLink id="bcd5-5a4a-b84b-98cb" name="Lords of the Clan" hidden="false" targetId="3388-e687-3bd2-98a8" type="selectionEntry">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="e6f6-ccff-b430-f53c" name="1. Lords of the Clan" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5746-2641-1827-a767" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="75ca-74b4-591c-5265" type="min"/>
-          </constraints>
-          <categoryLinks>
-            <categoryLink id="8eab-f142-fb93-e2bf" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="4e9c-abda-dcaf-d0f7" name="*Battalion: Lords of the Clan" hidden="false" targetId="3388-e687-3bd2-98a8" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints/>
-            </categoryLink>
-          </categoryLinks>
-        </entryLink>
-        <entryLink id="3956-c2f5-6be1-b5dc" name="Household" hidden="false" targetId="d141-06d7-9c9e-d410" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91af-9cd3-ac0e-0f86" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abff-08a0-00cf-2844" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="543d-d93b-fb07-3939" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6b04-4674-a5d8-fc93" name="2. Households" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c859-cb82-327c-b430" type="max"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2500-5302-09c7-c8e2" type="min"/>
-          </constraints>
-          <categoryLinks>
-            <categoryLink id="0673-5c20-fba7-d66e" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="1ac6-850c-c28c-dc7a" name="*Battalion: Household" hidden="false" targetId="d141-06d7-9c9e-d410" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints/>
-            </categoryLink>
-          </categoryLinks>
-        </entryLink>
-        <entryLink id="0529-6bdd-22df-2e71" name="Forest Folk" hidden="false" targetId="756d-d96e-e298-5558" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="34d1-46e6-67f0-d648" type="max"/>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c2c-be13-5450-c6c8" type="min"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="f913-267f-9784-7128" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="658c-d821-6cdc-9963" name="3. Forest Folk" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80a7-51fc-6542-c5c3" type="max"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a045-3f8b-a195-829c" type="min"/>
-          </constraints>
-          <categoryLinks>
-            <categoryLink id="cb13-7b49-089a-fc0e" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="cc4d-fbc8-b560-c2c1" name="*Battalion: Forest Folk" hidden="false" targetId="756d-d96e-e298-5558" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints/>
-            </categoryLink>
-          </categoryLinks>
-        </entryLink>
-        <entryLink id="2dae-801c-5c82-e1e7" name="Free Spirits" hidden="false" targetId="f852-7524-198b-2957" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e60-c150-5348-b770" type="max"/>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2624-9e83-0ec7-736b" type="min"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="a955-a33c-2e89-311f" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="27ef-d063-8e77-fde0" name="4. Free Spirits" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0486-944e-c68f-126a" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d041-a116-4173-8411" type="max"/>
-          </constraints>
-          <categoryLinks>
-            <categoryLink id="e3fa-d242-8004-14ae" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="0d84-6aff-f0ac-eedc" name="*Battalion: Free Spirits" hidden="false" targetId="f852-7524-198b-2957" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints/>
-            </categoryLink>
-          </categoryLinks>
-        </entryLink>
-        <entryLink id="6ddd-e7ed-9c0c-d4d6" name="Outcasts" hidden="false" targetId="471d-38f0-5388-84a0" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8de9-938d-a281-1590" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d4d7-2563-3a75-beef" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="d9b4-b111-af9f-fda1" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="f74b-5da5-1001-cf5c" name="5. Outcasts" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b683-8cd3-ed69-e1ed" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0884-3192-e51f-8d6d" type="max"/>
-          </constraints>
-          <categoryLinks>
-            <categoryLink id="9ec7-db2b-48d3-a36b" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="65c6-7cf9-395f-fbae" name="*Battalion: Outcasts" hidden="false" targetId="471d-38f0-5388-84a0" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints/>
-            </categoryLink>
-          </categoryLinks>
-        </entryLink>
-      </entryLinks>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dabd-c31c-c020-3f8a" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="72bb-09db-caa2-4700" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="db64-fa02-3969-012a" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="80.0"/>
       </costs>
@@ -4632,7 +5135,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="She can give voice to the song in each of her hero phases. If she does so, pick a model anywhere on the battlefield; that model heals 1 wound (it heals D3 wounds instead if it is a SYLVANETH unit within 18&quot;)."/>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="The Lady of the Vines canuse this ability in each of her hero phases. If she does so, pick a model anywhere on the battlefield; that model heals 1 wound (it heals D3 wounds instead if it is a SYLVANETH unit within 18&quot;)."/>
           </characteristics>
         </profile>
         <profile id="f9f6-46e4-6c08-aa5a" name="Master of Defence" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
@@ -4641,7 +5144,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Add 1 to the save rolls of Grymn, and to the save rolls of any STORMCAST ETERNALS unit from this battalion that is within 9&quot; of him when the save is made."/>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Add 1 to the save rolls of Lorrus Grymn, and to the save rolls of any STORMCAST ETERNALS unit from this battalion that is within 9&quot; of him when the save is made."/>
           </characteristics>
         </profile>
         <profile id="fca2-c8c8-ccf8-8b4c" name="Guardians of the Queen-seed" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
@@ -4653,69 +5156,6 @@
             <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="So long as the Lady of Vines is still alive, the Bravery of all Guardians of Alarielle units is 10."/>
           </characteristics>
         </profile>
-        <profile id="6eb6-a07c-3bbd-354d" name="-" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="The Guardians of Alarielle consist of the following: "/>
-          </characteristics>
-        </profile>
-        <profile id="e30b-40a2-44db-7815" name="Branchwraith (The Lady of Vines)" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1"/>
-          </characteristics>
-        </profile>
-        <profile id="56e4-c733-20a3-46a5" name="Treelords or Treelord Ancients" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="2 in any combination."/>
-          </characteristics>
-        </profile>
-        <profile id="945c-81c7-3722-a3c9" name="Dryad Units" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="2"/>
-          </characteristics>
-        </profile>
-        <profile id="6df4-0195-0f93-5338" name="Lord-Castellant (Lorrus Grymn)" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1"/>
-          </characteristics>
-        </profile>
-        <profile id="46d1-de22-f7ce-b793" name="Liberator Units" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="2"/>
-          </characteristics>
-        </profile>
-        <profile id="636a-228c-71e5-46c2" name="Judicator Units" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="1"/>
-          </characteristics>
-        </profile>
       </profiles>
       <rules/>
       <infoLinks/>
@@ -4723,13 +5163,1078 @@
       <constraints/>
       <categoryLinks/>
       <selectionEntries/>
-      <selectionEntryGroups/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="5364-5df5-bbaa-f4d9" name="1. Branchwraith (The Lady of the Vines)" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks>
+            <categoryLink id="0020-f003-62e9-e8f1" name="Leader" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </categoryLink>
+          </categoryLinks>
+          <selectionEntries>
+            <selectionEntry id="042b-e386-f323-838c" name="Branchwraith" hidden="false" collective="false" type="unit">
+              <profiles>
+                <profile id="139e-6f19-f71a-2883" name="Branchwraith" hidden="false" profileTypeId="1960-ca8e-67ce-2014" profileTypeName="Unit">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Move" characteristicTypeId="8655-6213-2824-1752" value="7&quot;"/>
+                    <characteristic name="Wounds" characteristicTypeId="cd0e-fea6-411f-904d" value="5"/>
+                    <characteristic name="Bravery" characteristicTypeId="0c85-bf79-836b-759e" value="8"/>
+                    <characteristic name="Save" characteristicTypeId="f8dd-4f2a-8543-4f36" value="5+"/>
+                  </characteristics>
+                </profile>
+                <profile id="a871-9bc7-da10-2526" name="Blessings of the Forest" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="Unit Abilities">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="Subtract 1 from all hit rolls made against a Branchwraith if she is within 3&quot; of a Sylvaneth Wyldwood."/>
+                  </characteristics>
+                </profile>
+                <profile id="babb-ca1a-342b-79e3" name="Roused to Wrath" book="Battletome: Sylvaneth Errata, July 2018" hidden="false" profileTypeId="f55d-ee3a-1597-110f" profileTypeName="Magic">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Cast/Unbind" characteristicTypeId="8294-f605-2c0f-8f92" value="7"/>
+                    <characteristic name="Spells Known" characteristicTypeId="dc9c-47d3-6931-859c" value="If successfully cast, you can summon a unit of 10 DRYADS and add it to your army. The summoned unit must be set up more than 9&quot; from any enemy units, and wholly on or within a SYLVANETH WYLDWOOD that is within 12&quot; of the caster. The summoned unit cannot move in the following movement phase."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="name" value="The Lady of the Vines">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="056d-d3ad-7d2e-4ad1" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2fa3-9344-4d14-f7c6" type="min"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="cd33-3538-a4d0-a943" name="New CategoryLink" hidden="false" targetId="5bb1-ed20-b7d9-9d94" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="c8c8-6148-1126-c1d5" name="New CategoryLink" hidden="false" targetId="4e0e-664d-51ea-0929" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="7563-e2c5-0321-6508" name="New CategoryLink" hidden="false" targetId="4f53-8230-2f02-9639" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="611a-67d9-cdf4-9efb" name="New CategoryLink" hidden="false" targetId="b970-b3bf-e1a4-a6fc" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="85cf-03e2-3a42-9243" name="New CategoryLink" hidden="false" targetId="de6f-3fcb-09b2-a59e" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+              <selectionEntries>
+                <selectionEntry id="1f69-d8d6-200a-6c59" name="Piercing Talons" hidden="false" collective="false" type="upgrade">
+                  <profiles>
+                    <profile id="010c-540f-1e81-879d" name="Piercing Talons" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                        <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="2&quot;"/>
+                        <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="3"/>
+                        <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="4+"/>
+                        <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="4+"/>
+                        <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-1"/>
+                        <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87e2-9931-f700-3d27" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ace4-477d-581a-96fe" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="ee2e-3971-cd37-a957" name="General" hidden="false" targetId="b341-0885-3f1c-7d8a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="fac7-fd2d-3dcf-e2f1" name="Artefacts" hidden="false" targetId="083e-a950-b54a-c2a4" type="selectionEntryGroup">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="8318-ab02-e1df-a053" name="Deepwood Spell Lore" hidden="false" targetId="ad08-f268-8b24-726b" type="selectionEntryGroup">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="faf8-2018-c7b8-ef53" name="Command Traits" hidden="false" targetId="1d10-2017-059e-f52d" type="selectionEntryGroup">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="cab0-0258-3626-dec1" name="Wargrove Bonuses" hidden="false" targetId="7991-c400-3deb-c3be" type="selectionEntryGroup">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="80.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="94c4-5e6d-4891-f16f" name="2. Treelords / Treelord Ancients" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f304-a76f-4c50-07ee" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c33-cf72-21d3-76f4" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="c1e7-cac1-61de-8f92" name="Treelord" hidden="false" targetId="0861-c6bd-bf12-f2f4" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="1774-5093-104f-660c" name="Treelord Ancient" hidden="false" targetId="524f-f49b-0bfd-9414" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="7fe2-e48a-5c83-07bf" name="Leader" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="8671-76cd-c764-ae6b" name="4. Lord-Castellant (Lorrus Grymn)" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="d5c4-0a8e-fbbd-a773" name="Lord-Castellant" hidden="false" collective="false" type="model">
+              <profiles>
+                <profile id="4dbc-a44f-3e23-7b7b" name="Faithful Gryph-hound" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="Unit Abilities">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="The first time this model is set up on the battlefield, you can call a GRYPH-HOUND unit consisting of a single model to the battlefield and add it to your army. Set up the GRYPH-HOUND wholly within 3&quot; of this model and more than 9&quot; from any enemy units."/>
+                  </characteristics>
+                </profile>
+                <profile id="5112-0495-ef1d-bf2f" name="Lord-Castellant" hidden="false" profileTypeId="1960-ca8e-67ce-2014" profileTypeName="01 Unit">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Move" characteristicTypeId="8655-6213-2824-1752" value="5&quot;"/>
+                    <characteristic name="Wounds" characteristicTypeId="cd0e-fea6-411f-904d" value="6"/>
+                    <characteristic name="Bravery" characteristicTypeId="0c85-bf79-836b-759e" value="9"/>
+                    <characteristic name="Save" characteristicTypeId="f8dd-4f2a-8543-4f36" value="3+"/>
+                  </characteristics>
+                </profile>
+                <profile id="c2f8-f250-b14d-db61" name="Warding Lantern" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="08 Ability (Unit)">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="In your hero phase, pick either a CHAOS unit or a STORMCAST ETERNAL unit that is wholly within 18&quot; of this model. The same unit cannot be picked as the target of a warding lantern more than once in the same hero phase.  If a CHAOS unit is picked, it suffers 1 mortal wound. If a CHAOS DAEMON unit is picked it suffers D3 mortal wounds instead.  If a STORMCAST ETERNAL unit is picked, add 1 to save rolls for attacks that target that unit until your next hero phase. In addition, until your next hero phase, each time you make a save roll of 7+ for an attack that targets that unit, you can heal 1 wound allocated to a model from that unit."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="name" value="Lorrus Grymn">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c16a-fb7c-b89f-5ad4" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b730-bae5-5ea4-3cc7" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries>
+                <selectionEntry id="13dc-2feb-3ce5-5c53" name="Castellant&apos;s Halberd" hidden="false" collective="false" type="upgrade">
+                  <profiles>
+                    <profile id="bee0-9bc6-0398-27b4" name="Castellant&apos;s Halberd" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="03 Weapon">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                        <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="2&quot;"/>
+                        <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="3"/>
+                        <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="3+"/>
+                        <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+                        <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-1"/>
+                        <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="2"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2860-922a-2680-c7ae" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7702-53fa-3916-6b1b" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="0560-04c1-5b79-96bb" name="General" hidden="false" targetId="b341-0885-3f1c-7d8a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="8fd5-5bba-ae9f-186c" name="Artefacts" hidden="false" targetId="083e-a950-b54a-c2a4" type="selectionEntryGroup">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="a691-e591-abc4-deaa" name="Command Traits" hidden="false" targetId="1d10-2017-059e-f52d" type="selectionEntryGroup">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="100.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="a3ba-d932-b0e3-d3f7" name="5. Liberators" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="db5b-33a2-27d4-a1be" name="Liberators" hidden="false" collective="false" type="unit">
+              <profiles>
+                <profile id="c55b-ba17-8b44-b062" name="Liberator-Prime" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="08 Ability (Unit)">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="The leader of this unit is a Liberator-Prime. Add 1 to the Attacks characteristic of a Liberator-Prime’s melee weapon."/>
+                  </characteristics>
+                </profile>
+                <profile id="2c59-dde1-555e-7213" name="Liberator" hidden="false" profileTypeId="1960-ca8e-67ce-2014">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Move" characteristicTypeId="8655-6213-2824-1752" value="5&quot;"/>
+                    <characteristic name="Wounds" characteristicTypeId="cd0e-fea6-411f-904d" value="2"/>
+                    <characteristic name="Bravery" characteristicTypeId="0c85-bf79-836b-759e" value="7"/>
+                    <characteristic name="Save" characteristicTypeId="f8dd-4f2a-8543-4f36" value="4+"/>
+                  </characteristics>
+                </profile>
+                <profile id="d532-644e-66cc-b1a7" name="Paired Weapons" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="Unit Abilities">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="Each unmodified hit roll of 6 made for a model armed with either a pair or warhammers or a pair of warblades inflicts 2 hits on the target instead of 1. Make a wound and save roll for each hit."/>
+                  </characteristics>
+                </profile>
+                <profile id="6b9e-2e75-161c-8a21" name="Lay Low the Tyrants" hidden="false" profileTypeId="c924-5a68-471a-2fd5">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="You can add 1 to hit rolls for attacks made by this unit that target an enemy unit with a Wounds characteristic of 5 or more."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="decrement" field="points" value="80">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="db5b-33a2-27d4-a1be" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e0fc-51f1-88c3-5b61" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09b7-602d-c2a4-09dd" type="max"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="216a-e6ba-bcbf-f594" type="min"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries>
+                <selectionEntry id="e0fc-51f1-88c3-5b61" name="5 Liberators" hidden="false" collective="false" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="eae7-86ed-e890-7771" type="min"/>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f90b-a2b1-ada9-aa02" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="100.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="fe51-f9bf-9d34-19fe" name="Grand Weapons" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="eeca-90e3-6c5b-86ba" value="1">
+                      <repeats>
+                        <repeat field="selections" scope="db5b-33a2-27d4-a1be" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e0fc-51f1-88c3-5b61" repeats="1" roundUp="false"/>
+                      </repeats>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3101-691c-4804-a7ee" type="min"/>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="eeca-90e3-6c5b-86ba" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries>
+                    <selectionEntry id="253b-f07c-28e5-4218" name="Grandhammer" hidden="false" collective="false" type="upgrade">
+                      <profiles>
+                        <profile id="8c91-17cd-7918-009b" name="Grandhammer" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <characteristics>
+                            <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                            <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
+                            <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="2"/>
+                            <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="4+"/>
+                            <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+                            <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-1"/>
+                            <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="2"/>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks/>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks/>
+                      <costs>
+                        <cost name="pts" costTypeId="points" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="1fe3-7a24-f6b8-f8d3" name="Grandblade" hidden="false" collective="false" type="upgrade">
+                      <profiles>
+                        <profile id="423b-6c75-ddb2-572f" name="Grandblade" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <characteristics>
+                            <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                            <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
+                            <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="2"/>
+                            <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="3+"/>
+                            <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="4+"/>
+                            <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-1"/>
+                            <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="2"/>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks/>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks/>
+                      <costs>
+                        <cost name="pts" costTypeId="points" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="57f0-b87f-33a0-43e6" name="Weapons" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f536-f491-cc25-63f6" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4905-afd3-1e5d-cd8c" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries>
+                    <selectionEntry id="7657-7e66-4ccf-72c9" name="Warhammer and Shield" hidden="false" collective="false" type="upgrade">
+                      <profiles>
+                        <profile id="e2b8-4231-7049-2957" name="Sigmarite Shields" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="08 Ability (Unit)">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <characteristics>
+                            <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="You can re-roll save rolls of 1 for attacks that target this unit if any models from this unit are carrying Sigmarite Shields."/>
+                          </characteristics>
+                        </profile>
+                        <profile id="d8be-f9a2-63ae-e81c" name="Warhammer(s)" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <characteristics>
+                            <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                            <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
+                            <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="2"/>
+                            <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="4+"/>
+                            <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+                            <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-"/>
+                            <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bca7-a952-c1c7-fb90" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks/>
+                      <costs>
+                        <cost name="pts" costTypeId="points" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="9494-ad7c-5aff-78c6" name="Warblade and Shield" hidden="false" collective="false" type="upgrade">
+                      <profiles>
+                        <profile id="afb9-0cde-b0eb-b126" name="Sigmarite Shields" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="08 Ability (Unit)">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <characteristics>
+                            <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="You can re-roll save rolls of 1 for attacks that target this unit if any models from this unit are carrying Sigmarite Shields."/>
+                          </characteristics>
+                        </profile>
+                        <profile id="d19b-026d-621f-6f7d" name="Warblade(s)" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <characteristics>
+                            <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                            <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
+                            <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="2"/>
+                            <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="3+"/>
+                            <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="4+"/>
+                            <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-"/>
+                            <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d9c5-cccd-4697-0e77" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks/>
+                      <costs>
+                        <cost name="pts" costTypeId="points" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="3a5b-5ca5-afff-8ad7" name="Paired Warblades" hidden="false" collective="false" type="upgrade">
+                      <profiles>
+                        <profile id="febd-f1f2-741e-8e99" name="Warblade(s)" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <characteristics>
+                            <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                            <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
+                            <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="2"/>
+                            <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="3+"/>
+                            <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="4+"/>
+                            <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-"/>
+                            <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3d35-417a-3d68-662b" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks/>
+                      <costs>
+                        <cost name="pts" costTypeId="points" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="94d0-cf2c-f036-354a" name="Paired Warhammers" hidden="false" collective="false" type="upgrade">
+                      <profiles>
+                        <profile id="6a36-0bf4-53d8-6f98" name="Warhammer(s)" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <characteristics>
+                            <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                            <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
+                            <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="2"/>
+                            <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="4+"/>
+                            <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+                            <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-"/>
+                            <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5ec7-dd4e-a7a3-a422" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks/>
+                      <costs>
+                        <cost name="pts" costTypeId="points" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks/>
+              <costs/>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="9966-764e-a44f-392d" name="6. Judicators" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="2322-ab32-3606-f2c2" name="Judicators" hidden="false" collective="false" type="unit">
+              <profiles>
+                <profile id="0b05-4a26-c610-a87d" name="Judicators" hidden="false" profileTypeId="1960-ca8e-67ce-2014" profileTypeName="01 Unit">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Move" characteristicTypeId="8655-6213-2824-1752" value="5&quot;"/>
+                    <characteristic name="Wounds" characteristicTypeId="cd0e-fea6-411f-904d" value="2"/>
+                    <characteristic name="Bravery" characteristicTypeId="0c85-bf79-836b-759e" value="7"/>
+                    <characteristic name="Save" characteristicTypeId="f8dd-4f2a-8543-4f36" value="4+"/>
+                  </characteristics>
+                </profile>
+                <profile id="686b-e3a8-4f37-9951" name="Eternal Judgement" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="08 Ability (Unit)">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="Re-roll hit rolls of 1 for attacks made with this unit’s missile weapons that target a CHAOS unit."/>
+                  </characteristics>
+                </profile>
+                <profile id="9624-adf0-48b7-471c" name="Judicator-Prime" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="08 Ability (Unit)">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="The leader of this unit is a Judicator-Prime. Add 1 to hit rolls for attacks made by a Judicator-Prime."/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3b7-4c12-bf9c-0b9f" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4439-9c66-291a-fd71" type="min"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries>
+                <selectionEntry id="31fc-3c4a-398b-cede" name="5 Judicators" hidden="false" collective="false" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6763-3452-cc5e-4b92" type="min"/>
+                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bf94-31d6-4d91-4d77" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="160.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="2e4c-7782-3352-667f" name="Storm Gladius" hidden="false" collective="false" type="upgrade">
+                  <profiles>
+                    <profile id="9f98-a927-03db-631d" name="Storm Gladius" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="03 Weapon">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                        <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
+                        <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="1"/>
+                        <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="3+"/>
+                        <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="4+"/>
+                        <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-"/>
+                        <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="536d-4cde-296e-7dd5" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a3c-bf6e-3b24-03d8" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="2780-a0d6-0f41-a713" name="Grand Weapons" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="7e53-5a8e-7d91-b56a" value="1">
+                      <repeats>
+                        <repeat field="selections" scope="2322-ab32-3606-f2c2" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="31fc-3c4a-398b-cede" repeats="1" roundUp="false"/>
+                      </repeats>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7e53-5a8e-7d91-b56a" type="max"/>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4999-e69c-48e3-94bf" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries>
+                    <selectionEntry id="1f3c-e1d2-a2ce-cf3f" name="Shockbolt Bow" hidden="false" collective="false" type="upgrade">
+                      <profiles>
+                        <profile id="e316-bdf8-1465-76b9" name="Shockbolt Bow" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="03 Weapon">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <characteristics>
+                            <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Missile"/>
+                            <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="24&quot;"/>
+                            <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="1"/>
+                            <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="3+"/>
+                            <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+                            <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-1"/>
+                            <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
+                          </characteristics>
+                        </profile>
+                        <profile id="241d-772a-fdc4-ef0b" name="Chained Lightning" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="08 Ability (Unit)">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <characteristics>
+                            <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="If the hit roll for an attack made with a Shockbolt Bow scores a hit, that attack inflicts D6 hits on the target instead of 1. Make a wound and save roll for each hit."/>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks/>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks/>
+                      <costs>
+                        <cost name="pts" costTypeId="points" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="53f7-f428-0da1-3b3c" name="Thunderbolt Crossbow" hidden="false" collective="false" type="upgrade">
+                      <profiles>
+                        <profile id="2040-7836-05a4-9ce2" name="Thunderbolt Crossbow" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="03 Weapon">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <characteristics>
+                            <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Missile"/>
+                            <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="18&quot;"/>
+                            <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="*"/>
+                            <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="*"/>
+                            <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="*"/>
+                            <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="*"/>
+                            <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="*"/>
+                          </characteristics>
+                        </profile>
+                        <profile id="93b3-a08c-5854-cdeb" name="Thunderbolt Crossbow" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="08 Ability (Unit)">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <characteristics>
+                            <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="Do not use the attack sequence for an attack made with a Thunderbolt Crossbow. Instead, roll a dice. Subtract 1 from the roll if the target is a MONSTER. If the result is equal to or less than the number of models in the target unit, that unit suffers D3 mortal wounds."/>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks/>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks/>
+                      <costs>
+                        <cost name="pts" costTypeId="points" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="46cb-fb8c-ee32-e8cf" name="Weapons" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48c1-9f56-f18b-75a4" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae26-53f7-6f84-4337" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries>
+                    <selectionEntry id="df65-1581-f9af-1cf2" name="Boltstorm Crossbow" hidden="false" collective="false" type="upgrade">
+                      <profiles>
+                        <profile id="01af-60b4-11a8-f08c" name="Boltstorm Crossbow" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="03 Weapon">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <characteristics>
+                            <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Missile"/>
+                            <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="12&quot;"/>
+                            <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="3"/>
+                            <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="3+"/>
+                            <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="4+"/>
+                            <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-"/>
+                            <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
+                          </characteristics>
+                        </profile>
+                        <profile id="b66f-faaf-e0d3-245f" name="Rapid Fire" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="08 Ability (Unit)">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <characteristics>
+                            <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="Add 1 to the Attacks characteristic of this unit’s Boltstorm Crossbows if this unit did not move in the movement phase of the same turn."/>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22ae-96d0-ace1-4028" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks/>
+                      <costs>
+                        <cost name="pts" costTypeId="points" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="cefb-ded4-3efc-58ee" name="Skybolt Bow" hidden="false" collective="false" type="upgrade">
+                      <profiles>
+                        <profile id="b396-3d38-736e-1d48" name="Skybolt Bow" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="03 Weapon">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <characteristics>
+                            <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Missile"/>
+                            <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="24&quot;"/>
+                            <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="1"/>
+                            <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="3+"/>
+                            <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+                            <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-1"/>
+                            <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a78-42b6-ca92-cc8e" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks/>
+                      <costs>
+                        <cost name="pts" costTypeId="points" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks/>
+              <costs/>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="f54c-aac7-177a-4948" name="3. Dryads" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f43f-3a78-bca2-3d03" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b506-416f-b7d7-22b4" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="c2b0-1a0c-3bcc-4990" name="Dryads" hidden="false" targetId="0a14-90fc-1335-3c79" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="1489-412c-aaf2-5402" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="0014-b1a4-c518-7274" name="Dryads" hidden="false" targetId="0a14-90fc-1335-3c79" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="notInstanceOf"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="notInstanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks>
+                <categoryLink id="7e04-c3ee-eec3-c326" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="200.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="bda6-1072-95c9-3f87" name="Battalion: Winterleaf Wargrove" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="bda6-1072-95c9-3f87" name="Super Battalion: Winterleaf Wargrove" hidden="false" collective="false" type="upgrade">
       <profiles>
         <profile id="33e6-0a76-b946-07b6" name="Surrounded by Devastation" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
           <profiles/>
@@ -4737,7 +6242,7 @@
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Any  SYLVANETH Winterleaf units that are set up in a hidden enclave at the start of the battle (see the Forest Spirits), can be set up within 3&quot; of an Ophidian Archway and more than 9&quot; from any enemy models, in addition to the other ways it can be set up. This is their move for that movement phase."/>
+            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Any SYLVANETH Winterleaf units that are set up in a hidden enclave at the start of the battle (see the Forest Spirits), can be set up within 3&quot; of an Ophidian Archway and more than 9&quot; from any enemy models, in addition to the other ways it can be set up. This is their move for that movement phase."/>
           </characteristics>
         </profile>
         <profile id="5cbd-0fcf-1d28-f35a" name="Embittered by War" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
@@ -4760,74 +6265,48 @@
         </profile>
       </profiles>
       <rules/>
-      <infoLinks/>
+      <infoLinks>
+        <infoLink id="a89c-32a8-f146-e57b" name="Mighty Wildwood" hidden="false" targetId="e69e-ffc7-e031-9478" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
       <constraints/>
       <categoryLinks/>
       <selectionEntries/>
       <selectionEntryGroups>
-        <selectionEntryGroup id="5f7b-1976-bef8-e4bc" name="May also contain:" hidden="false" collective="false">
+        <selectionEntryGroup id="5f7b-1976-bef8-e4bc" name="2. May also contain:" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints/>
           <categoryLinks/>
-          <selectionEntries>
-            <selectionEntry id="3bbc-98c7-2884-83f0" name="0-1: ORDER unit" hidden="false" collective="false" type="upgrade">
-              <profiles>
-                <profile id="c916-94d5-6a79-055e" name="ORDER Unit" hidden="false" profileTypeId="75e0-a332-e4f5-bf36" profileTypeName="Battalion Organisation">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <characteristics>
-                    <characteristic name="Required" characteristicTypeId="eb5f-e9d2-e457-bff5" value="0-1"/>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="name" value="ORDER Unit">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="bda6-1072-95c9-3f87" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3bbc-98c7-2884-83f0" type="greaterThan"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e22-8040-e180-b080" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
+          <selectionEntries/>
           <selectionEntryGroups>
-            <selectionEntryGroup id="26aa-0347-64ee-eac5" name="0-2 Forest Folk battalions" hidden="false" collective="false">
+            <selectionEntryGroup id="6e48-396e-78fe-5286" name="1. Lords of the Clan" hidden="false" collective="false">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints/>
               <categoryLinks/>
-              <selectionEntries>
-                <selectionEntry id="a358-8a59-9afd-8add" name="Battalion: Forest Folk" hidden="false" collective="false" type="upgrade">
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="9365-2680-4624-6d04" name="*Battalion: Lords of the Clan" hidden="false" targetId="3388-e687-3bd2-98a8" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e9e-e42e-4cd9-34c6" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1b8-f041-0dd0-1626" type="max"/>
                   </constraints>
                   <categoryLinks>
-                    <categoryLink id="0e48-976f-293a-da7d" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="false">
+                    <categoryLink id="07c8-a4f9-54d4-75a6" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -4835,50 +6314,82 @@
                       <constraints/>
                     </categoryLink>
                   </categoryLinks>
-                  <selectionEntries>
-                    <selectionEntry id="6f41-fe60-e7c8-d246" name="Forest Folk" hidden="false" collective="false" type="upgrade">
-                      <profiles>
-                        <profile id="954c-9f51-7cb5-2304" name="Fade from View" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                          <characteristics>
-                            <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Once per game, in your hero phase, the Forest Folk can vanish along the spirit paths. Remove all of the models in the battalion from the battlefield and set them to one side. Then set up each of the units anywhere within your territory, or within 3&quot; of a Sylvaneth Wyldwood. They must be set up at least 9&quot; from the enemy, and cannot move in the following movement phase."/>
-                          </characteristics>
-                        </profile>
-                      </profiles>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="b11a-8449-eadc-4207" name="2. Households" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="316c-d581-91d2-4f29" name="*Battalion: Household" hidden="false" targetId="d141-06d7-9c9e-d410" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04e8-739b-e26a-1f7b" type="max"/>
+                  </constraints>
+                  <categoryLinks>
+                    <categoryLink id="506d-e4ee-eeba-51ff" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                      <profiles/>
                       <rules/>
                       <infoLinks/>
                       <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="419d-27f4-1392-b05d" type="max"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="24fb-3d0a-6aa8-3635" type="min"/>
-                      </constraints>
-                      <categoryLinks/>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="110.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="3da0-0ff0-fd45-0138" name="3. Forest Folk" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries>
+                <selectionEntry id="db09-d0d9-828c-d7dd" name="*Battalion: Forest Folk" hidden="false" collective="false" type="upgrade">
+                  <profiles>
+                    <profile id="8128-46d0-441d-3546" name="Fade from View" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Once per game, in your hero phase, the Forest Folk can vanish along the spirit paths. Remove all of the models in the battalion from the battlefield and set them to one side. Then set up each of the units anywhere within your territory, or within 3&quot; of a Sylvaneth Wyldwood. They must be set up at least 9&quot; from the enemy, and cannot move in the following movement phase."/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce29-325b-30c8-d62f" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
                   <selectionEntryGroups>
-                    <selectionEntryGroup id="0001-3722-fd82-4fa0" name="3-4 units of Dryads" hidden="false" collective="false">
+                    <selectionEntryGroup id="ae61-4b0e-20a0-8d28" name="2. Dryads (3 to 4)" hidden="false" collective="false">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
                       <modifiers/>
                       <constraints>
-                        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="816c-1b98-1d2a-c15e" type="min"/>
-                        <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc0c-703d-73c1-3cb6" type="max"/>
+                        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="53af-32d5-9e7d-403c" type="min"/>
+                        <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e7f-d5a7-7b2b-6a45" type="max"/>
                       </constraints>
                       <categoryLinks/>
                       <selectionEntries/>
                       <selectionEntryGroups/>
                       <entryLinks>
-                        <entryLink id="e6dd-0a5f-55a7-c730" name="Dryads" hidden="false" targetId="0a14-90fc-1335-3c79" type="selectionEntry">
+                        <entryLink id="d026-50ad-d68c-e840" name="Dryads" hidden="false" targetId="0a14-90fc-1335-3c79" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -4900,7 +6411,7 @@
                           </modifiers>
                           <constraints/>
                           <categoryLinks>
-                            <categoryLink id="288a-9524-cbce-8390" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                            <categoryLink id="29d7-99a2-2197-00c5" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
                               <profiles/>
                               <rules/>
                               <infoLinks/>
@@ -4909,7 +6420,7 @@
                             </categoryLink>
                           </categoryLinks>
                         </entryLink>
-                        <entryLink id="6bc5-84f8-04c2-396b" name="Dryads" hidden="false" targetId="0a14-90fc-1335-3c79" type="selectionEntry">
+                        <entryLink id="dbf7-f050-551a-f10d" name="Dryads" hidden="false" targetId="0a14-90fc-1335-3c79" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -4931,7 +6442,7 @@
                           </modifiers>
                           <constraints/>
                           <categoryLinks>
-                            <categoryLink id="336f-f05b-ff3a-2813" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                            <categoryLink id="e385-6e7d-aa99-51c9" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
                               <profiles/>
                               <rules/>
                               <infoLinks/>
@@ -4942,28 +6453,27 @@
                         </entryLink>
                       </entryLinks>
                     </selectionEntryGroup>
-                    <selectionEntryGroup id="f10c-31a7-57b5-804e" name="1 Branchwraith" book="" hidden="false" collective="false">
+                    <selectionEntryGroup id="7fdb-949e-63af-9a15" name="1. Branchwraith" book="" hidden="false" collective="false">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
                       <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d546-dc34-5cc7-3430" type="min"/>
-                      </constraints>
+                      <constraints/>
                       <categoryLinks/>
                       <selectionEntries/>
                       <selectionEntryGroups/>
                       <entryLinks>
-                        <entryLink id="8e0a-f932-01ee-9e13" name="Branchwraith" hidden="false" targetId="67ae-bbfe-04fe-0e20" type="selectionEntry">
+                        <entryLink id="710c-eb42-52e4-ccb4" name="Branchwraith" hidden="false" targetId="67ae-bbfe-04fe-0e20" type="selectionEntry">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
                           <modifiers/>
                           <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47e9-6877-312e-1ce0" type="max"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b6e2-c6b9-cb6b-4e4c" type="max"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12d2-853f-5f16-4ad3" type="min"/>
                           </constraints>
                           <categoryLinks>
-                            <categoryLink id="755f-d726-f626-0d7e" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                            <categoryLink id="0ad7-6d5d-4da4-f9b0" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
                               <profiles/>
                               <rules/>
                               <infoLinks/>
@@ -4977,14 +6487,14 @@
                   </selectionEntryGroups>
                   <entryLinks/>
                   <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
+                    <cost name="pts" costTypeId="points" value="140.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
               <selectionEntryGroups/>
               <entryLinks/>
             </selectionEntryGroup>
-            <selectionEntryGroup id="9cab-c198-e8b8-d57e" name="0-3 Household battalions" hidden="false" collective="false">
+            <selectionEntryGroup id="aa32-8667-8acc-ac1f" name="4. Free Spirits" hidden="false" collective="false">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -4994,16 +6504,16 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="2a63-2035-cc3b-28a0" name="Battalion: Household" hidden="false" targetId="d141-06d7-9c9e-d410" type="selectionEntry">
+                <entryLink id="dc54-2ce0-aa13-edd5" name="*Battalion: Free Spirits" hidden="false" targetId="f852-7524-198b-2957" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bfa6-18c8-7c0d-2e57" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="928f-0ddf-ea76-4f30" type="max"/>
                   </constraints>
                   <categoryLinks>
-                    <categoryLink id="0ebd-12f7-ec64-081a" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                    <categoryLink id="e953-865c-17cf-0f48" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -5014,62 +6524,62 @@
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
+            <selectionEntryGroup id="1253-3a1b-497f-3484" name="5. Outcasts" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="c189-eb65-194e-cb6e" name="*Battalion: Outcasts" hidden="false" targetId="471d-38f0-5388-84a0" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98ac-493e-395b-b3e7" type="max"/>
+                  </constraints>
+                  <categoryLinks>
+                    <categoryLink id="c8b8-8cf5-8897-e0a9" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </categoryLink>
+                  </categoryLinks>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="22c5-0492-4471-0652" name="6. Order Unit" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries>
+                <selectionEntry id="97bc-fe37-8463-685e" name="Literally Any Order Unit" hidden="false" collective="false" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs/>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="f435-9644-8dc1-6779" name="Battalion: Free Spirits" hidden="false" targetId="f852-7524-198b-2957" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2b0-d072-9093-996e" type="max"/>
-              </constraints>
-              <categoryLinks>
-                <categoryLink id="0a9e-f00e-51a7-acc8" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </categoryLink>
-              </categoryLinks>
-            </entryLink>
-            <entryLink id="e92a-ffa5-0cc4-5e5a" name="Battalion: Lords of the Clan" hidden="false" targetId="3388-e687-3bd2-98a8" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db75-75a2-f058-e9e5" type="max"/>
-              </constraints>
-              <categoryLinks>
-                <categoryLink id="de68-7dca-0d53-284f" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </categoryLink>
-              </categoryLinks>
-            </entryLink>
-            <entryLink id="824e-c5b8-8764-6514" name="Battalion: Outcasts" hidden="false" targetId="471d-38f0-5388-84a0" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="136d-fff2-9417-7b0f" type="max"/>
-              </constraints>
-              <categoryLinks>
-                <categoryLink id="0a85-42db-4608-301c" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </categoryLink>
-              </categoryLinks>
-            </entryLink>
             <entryLink id="7b5c-2e57-85b2-974b" name="Any number of Additional Sylvaneth Units" hidden="false" targetId="2f01-3499-14c8-1107" type="selectionEntryGroup">
               <profiles/>
               <rules/>
@@ -5080,77 +6590,50 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="cd71-809f-395a-b4cd" name="1 Forest Folk battalion" hidden="false" collective="false">
+        <selectionEntryGroup id="cd71-809f-395a-b4cd" name="1. Forest Folk battalion" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a73-f7e8-6fcc-c8fe" type="min"/>
-          </constraints>
+          <constraints/>
           <categoryLinks/>
           <selectionEntries>
-            <selectionEntry id="eddf-0530-e4d3-2397" name="Battalion: Forest Folk" hidden="false" collective="false" type="upgrade">
-              <profiles/>
+            <selectionEntry id="7751-fa89-4c4a-46f0" name="Battalion: Forest Folk" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="6a6d-80d8-1917-d421" name="Fade from View" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Once per game, in your hero phase, the Forest Folk can vanish along the spirit paths. Remove all of the models in the battalion from the battlefield and set them to one side. Then set up each of the units anywhere within your territory, or within 3&quot; of a Sylvaneth Wyldwood. They must be set up at least 9&quot; from the enemy, and cannot move in the following movement phase."/>
+                  </characteristics>
+                </profile>
+              </profiles>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e91f-9ca6-3b10-5465" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed8b-d117-912e-a1ae" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d64-1d34-62e4-0639" type="min"/>
               </constraints>
-              <categoryLinks>
-                <categoryLink id="a7ce-1843-83c7-8718" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </categoryLink>
-              </categoryLinks>
-              <selectionEntries>
-                <selectionEntry id="13cd-4ef3-3ca1-d24d" name="Forest Folk" hidden="false" collective="false" type="upgrade">
-                  <profiles>
-                    <profile id="66ef-fe11-9189-2a84" name="Fade from View" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <characteristics>
-                        <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="Once per game, in your hero phase, the Forest Folk can vanish along the spirit paths. Remove all of the models in the battalion from the battlefield and set them to one side. Then set up each of the units anywhere within your territory, or within 3&quot; of a Sylvaneth Wyldwood. They must be set up at least 9&quot; from the enemy, and cannot move in the following movement phase."/>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="88c5-9086-cc6f-5b49" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8080-b142-bc73-ab94" type="min"/>
-                  </constraints>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="110.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
+              <categoryLinks/>
+              <selectionEntries/>
               <selectionEntryGroups>
-                <selectionEntryGroup id="bc83-4f07-e382-380c" name="4 units of Dryads" hidden="false" collective="false">
+                <selectionEntryGroup id="4eea-4f05-8b66-1cd3" name="2. Dryads" hidden="false" collective="false">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f30-f072-2e15-9916" type="min"/>
-                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1b6-a300-1f46-7ef5" type="max"/>
+                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b07-840f-fc7e-3d25" type="min"/>
+                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c655-f14f-323f-4303" type="max"/>
                   </constraints>
                   <categoryLinks/>
                   <selectionEntries/>
                   <selectionEntryGroups/>
                   <entryLinks>
-                    <entryLink id="a688-4b51-00bb-1a14" name="Dryads" hidden="false" targetId="0a14-90fc-1335-3c79" type="selectionEntry">
+                    <entryLink id="ab2b-6fa0-b500-c20f" name="Dryads" hidden="false" targetId="0a14-90fc-1335-3c79" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -5172,7 +6655,7 @@
                       </modifiers>
                       <constraints/>
                       <categoryLinks>
-                        <categoryLink id="8602-1995-4793-8adf" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
+                        <categoryLink id="8307-4565-b037-56e3" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -5181,7 +6664,7 @@
                         </categoryLink>
                       </categoryLinks>
                     </entryLink>
-                    <entryLink id="4ef8-7c2a-3318-0fc9" name="Dryads" hidden="false" targetId="0a14-90fc-1335-3c79" type="selectionEntry">
+                    <entryLink id="6cf1-62bf-ac8f-d32d" name="Dryads" hidden="false" targetId="0a14-90fc-1335-3c79" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -5203,7 +6686,7 @@
                       </modifiers>
                       <constraints/>
                       <categoryLinks>
-                        <categoryLink id="e298-581e-69e6-06c3" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
+                        <categoryLink id="72dc-c39a-d5e2-db3c" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -5214,28 +6697,27 @@
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
-                <selectionEntryGroup id="a372-4248-244a-7a8f" name="1 Branchwraith" book="" hidden="false" collective="false">
+                <selectionEntryGroup id="f507-a7c1-954e-e4a2" name="1. Branchwraith" book="" hidden="false" collective="false">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b0a-4f45-096f-116c" type="min"/>
-                  </constraints>
+                  <constraints/>
                   <categoryLinks/>
                   <selectionEntries/>
                   <selectionEntryGroups/>
                   <entryLinks>
-                    <entryLink id="0bec-2c6c-eec2-12a9" name="Branchwraith" hidden="false" targetId="67ae-bbfe-04fe-0e20" type="selectionEntry">
+                    <entryLink id="2302-4434-cfaf-34f0" name="Branchwraith" hidden="false" targetId="67ae-bbfe-04fe-0e20" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
                       <modifiers/>
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90ae-1a95-ef9f-791b" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd1d-b83f-e533-ea7b" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c13-d953-054e-0e8b" type="min"/>
                       </constraints>
                       <categoryLinks>
-                        <categoryLink id="fe24-14de-05cf-da77" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
+                        <categoryLink id="5107-01e1-fb53-3542" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -5249,7 +6731,7 @@
               </selectionEntryGroups>
               <entryLinks/>
               <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
+                <cost name="pts" costTypeId="points" value="140.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -5336,6 +6818,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="acc3-3330-c9ea-c576" name="Leader" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="4adc-a5a6-92c4-55f6" name="Piercing Talons" hidden="false" collective="false" type="upgrade">
@@ -5399,6 +6888,14 @@
           <categoryLinks/>
         </entryLink>
         <entryLink id="99dc-06b5-2d16-9ab7" name="Command Traits" hidden="false" targetId="1d10-2017-059e-f52d" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="b112-8db0-2c5e-bbd5" name="Wargrove Bonuses" hidden="false" targetId="7991-c400-3deb-c3be" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5488,6 +6985,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="567b-0a37-40be-2a6f" name="New CategoryLink" hidden="false" targetId="de6f-3fcb-09b2-a59e" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="4836-42ae-282d-0e0b" name="Leader" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5597,6 +7101,14 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
+        <entryLink id="6bad-b045-0d5e-3fee" name="Wargrove Bonuses" hidden="false" targetId="7991-c400-3deb-c3be" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="80.0"/>
@@ -5625,7 +7137,7 @@
             <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="Subtract 1 from all hit rolls made against this unit if it is within 3&quot; of a Sylaneth Wyldwood."/>
           </characteristics>
         </profile>
-        <profile id="024f-1313-fa09-891a" name="Enrapturing Sond" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="08 Ability (Unit)">
+        <profile id="024f-1313-fa09-891a" name="Enrapturing Song" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="08 Ability (Unit)">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5905,6 +7417,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="dcae-209c-1f30-7ce1" name="New CategoryLink" hidden="false" targetId="de6f-3fcb-09b2-a59e" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="d3cf-6c4d-600e-86ba" name="Leader" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6335,78 +7854,6 @@
             <characteristic name="Save" characteristicTypeId="f8dd-4f2a-8543-4f36" value="3+"/>
           </characteristics>
         </profile>
-        <profile id="7f19-7c21-417f-05b3" name="Wounds0" hidden="false" profileTypeId="90d1-a434-348d-a861" profileTypeName="Damage Table">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Variable 1" characteristicTypeId="420a-645a-ab28-93a0" value="Wounds Suffered"/>
-            <characteristic name="Variable 2" characteristicTypeId="4cdd-1e03-530f-0ff7" value="Verdent Blast"/>
-            <characteristic name="Variable 3" characteristicTypeId="b1ea-56be-ba52-16e9" value="Guardian Sword"/>
-            <characteristic name="Variable 4" characteristicTypeId="ad26-bf56-95c4-80f1" value="Massive Impaling Talons"/>
-          </characteristics>
-        </profile>
-        <profile id="137b-ce5e-4003-e3ce" name="Wounds1" hidden="false" profileTypeId="90d1-a434-348d-a861" profileTypeName="Damage Table">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Variable 1" characteristicTypeId="420a-645a-ab28-93a0" value="0-2"/>
-            <characteristic name="Variable 2" characteristicTypeId="4cdd-1e03-530f-0ff7" value="6"/>
-            <characteristic name="Variable 3" characteristicTypeId="b1ea-56be-ba52-16e9" value="6"/>
-            <characteristic name="Variable 4" characteristicTypeId="ad26-bf56-95c4-80f1" value="2+"/>
-          </characteristics>
-        </profile>
-        <profile id="c9d1-4f12-3f33-4da5" name="Wounds2" hidden="false" profileTypeId="90d1-a434-348d-a861" profileTypeName="Damage Table">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Variable 1" characteristicTypeId="420a-645a-ab28-93a0" value="3-4"/>
-            <characteristic name="Variable 2" characteristicTypeId="4cdd-1e03-530f-0ff7" value="5"/>
-            <characteristic name="Variable 3" characteristicTypeId="b1ea-56be-ba52-16e9" value="D6"/>
-            <characteristic name="Variable 4" characteristicTypeId="ad26-bf56-95c4-80f1" value="2+"/>
-          </characteristics>
-        </profile>
-        <profile id="8f9d-8ac3-898b-1079" name="Wounds3" hidden="false" profileTypeId="90d1-a434-348d-a861" profileTypeName="Damage Table">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Variable 1" characteristicTypeId="420a-645a-ab28-93a0" value="5-7"/>
-            <characteristic name="Variable 2" characteristicTypeId="4cdd-1e03-530f-0ff7" value="4"/>
-            <characteristic name="Variable 3" characteristicTypeId="b1ea-56be-ba52-16e9" value="D6"/>
-            <characteristic name="Variable 4" characteristicTypeId="ad26-bf56-95c4-80f1" value="3+"/>
-          </characteristics>
-        </profile>
-        <profile id="dce1-7a76-7e08-0dd6" name="Wounds4" hidden="false" profileTypeId="90d1-a434-348d-a861" profileTypeName="Damage Table">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Variable 1" characteristicTypeId="420a-645a-ab28-93a0" value="8-9"/>
-            <characteristic name="Variable 2" characteristicTypeId="4cdd-1e03-530f-0ff7" value="3"/>
-            <characteristic name="Variable 3" characteristicTypeId="b1ea-56be-ba52-16e9" value="D6"/>
-            <characteristic name="Variable 4" characteristicTypeId="ad26-bf56-95c4-80f1" value="3+"/>
-          </characteristics>
-        </profile>
-        <profile id="0875-968f-a028-67a9" name="Wounds5" hidden="false" profileTypeId="90d1-a434-348d-a861" profileTypeName="Damage Table">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Variable 1" characteristicTypeId="420a-645a-ab28-93a0" value="10+"/>
-            <characteristic name="Variable 2" characteristicTypeId="4cdd-1e03-530f-0ff7" value="2"/>
-            <characteristic name="Variable 3" characteristicTypeId="b1ea-56be-ba52-16e9" value="D3"/>
-            <characteristic name="Variable 4" characteristicTypeId="ad26-bf56-95c4-80f1" value="4+"/>
-          </characteristics>
-        </profile>
         <profile id="3afe-8250-5ffd-79d3" name="Groundshaking Stomp" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="Unit Abilities">
           <profiles/>
           <rules/>
@@ -6505,6 +7952,13 @@
           <constraints/>
         </categoryLink>
         <categoryLink id="f7b4-4649-b93d-ce47" name="New CategoryLink" hidden="false" targetId="de6f-3fcb-09b2-a59e" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="ad55-9d33-06d7-be3b" name="Leader" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6612,6 +8066,91 @@
             <cost name="pts" costTypeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
+        <selectionEntry id="4a88-a312-1f16-e844" name="Durthu Wound Track" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="ca5a-4d18-f030-ce45" name="Wounds0" hidden="false" profileTypeId="90d1-a434-348d-a861" profileTypeName="Damage Table">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Variable 1" characteristicTypeId="420a-645a-ab28-93a0" value="Wounds Suffered"/>
+                <characteristic name="Variable 2" characteristicTypeId="4cdd-1e03-530f-0ff7" value="Verdent Blast"/>
+                <characteristic name="Variable 3" characteristicTypeId="b1ea-56be-ba52-16e9" value="Guardian Sword"/>
+                <characteristic name="Variable 4" characteristicTypeId="ad26-bf56-95c4-80f1" value="Massive Impaling Talons"/>
+              </characteristics>
+            </profile>
+            <profile id="99c1-63c3-68cc-1cc2" name="Wounds1" hidden="false" profileTypeId="90d1-a434-348d-a861" profileTypeName="Damage Table">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Variable 1" characteristicTypeId="420a-645a-ab28-93a0" value="0-2"/>
+                <characteristic name="Variable 2" characteristicTypeId="4cdd-1e03-530f-0ff7" value="6"/>
+                <characteristic name="Variable 3" characteristicTypeId="b1ea-56be-ba52-16e9" value="6"/>
+                <characteristic name="Variable 4" characteristicTypeId="ad26-bf56-95c4-80f1" value="2+"/>
+              </characteristics>
+            </profile>
+            <profile id="8c19-02f3-da56-e840" name="Wounds2" hidden="false" profileTypeId="90d1-a434-348d-a861" profileTypeName="Damage Table">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Variable 1" characteristicTypeId="420a-645a-ab28-93a0" value="3-4"/>
+                <characteristic name="Variable 2" characteristicTypeId="4cdd-1e03-530f-0ff7" value="5"/>
+                <characteristic name="Variable 3" characteristicTypeId="b1ea-56be-ba52-16e9" value="D6"/>
+                <characteristic name="Variable 4" characteristicTypeId="ad26-bf56-95c4-80f1" value="2+"/>
+              </characteristics>
+            </profile>
+            <profile id="e1e1-8272-c43c-f157" name="Wounds3" hidden="false" profileTypeId="90d1-a434-348d-a861" profileTypeName="Damage Table">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Variable 1" characteristicTypeId="420a-645a-ab28-93a0" value="5-7"/>
+                <characteristic name="Variable 2" characteristicTypeId="4cdd-1e03-530f-0ff7" value="4"/>
+                <characteristic name="Variable 3" characteristicTypeId="b1ea-56be-ba52-16e9" value="D6"/>
+                <characteristic name="Variable 4" characteristicTypeId="ad26-bf56-95c4-80f1" value="3+"/>
+              </characteristics>
+            </profile>
+            <profile id="3023-9375-c6c5-8005" name="Wounds4" hidden="false" profileTypeId="90d1-a434-348d-a861" profileTypeName="Damage Table">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Variable 1" characteristicTypeId="420a-645a-ab28-93a0" value="8-9"/>
+                <characteristic name="Variable 2" characteristicTypeId="4cdd-1e03-530f-0ff7" value="3"/>
+                <characteristic name="Variable 3" characteristicTypeId="b1ea-56be-ba52-16e9" value="D6"/>
+                <characteristic name="Variable 4" characteristicTypeId="ad26-bf56-95c4-80f1" value="3+"/>
+              </characteristics>
+            </profile>
+            <profile id="f55f-1852-9f09-0018" name="Wounds5" hidden="false" profileTypeId="90d1-a434-348d-a861" profileTypeName="Damage Table">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Variable 1" characteristicTypeId="420a-645a-ab28-93a0" value="10+"/>
+                <characteristic name="Variable 2" characteristicTypeId="4cdd-1e03-530f-0ff7" value="2"/>
+                <characteristic name="Variable 3" characteristicTypeId="b1ea-56be-ba52-16e9" value="D3"/>
+                <characteristic name="Variable 4" characteristicTypeId="ad26-bf56-95c4-80f1" value="4+"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs/>
+        </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>
       <entryLinks>
@@ -6632,6 +8171,14 @@
           <categoryLinks/>
         </entryLink>
         <entryLink id="9006-48b1-85f4-a3a6" name="Command Traits" hidden="false" targetId="1d10-2017-059e-f52d" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="0945-e558-a478-b760" name="Wargrove Bonuses" hidden="false" targetId="7991-c400-3deb-c3be" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -7494,6 +9041,13 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="141d-0f1a-d7da-568e" name="Leader" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="5b8c-438b-dc67-3d25" name="Doom Tendril Staff" hidden="false" collective="false" type="upgrade">
@@ -7630,6 +9184,14 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
+        <entryLink id="c413-9408-8c0d-9a37" name="Wargrove Bonuses" hidden="false" targetId="7991-c400-3deb-c3be" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="300.0"/>
@@ -7717,6 +9279,358 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="a70a-a23d-860a-8dce" name="Treelord Ancient (Head of the Clan)" hidden="false" collective="false" type="unit">
+      <profiles>
+        <profile id="0250-9154-9e5b-e8de" name="Treelord Ancient" hidden="false" profileTypeId="1960-ca8e-67ce-2014" profileTypeName="Unit">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Move" characteristicTypeId="8655-6213-2824-1752" value="5&quot;"/>
+            <characteristic name="Wounds" characteristicTypeId="cd0e-fea6-411f-904d" value="12"/>
+            <characteristic name="Bravery" characteristicTypeId="0c85-bf79-836b-759e" value="9"/>
+            <characteristic name="Save" characteristicTypeId="f8dd-4f2a-8543-4f36" value="3+"/>
+          </characteristics>
+        </profile>
+        <profile id="c7e1-c8de-9398-da38" name="Groundshaking Stomp" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="08 Ability (Unit)">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="At the start of the combat phase, roll a dice for each enemy unit within 3&quot; of any models with this ability. On a roll of 4 or more that unit is knocked off their feet by the impact and must subtract 1 from all hit rolls in that combat phase as they regain their footing."/>
+          </characteristics>
+        </profile>
+        <profile id="1c1a-56af-66f2-f8c7" name="Impale" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="08 Ability (Unit)">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="If a Treelord Ancient&apos;s Massive Impaling Talons inflict a wound on an enemy model, roll a dice and subtract 1 from the roll. If the result equals or exceeds the number of wounds the enemy model has remaining, it is slain."/>
+          </characteristics>
+        </profile>
+        <profile id="89c7-a11f-efe3-bc5e" name="Wounds0" hidden="false" profileTypeId="90d1-a434-348d-a861" profileTypeName="Damage Table">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Variable 1" characteristicTypeId="420a-645a-ab28-93a0" value="Wounds Suffered"/>
+            <characteristic name="Variable 2" characteristicTypeId="4cdd-1e03-530f-0ff7" value="Doom Tendril Staff"/>
+            <characteristic name="Variable 3" characteristicTypeId="b1ea-56be-ba52-16e9" value="Sweeping Blows"/>
+            <characteristic name="Variable 4" characteristicTypeId="ad26-bf56-95c4-80f1" value="Massive Impaling Talons"/>
+          </characteristics>
+        </profile>
+        <profile id="0730-a43c-4661-3d0a" name="Wounds1" hidden="false" profileTypeId="90d1-a434-348d-a861" profileTypeName="Damage Table">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Variable 1" characteristicTypeId="420a-645a-ab28-93a0" value="0-2"/>
+            <characteristic name="Variable 2" characteristicTypeId="4cdd-1e03-530f-0ff7" value="2+"/>
+            <characteristic name="Variable 3" characteristicTypeId="b1ea-56be-ba52-16e9" value="3"/>
+            <characteristic name="Variable 4" characteristicTypeId="ad26-bf56-95c4-80f1" value="2+"/>
+          </characteristics>
+        </profile>
+        <profile id="3ba3-7f2e-5730-3983" name="Wounds2" hidden="false" profileTypeId="90d1-a434-348d-a861" profileTypeName="Damage Table">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Variable 1" characteristicTypeId="420a-645a-ab28-93a0" value="3-4"/>
+            <characteristic name="Variable 2" characteristicTypeId="4cdd-1e03-530f-0ff7" value="3+"/>
+            <characteristic name="Variable 3" characteristicTypeId="b1ea-56be-ba52-16e9" value="2"/>
+            <characteristic name="Variable 4" characteristicTypeId="ad26-bf56-95c4-80f1" value="2+"/>
+          </characteristics>
+        </profile>
+        <profile id="b66b-4548-1e04-d5a7" name="Wounds3" hidden="false" profileTypeId="90d1-a434-348d-a861" profileTypeName="Damage Table">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Variable 1" characteristicTypeId="420a-645a-ab28-93a0" value="5-7"/>
+            <characteristic name="Variable 2" characteristicTypeId="4cdd-1e03-530f-0ff7" value="4+"/>
+            <characteristic name="Variable 3" characteristicTypeId="b1ea-56be-ba52-16e9" value="2"/>
+            <characteristic name="Variable 4" characteristicTypeId="ad26-bf56-95c4-80f1" value="3+"/>
+          </characteristics>
+        </profile>
+        <profile id="6bd2-ab2c-c885-1232" name="Wounds4" hidden="false" profileTypeId="90d1-a434-348d-a861" profileTypeName="Damage Table">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Variable 1" characteristicTypeId="420a-645a-ab28-93a0" value="8-9"/>
+            <characteristic name="Variable 2" characteristicTypeId="4cdd-1e03-530f-0ff7" value="5+"/>
+            <characteristic name="Variable 3" characteristicTypeId="b1ea-56be-ba52-16e9" value="1"/>
+            <characteristic name="Variable 4" characteristicTypeId="ad26-bf56-95c4-80f1" value="3+"/>
+          </characteristics>
+        </profile>
+        <profile id="d8d0-17e4-8585-ee17" name="Wounds5" hidden="false" profileTypeId="90d1-a434-348d-a861" profileTypeName="Damage Table">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Variable 1" characteristicTypeId="420a-645a-ab28-93a0" value="10+"/>
+            <characteristic name="Variable 2" characteristicTypeId="4cdd-1e03-530f-0ff7" value="6+"/>
+            <characteristic name="Variable 3" characteristicTypeId="b1ea-56be-ba52-16e9" value="1"/>
+            <characteristic name="Variable 4" characteristicTypeId="ad26-bf56-95c4-80f1" value="4+"/>
+          </characteristics>
+        </profile>
+        <profile id="44cb-716d-0977-26c4" name="Spirit Paths" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="Unit Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="If a Treelord Ancient is within 3&quot; of a Sylvaneth Wyldwood at the start of your movement phase, they can travel along the spirit paths. If they do so, remove the Treelord Ancient from the battlefield, and then set them up within 3&quot; of a different Sylvaneth Wyldwood, more than 9&quot; from any enemy models. This is their move for the movement phase."/>
+          </characteristics>
+        </profile>
+        <profile id="405c-546c-6c43-92f6" name="Silent Communion" book="Battletome: Sylvaneth Errata, July 2018" hidden="false" profileTypeId="c924-5a68-471a-2fd5" profileTypeName="Unit Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Ability Details" characteristicTypeId="d4dc-8e81-bc0e-b8f0" value="In your hero phase, you can pick 1 friendly TREELORD ANCIENT and roll a dice. On a 4+, you can set up 1 SYLVANETH WYLDWOOD terrain feature wholly within 24&quot; of that TREELORD ANCIENT, and more than 3&quot; from any other models or terrain features."/>
+          </characteristics>
+        </profile>
+        <profile id="62b2-45c5-496f-7a57" name="Awakening of the Wood" hidden="false" profileTypeId="f55d-ee3a-1597-110f" profileTypeName="Magic">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Cast/Unbind" characteristicTypeId="8294-f605-2c0f-8f92" value="6"/>
+            <characteristic name="Spells Known" characteristicTypeId="dc9c-47d3-6931-859c" value="If successfully cast, pick a Sylvaneth Wyldwood that is within 24&quot; of the caster. Each enemy unit within 3&quot; of this Sylvaneth Wyldwood suffers D3 mortal wounds as the trees come to life and attack with twisted branches and thorny boughs."/>
+          </characteristics>
+        </profile>
+        <profile id="737c-6310-5292-269a" name="Heed the Spirit-song" hidden="false" profileTypeId="f71f-b0a4-730e-ced3" profileTypeName="Command Abilities">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Command Ability Details" characteristicTypeId="1b71-4c83-4e8c-093f" value="Until your next hero phase, you can re-roll save rolls of 1 for SYLVANETH units if they are within 10&quot; of the Treelord Ancient."/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="56c5-8a25-692c-4004" name="New CategoryLink" hidden="false" targetId="4e0e-664d-51ea-0929" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="ca15-5945-f899-9309" name="New CategoryLink" hidden="false" targetId="1959-9f6a-3056-913a" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="07bc-9601-8f72-4d60" name="New CategoryLink" hidden="false" targetId="4b76-b5c5-2c23-c72a" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="d57a-da2d-88f9-faf8" name="New CategoryLink" hidden="false" targetId="4f53-8230-2f02-9639" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="208a-1138-2013-e48c" name="New CategoryLink" hidden="false" targetId="b970-b3bf-e1a4-a6fc" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="b8b6-9e5c-3576-76b2" name="New CategoryLink" hidden="false" targetId="de6f-3fcb-09b2-a59e" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="ff65-b27c-542f-d3ee" name="Behemoth" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="e592-0db8-b332-15d2" name="Leader" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="c910-927a-dec3-0765" name="Doom Tendril Staff" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="850b-588e-f446-5d21" name="Doom Tendril Staff" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Missile"/>
+                <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="18&quot;"/>
+                <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="1"/>
+                <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="*"/>
+                <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+                <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-1"/>
+                <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="D6"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6b7-b661-036e-6c9c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a487-0623-8ccc-b453" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="bd02-91bb-4a07-beb9" name="Massive Impaling Talons" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="db11-fb85-6ada-a835" name="Massive Impaling Talons" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="1&quot;"/>
+                <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="1"/>
+                <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="3+"/>
+                <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="*"/>
+                <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-2"/>
+                <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="1"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2885-76c2-93ec-045f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c52-25d0-bfca-515f" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="58e1-8235-8571-f052" name="Sweeping Blows" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="8359-0c49-50f3-a925" name="Sweeping Blows" hidden="false" profileTypeId="96df-ab28-5d72-bbb3" profileTypeName="Weapon">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Type" characteristicTypeId="655c-362e-a663-3e50" value="Melee"/>
+                <characteristic name="Range" characteristicTypeId="ee32-7f8e-ccd7-b7b0" value="3&quot;"/>
+                <characteristic name="Attacks" characteristicTypeId="0bd7-bded-a0e0-19a0" value="*"/>
+                <characteristic name="To Hit" characteristicTypeId="87f2-fb99-33f9-7269" value="3+"/>
+                <characteristic name="To Wound" characteristicTypeId="8842-17f1-9794-4efc" value="3+"/>
+                <characteristic name="Rend" characteristicTypeId="f578-d2a5-f0d3-b707" value="-1"/>
+                <characteristic name="Damage" characteristicTypeId="b5b6-4cbd-661d-1b70" value="D6"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c0a2-4a8f-a626-5f0a" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ee1-1594-f365-4353" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="ac27-58d5-eede-76e4" name="General" hidden="false" targetId="b341-0885-3f1c-7d8a" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="e38c-75b2-1ce8-493f" name="Artefacts" hidden="false" targetId="083e-a950-b54a-c2a4" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="72f1-c7c0-5c9d-b731" name="Deepwood Spell Lore" hidden="false" targetId="ad08-f268-8b24-726b" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="1b99-f322-2299-3d1e" name="Command Traits" hidden="false" targetId="1d10-2017-059e-f52d" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="0103-8324-13ed-c1b3" name="Wargrove Bonuses" hidden="false" targetId="7991-c400-3deb-c3be" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="300.0"/>
+      </costs>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="083e-a950-b54a-c2a4" name="Artefacts" hidden="false" collective="false">
@@ -7730,6 +9644,19 @@
           </repeats>
           <conditions/>
           <conditionGroups/>
+        </modifier>
+        <modifier type="set" field="903c-54ee-5c65-eed8" value="0.0">
+          <repeats/>
+          <conditions/>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="19c7-ac1a-e0fb-b473" type="equalTo"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3fcc-3c45-6c73-5002" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
@@ -7807,6 +9734,13 @@
           <repeats/>
           <conditions>
             <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b745-17c4-8fbf-8b04" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+        <modifier type="set" field="b7cd-9b0e-9faf-6ea4" value="0.0">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7947-8f6a-e061-d4bb" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -8382,13 +10316,14 @@
           <repeats/>
           <conditions>
             <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cc2e-a897-99a2-353f" type="equalTo"/>
+            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="de6f-3fcb-09b2-a59e" type="notInstanceOf"/>
           </conditions>
           <conditionGroups/>
         </modifier>
-        <modifier type="set" field="hidden" value="true">
+        <modifier type="increment" field="2ba7-5c71-2b3a-bb00" value="1">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="de6f-3fcb-09b2-a59e" type="notInstanceOf"/>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3fcc-3c45-6c73-5002" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
@@ -8880,6 +10815,281 @@
         </entryLink>
       </entryLinks>
     </selectionEntryGroup>
+    <selectionEntryGroup id="7991-c400-3deb-c3be" name="Wargrove Bonuses" hidden="false" collective="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries>
+        <selectionEntry id="7947-8f6a-e061-d4bb" name="Ancient Nobility" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="46a8-5aa6-bfee-fdf6" name="Ancient Nobility" hidden="false" profileTypeId="c749-bae4-71a8-0c36" profileTypeName="Command Trait">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Command Trait Details" characteristicTypeId="ee96-6f3a-e5ca-2350" value="All friendly SYLVANETH units within 15&quot; of your general in the battleshock phase add 1 to their Bravery."/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fc74-5007-3ac8-3b19" type="notInstanceOf"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b745-17c4-8fbf-8b04" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e7c-634c-b838-aabe" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="64df-1408-33dc-cc04" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0c7b-8b6c-ffe5-66fc" name="Verdurous Harmony" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="09a7-7be6-836e-3a3e" name="Verdurous Harmony" hidden="false" profileTypeId="2e81-5e22-c6e1-73cb" profileTypeName="Spell">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Casting Value" characteristicTypeId="2508-b604-1258-a920" value="7"/>
+                <characteristic name="Description" characteristicTypeId="76ff-781d-b8e6-5f27" value="If successfully cast, select a friendly SYLVANETH unit within 18&quot;. One model in that unit that has been slain earlier during the battle is returned to life. Return D3 slain models to the unit instead if they are Dryads or Tree-Revenants."/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d51-f119-1a14-e947" type="notInstanceOf"/>
+                  </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d51-f119-1a14-e947" type="notInstanceOf"/>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f53-8230-2f02-9639" type="notInstanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="345b-1455-45f4-44b0" value="1">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d51-f119-1a14-e947" type="instanceOf"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ee6-25f4-2998-f90e" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="345b-1455-45f4-44b0" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="19c7-ac1a-e0fb-b473" name="Ironbark Talisman" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="507d-d16f-3680-dd3c" name="Ironbark Talisman" hidden="false" profileTypeId="0ac4-aacb-2481-8e72" profileTypeName="Artefact">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Artefact Details" characteristicTypeId="0918-c47a-d84e-c0cf" value="You can add 1 to all wound rolls made for the bearer’s melee weapons."/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9499-680b-d7f9-c2b4" type="notInstanceOf"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7423-5cc1-3416-79ed" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="069e-fcc9-3c62-8593" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3fcc-3c45-6c73-5002" name="Tear of Grace" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="53ed-56dd-2f04-e0d7" name="Tear of Grace" hidden="false" profileTypeId="0ac4-aacb-2481-8e72" profileTypeName="Artefact">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Artefact Details" characteristicTypeId="0918-c47a-d84e-c0cf" value="The bearer of the Tear of Grace knows an extra spell, which is always generated from the Deepwood spell lore. In addition, the bearer can add 3&quot; to the range of all of their spells."/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="36f8-6827-6ec9-c876" type="notInstanceOf"/>
+                  </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="36f8-6827-6ec9-c876" type="notInstanceOf"/>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5bb1-ed20-b7d9-9d94" type="notInstanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fdce-9c3b-5e71-d2bb" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11dd-683c-ab2c-f4a4" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4dd2-be00-5a3c-f1ad" name="Alarielle&apos;s Blessing" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="ca4c-77a1-1e9a-3315" name="Alarielle&apos;s Blessing" hidden="false" profileTypeId="2e81-5e22-c6e1-73cb" profileTypeName="Spell">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Casting Value" characteristicTypeId="2508-b604-1258-a920" value="5"/>
+                <characteristic name="Description" characteristicTypeId="76ff-781d-b8e6-5f27" value="If successfully cast, pick a model from the battalion that is within 18&quot; of the caster.  The model you pick heals D3 wounds."/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="48d1-ef89-4d11-ef1c" type="notInstanceOf"/>
+                  </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="48d1-ef89-4d11-ef1c" type="notInstanceOf"/>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f53-8230-2f02-9639" type="notInstanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="d3fe-57ba-8df2-525a" value="1">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="48d1-ef89-4d11-ef1c" type="instanceOf"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9230-150a-92ab-fb54" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d3fe-57ba-8df2-525a" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="f99e-36cd-f48a-0435" name="Order Wizards" hidden="false" collective="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="156d-0e27-2951-7be1" name="Duardin Units" hidden="false" collective="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+    </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules/>
   <sharedProfiles>
@@ -8899,6 +11109,15 @@
       <modifiers/>
       <characteristics>
         <characteristic name="Battle Trait Details" characteristicTypeId="9fdd-b4b1-5f7a-0970" value="Roll a dice for each model that makes a run or charge move across, or finishing on, a Sylvaneth Wyldwood. On a roll of 1, the model is slain. Do not roll for models that have the SYLVANETH, MONSTER, or HERO keywords."/>
+      </characteristics>
+    </profile>
+    <profile id="e69e-ffc7-e031-9478" name="Mighty Wildwood" hidden="false" profileTypeId="bdc6-78da-3796-60a3" profileTypeName="Battalion Abilities">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Battalion Ability Details" characteristicTypeId="08e0-9ead-1dbe-c801" value="If your army has the SYLVANETH allegiance and contains the maximum number of battalions, then the Wyldwood Groves ability allows you to set up one additional Sylvaneth Wyldwood. In addition, each time one of your units uses the Navigate Realmroots ability, add 1 to the dice result."/>
       </characteristics>
     </profile>
   </sharedProfiles>


### PR DESCRIPTION
All Bonesplitterz units updated to be Chompas (#810, #811), and the Sylvaneth catalog has been given a full overhaul in line with my previous reformats. 
1) Battalions numbered, corrected for points (#806)
2) Super Battalions separated
3) Wargroves VASTLY overhauled in favor of less confusing conditions, correcting points costs and setting proper abilities
4) Older increment/decrement system thrown out
5) Stormcast units added directly to Guardians of Alarielle battalion
6) Duardin Units and Order Wizards shifted to SSEGs for future update usage

Lemme know if anything needs to be changed.