### PR TITLE
Artefact limits for Greyfyrd lodge. #868.

### DIFF
--- a/Age of Sigmar.gst
+++ b/Age of Sigmar.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="e51d-b1a3-75fc-dc33" name="Age of Sigmar" revision="50" battleScribeVersion="2.02" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="e51d-b1a3-75fc-dc33" name="Age of Sigmar" revision="51" battleScribeVersion="2.02" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <publications>
     <publication id="e51d-b1a3-pubEC" name="The General&apos;s Handbook"/>
     <publication id="e51d-b1a3-pubEQ" name="Core Rules"/>
@@ -112,10 +112,15 @@
     <categoryEntry id="b745-17c4-8fbf-8b04" name="General" hidden="true"/>
     <categoryEntry id="3564-4c26-10b4-d953" name="Artefact" hidden="false">
       <modifiers>
-        <modifier type="increment" field="459e-bc05-f498-6753" value="1">
+        <modifier type="increment" field="459e-bc05-f498-6753" value="1.0">
           <repeats>
             <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="be17-6bbd-b857-3f43" repeats="1" roundUp="false"/>
           </repeats>
+        </modifier>
+        <modifier type="increment" field="459e-bc05-f498-6753" value="2.0">
+          <conditions>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f60b-d58c-bfee-5aa7" type="greaterThan"/>
+          </conditions>
         </modifier>
       </modifiers>
       <constraints>
@@ -210,6 +215,10 @@
     <categoryEntry id="cff6-06c5-3294-b74b" name="SHARDS OF VALAGHARR" hidden="false"/>
     <categoryEntry id="3b54-23ed-a577-ea1f" name="LAUCHON THE SOULSEEKER" hidden="false"/>
     <categoryEntry id="9945-bd78-56ea-5cde" name="HORRORGHAST" hidden="false"/>
+    <categoryEntry id="c34d-acb9-a4d9-74be" name="VOSTARG" hidden="false"/>
+    <categoryEntry id="f60b-d58c-bfee-5aa7" name="GREYFYRD" hidden="false"/>
+    <categoryEntry id="3559-43bd-385b-59a0" name="HERMDAR" hidden="false"/>
+    <categoryEntry id="a89a-9904-cf30-0d17" name="LOFNIR" hidden="false"/>
   </categoryEntries>
   <forceEntries>
     <forceEntry id="6ace-8bcc-48b2-6de7" name="*Old* *Pitched Battle (1,000)*" hidden="true">

--- a/Order - Fyreslayers.cat
+++ b/Order - Fyreslayers.cat
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="e67a-06d2-888c-b9be" name="Order - Fyreslayers" revision="23" battleScribeVersion="2.02" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="e67a-06d2-888c-b9be" name="Order - Fyreslayers" revision="25" battleScribeVersion="2.02" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="e67a-06d2-pubN65537" name="Order Battletome: Fyreslayers"/>
-    <publication id="e67a-06d2-pubN68071" name="Order Battletime - Fyreslayers"/>
     <publication id="e67a-06d2-pubN69594" name="Battletome: Fyreslayers Errata, July 2018"/>
+    <publication id="68d3-0b6a-3775-07d9" name="Battletome: Fyreslayers Official Errata, May 2019"/>
   </publications>
   <profileTypes>
     <profileType id="84c1-a205-4de9-2105" name="Ur-Gold Rune">
@@ -336,6 +336,9 @@
                           </characteristics>
                         </profile>
                       </profiles>
+                      <categoryLinks>
+                        <categoryLink id="d9e3-865e-55d6-a6a1" name="VOSTARG" hidden="false" targetId="c34d-acb9-a4d9-74be" primary="false"/>
+                      </categoryLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
                       </costs>
@@ -353,6 +356,9 @@
                           </characteristics>
                         </profile>
                       </profiles>
+                      <categoryLinks>
+                        <categoryLink id="1bbc-fbca-b259-bf41" name="GREYFYRD" hidden="false" targetId="f60b-d58c-bfee-5aa7" primary="false"/>
+                      </categoryLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
                       </costs>
@@ -370,6 +376,9 @@
                           </characteristics>
                         </profile>
                       </profiles>
+                      <categoryLinks>
+                        <categoryLink id="6d48-f9ab-acbf-827d" name="HERMDAR" hidden="false" targetId="3559-43bd-385b-59a0" primary="false"/>
+                      </categoryLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
                       </costs>
@@ -387,6 +396,9 @@
                           </characteristics>
                         </profile>
                       </profiles>
+                      <categoryLinks>
+                        <categoryLink id="03c1-32b2-b3d0-34a5" name="LOFNIR" hidden="false" targetId="a89a-9904-cf30-0d17" primary="false"/>
+                      </categoryLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
                       </costs>
