### PR TITLE
Fix #935 and #936.

### DIFF
--- a/Death - Legions of Nagash and Nighthaunt.cat
+++ b/Death - Legions of Nagash and Nighthaunt.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="e320-d5ec-ac8e-03dd" name="Death: Legions of Nagash and Nighthaunt" revision="42" battleScribeVersion="2.02" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="7" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="e320-d5ec-ac8e-03dd" name="Death: Legions of Nagash and Nighthaunt" revision="43" battleScribeVersion="2.02" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="7" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="e320-d5ec-pubN65537" name="Battletome: Legions of Nagash and Battletome: Nighthaunt"/>
     <publication id="e320-d5ec-pubN65555" name="Battletome: Nighthaunt"/>
@@ -9,8 +9,8 @@
     <publication id="e320-d5ec-pubN102904" name="Vampire Counts: Warscroll Compendium"/>
     <publication id="e320-d5ec-pubN126193" name="Soul Wars"/>
     <publication id="e320-d5ec-pubN143137" name="Warhammer Underworlds: Nightvault"/>
-    <publication id="e320-d5ec-pubN155312" name="`"/>
     <publication id="e320-d5ec-pubN155726" name="Tomb Kings: Warscroll Compendium"/>
+    <publication id="241a-2f06-84ad-d21d" name="Death Battletome: Nighthaunt"/>
   </publications>
   <profileTypes>
     <profileType id="c098-3f9a-28af-206d" name="Mourngul Wounds Suffered">
@@ -11381,9 +11381,9 @@ The slain models you return to a unit can only be set up withi 3&quot; of an ene
             <characteristic name="Spells Known" typeId="dc9c-47d3-6931-859c">Arcane Bolt, Mystic Shield, Spectral Lure</characteristic>
           </characteristics>
         </profile>
-        <profile id="2aa2-018a-0039-4a1c" name="Nightmare Lantern" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+        <profile id="2aa2-018a-0039-4a1c" name="Nightmare Lantern" publicationId="241a-2f06-84ad-d21d" page="77" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Add 1 to the wound rolls for melee weapons wielded by friendly NIGHTHAUNT models that are within 9&quot; of this model.</characteristic>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Add 1 to wound rolls for attacks made with melee weapons used by friendly NIGHTHAUNT units that are wholly within 12&quot; of this model.</characteristic>
           </characteristics>
         </profile>
         <profile id="3bf2-1a1c-378a-c121" name="Guardian of Souls" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
@@ -11410,16 +11410,16 @@ The slain models you return to a unit can only be set up withi 3&quot; of an ene
         <categoryLink id="a755-ee64-781b-9086" name="New CategoryLink" hidden="false" targetId="d4fa-feac-6db1-0da7" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="d7f8-c1fe-46bd-8d89" name="Spectral Lure" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="d7f8-c1fe-46bd-8d89" name="Spectral Lure" page="" hidden="false" collective="false" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f68-3bfa-dd88-4610" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e87-bf68-9ae3-812a" type="max"/>
           </constraints>
           <profiles>
-            <profile id="60fb-7778-30a4-b137" name="Spectral Lure" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
+            <profile id="60fb-7778-30a4-b137" name="Spectral Lure" publicationId="241a-2f06-84ad-d21d" page="77" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
               <characteristics>
                 <characteristic name="Casting Value" typeId="2508-b604-1258-a920">6</characteristic>
-                <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, pick a friendly SUMMONABLE NIGHTHAUNT unit wholly within 18&quot; of the caster. You can either heal D6 wounds that have been allocated to that unit or, if no wounds are currently allocated to the unit, you may return a number of slain models to it that have a combined Wounds characteristic equal to or less than the roll of a D6.</characteristic>
+                <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, pick a friendly SUMMONABLE NIGHTHAUNT unit wholly within 24&quot; of the caster. You can either heal D6 wounds that have been allocated to that unit or, if no wounds have been allocated to the unit, you can return a number of slain models to it that have a combined Wounds characteristic equal to or less than the roll of a D6.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -14553,7 +14553,7 @@ The slain models you return to a unit can only be set up withi 3&quot; of an ene
         </profile>
         <profile id="0cb1-5b5e-d1d8-e865" name="Mortality Glass" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">When enemy units within 9&apos; of this model charge, roll a D6 instead of 2D6 when determining the distance they can move.</characteristic>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">When enemy units within 9&quot; of this model charge, roll a D6 instead of 2D6 when determining the distance they can move.</characteristic>
           </characteristics>
         </profile>
         <profile id="3556-b15c-c578-9772" name="Guardian of Souls" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
@@ -16732,7 +16732,7 @@ The slain models you return to a unit can only be set up withi 3&quot; of an ene
             <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d435-9dd9-b159-5e18" type="max"/>
           </constraints>
           <profiles>
-            <profile id="adbb-6c60-f259-f778" name="Headsman&apos;s Judgement" publicationId="e320-d5ec-pubN155312" hidden="false" typeId="0ac4-aacb-2481-8e72" typeName="Artefact">
+            <profile id="adbb-6c60-f259-f778" name="Headsman&apos;s Judgement" publicationId="e320-d5ec-pubN65537" hidden="false" typeId="0ac4-aacb-2481-8e72" typeName="Artefact">
               <characteristics>
                 <characteristic name="Artefact Details" typeId="0918-c47a-d84e-c0cf">Pick one of the bearer&apos;s melee weapons. Add 1 to hit and wound rolls for attacks made with that weapon.</characteristic>
               </characteristics>


### PR DESCRIPTION
The warscroll card from the GW website (https://www.games-workshop.com/resources/PDF/Downloads//ENG_Guardian_of_Souls_Nighthaunt_2018.pdf) is in conflict with the warscroll published in the Nighthaunt Battletome.   There is no errata to clarify which value is correct.  Opting for the value published in the Nighthaunt Battletome.