### PR TITLE
Who Fights First Errata

### DIFF
--- a/Death - Legions of Nagash and Nighthaunt.cat
+++ b/Death - Legions of Nagash and Nighthaunt.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="e320-d5ec-ac8e-03dd" name="Death: Legions of Nagash and Nighthaunt" book="Battletome: Legions of Nagash and Battletome: Nighthaunt" revision="39" battleScribeVersion="2.01" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="7" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="e320-d5ec-ac8e-03dd" name="Death: Legions of Nagash and Nighthaunt" book="Battletome: Legions of Nagash and Battletome: Nighthaunt" revision="40" battleScribeVersion="2.01" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="7" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules>
     <rule id="c7d8-4531-1671-0e10" name="Returning Slain Models - Nighthaunt" book="Battletome: Nighthaunt" hidden="false">
@@ -28154,7 +28154,7 @@ The slain models you return to a unit can only be set up withi 3&quot; of an ene
               <modifiers/>
               <characteristics>
                 <characteristic name="Casting Value" characteristicTypeId="2508-b604-1258-a920" value="6"/>
-                <characteristic name="Description" characteristicTypeId="76ff-781d-b8e6-5f27" value="If successfully cast, pick an enemy unit within 12&quot; of the caster that is visible to them. Until the start of your next hero phase, that unit cannot retreat. In addition, until the start of your next hero phase, that unit cannot fight in the combat phase unless all other enemy units that are eligible to fight have already done so."/>
+                <characteristic name="Description" characteristicTypeId="76ff-781d-b8e6-5f27" value="If successfully cast, pick an enemy unit within 12&quot; of the caster that is visible to them. Until the start of your next hero phase, that unit cannot retreat. In addition, until your next hero phase, that unit fights at the end of the combat phase."/>
               </characteristics>
             </profile>
           </profiles>

--- a/Order - Idoneth Deepkin.cat
+++ b/Order - Idoneth Deepkin.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="0d25-2712-00a2-3028" name="Order - Idoneth Deepkin" book="Order Battletome: Idoneth Deepkin" revision="12" battleScribeVersion="2.01" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="19" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="0d25-2712-00a2-3028" name="Order - Idoneth Deepkin" book="Order Battletome: Idoneth Deepkin" revision="13" battleScribeVersion="2.01" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="19" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -984,7 +984,7 @@
                           <modifiers/>
                           <characteristics>
                             <characteristic name="Turn" characteristicTypeId="41bf-1d9a-c900-4a55" value="3/7"/>
-                            <characteristic name="Effect" characteristicTypeId="d0a7-be18-7209-6a57" value="In this battle round, units with the Tides of Death battle trait fight before any other units in the combat phase. Fight with all eligible Idoneth Deepkin units one after the other, and then resolve any fights with any other units."/>
+                            <characteristic name="Effect" characteristicTypeId="d0a7-be18-7209-6a57" value="In this battle round, units with the Tides of Death battle trait fight at the start of the combat phase."/>
                           </characteristics>
                         </profile>
                         <profile id="0731-1abb-e855-bc96" name="4. Ebbing Tide" hidden="false" profileTypeId="ac0f-3fba-b82e-a9e8" profileTypeName="Tides of Death">


### PR DESCRIPTION
Minor rule updates for Idoneth Deepkin and Nighthaunt clarifying the
order in which units fight during the combat phase.

Taken from this Warhammer Community update:
https://www.warhammer-community.com/2019/03/21/who-fights-first/