@@ -417,7 +429,7 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1823-43dd-1af2-b910" name="Auric Hearthguard" publicationId="e67a-06d2-pubN68071" page="111" hidden="false" collective="false" type="unit">
+    <selectionEntry id="1823-43dd-1af2-b910" name="Auric Hearthguard" publicationId="e67a-06d2-pubN65537" page="111" hidden="false" collective="false" type="unit">
       <profiles>
         <profile id="afd0-613f-c3f8-31c9" name="Karl" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
@@ -527,7 +539,7 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="88ae-2998-b72a-3f1c" name="Auric Runefather" publicationId="e67a-06d2-pubN68071" page="103" hidden="false" collective="false" type="model">
+    <selectionEntry id="88ae-2998-b72a-3f1c" name="Auric Runefather" publicationId="e67a-06d2-pubN65537" page="103" hidden="false" collective="false" type="model">
       <profiles>
         <profile id="571a-43be-ec53-ea94" name="Auric Runefather" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
@@ -618,7 +630,7 @@
         <cost name="pts" typeId="points" value="100.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d62c-b254-872a-3500" name="Auric Runefather on Magmadroth" publicationId="e67a-06d2-pubN68071" page="98" hidden="false" collective="false" type="unit">
+    <selectionEntry id="d62c-b254-872a-3500" name="Auric Runefather on Magmadroth" publicationId="e67a-06d2-pubN65537" page="98" hidden="false" collective="false" type="unit">
       <profiles>
         <profile id="f0e8-e742-fac0-6b5c" name="Auric Runefather on Magmadroth" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
@@ -1927,9 +1939,9 @@
             <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">4+</characteristic>
           </characteristics>
         </profile>
-        <profile id="9b5f-391e-f6db-8691" name="Icon of Grimnir" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+        <profile id="9b5f-391e-f6db-8691" name="Icon of Grimnir" publicationId="68d3-0b6a-3775-07d9" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">In your hero phase, you can say that this model is raising its icon of Grimnir. If it does so, add 1 to save rolls for attacks that target friendly FYRESLAYERS units wholly within 12&quot; of this model until the start of your next hero phase. However, if you do so, until the start of your next hero phase, friendly FYRESLAYERS units wholly within 12&quot; of this model cannot retreat.</characteristic>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">In your hero phase, you can say that this model is raising its icon of Grimnir. If it does so, add 1 to save rolls for attacks that target friendly FYRESLAYERS units wholly within 12&quot; of this model until the start of your next hero phase. However, if you do so, until the start of your next hero phase, friendly FYRESLAYERS units wholly within 12&quot; of this model cannot retreat.  A unit cannot benefit from this ability more than once per phase.</characteristic>
           </characteristics>
         </profile>
         <profile id="bf60-2274-0653-395d" name="None Shall Defile the Icon" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
@@ -2604,9 +2616,9 @@
     </selectionEntry>
     <selectionEntry id="9a34-4e73-b5a5-7b71" name="Magmic Battleforge" hidden="false" collective="false" type="upgrade">
       <profiles>
-        <profile id="57e8-4665-a13a-acf7" name="Molten Blessing" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+        <profile id="57e8-4665-a13a-acf7" name="Molten Blessing" publicationId="68d3-0b6a-3775-07d9" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">At the start of your hero phase, 1 friendly FYRESLAYERS PRIEST within 6&quot; of a Magmic Battleforge can control its magmic energies. If they do so, until the end of that phase, add 1 to prayer rolls for friendly FYRESLAYERS PRIESTS while they are within 18&quot; of that Magmic Battleforge.</characteristic>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">At the start of your hero phase, 1 friendly FYRESLAYERS PRIEST within 6&quot; of a Magmic Battleforge can control its magmic energies. If they do so, until the end of that phase, add 1 to prayer rolls for friendly FYRESLAYERS PRIESTS while they are within 18&quot; of that Magmic Battleforge. You cannot use the Molten Blessing ability and the Spending the Forge ability for the same Magmic Battleforge in the same phase.</characteristic>
           </characteristics>
         </profile>
         <profile id="5ac9-7370-2224-5514" name="Spending the Forge" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
@@ -2721,21 +2733,8 @@
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="083e-a950-b54a-c2a4" name="Artefacts" hidden="false" collective="false">
-      <modifiers>
-        <modifier type="increment" field="07a7-40b8-7171-da08" value="1">
-          <repeats>
-            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="be17-6bbd-b857-3f43" repeats="1" roundUp="false"/>
-          </repeats>
-        </modifier>
-        <modifier type="increment" field="07a7-40b8-7171-da08" value="2">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="36c2-a62f-8269-3258" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="903c-54ee-5c65-eed8" type="max"/>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="07a7-40b8-7171-da08" type="max"/>
       </constraints>
       <entryLinks>
         <entryLink id="e347-7b6c-1a48-4160" name="FYRESLAYER Artefacts" hidden="false" collective="false" targetId="871a-59b8-6df1-b751" type="selectionEntryGroup">


### PR DESCRIPTION
Allow Fyreslayer roster using the Greyfyrd lodge to have 2 additional artefacts.