### PR TITLE
Rework endless spells to improve formatting in roster. #942

### DIFF
--- a/Age of Sigmar.gst
+++ b/Age of Sigmar.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="e51d-b1a3-75fc-dc33" name="Age of Sigmar" revision="51" battleScribeVersion="2.02" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="e51d-b1a3-75fc-dc33" name="Age of Sigmar" revision="52" battleScribeVersion="2.02" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <publications>
     <publication id="e51d-b1a3-pubEC" name="The General&apos;s Handbook"/>
     <publication id="e51d-b1a3-pubEQ" name="Core Rules"/>
@@ -8,7 +8,7 @@
     <publication id="e51d-b1a3-pubETJDK" name="Malign Sorcery; Official Errata, December 2018"/>
     <publication id="e51d-b1a3-pubEFCFK" name="Malign Sorcery; Errata, July 2018"/>
     <publication id="e51d-b1a3-pubEKHGM" name="Malign Sorcery"/>
-    <publication id="e51d-b1a3-pubEHOGM" name="Malign Socery"/>
+    <publication id="e51d-b1a3-pubEHOGM" name="Malign Sorcery"/>
   </publications>
   <costTypes>
     <costType id="points" name="pts" defaultCostLimit="0.0"/>
@@ -774,14 +774,99 @@
         <categoryLink id="baa5-3a0c-fa64-212c" name="New CategoryLink" hidden="false" targetId="1974-3f49-7f0b-8422" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="7aaa-04ab-d0c3-c7fe" name="Endless Spells" hidden="false" collective="false" targetId="7e27-867f-400c-b20b" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="e072-803f-6fb3-8c69" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
-      </categoryLinks>
-    </entryLink>
     <entryLink id="e116-d465-3e8e-864c" name="Realm of Battle" hidden="false" collective="false" targetId="35ce-f528-13ad-8cea" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5552-cffb-c874-4e24" name="Realm of Battle" hidden="false" targetId="5e28-c4f1-4a92-b75c" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="28b7-9a3f-0f7b-c498" name="Aethervoid Pendulum" hidden="false" collective="false" targetId="98c8-838b-2c8a-a9f7" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="8ff7-043d-6044-8c48" name="Malign Sorcery" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="1d24-610d-46d2-30bf" name="Balewind Vortex" hidden="false" collective="false" targetId="98b9-64b2-7123-b7a2" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="c58f-6e74-d605-fe50" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="4095-992e-ecb5-f3e7" name="Chronomatic Cogs" hidden="false" collective="false" targetId="4a8c-091f-84b5-47aa" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="344d-c0f8-1f3d-3bee" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="88a7-aafe-c6f9-f78e" name="Emerald Lifeswarm" hidden="false" collective="false" targetId="ec28-3ec9-f2fa-82e5" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="102e-6e47-67c3-a9c8" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="21eb-635c-39bd-dd60" name="Geminids of Uhl-Gyish" hidden="false" collective="false" targetId="1ce8-9373-9c22-75a0" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="819f-b709-0da8-07b1" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="ef51-fb2f-8837-98ba" name="Horrorghast" hidden="false" collective="false" targetId="befc-365b-06f8-5575" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="3b8c-457e-a256-6932" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="14ff-3872-185d-2b22" name="Lauchon the Soulseeker" hidden="false" collective="false" targetId="1f68-29ac-db98-ff85" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="1552-59f8-e65e-3ee7" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="be68-a6e5-ded1-4a7f" name="Malevolent Maelstrom" hidden="false" collective="false" targetId="37a1-b025-6723-3fe1" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="52cd-a0ad-f236-4f62" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="3583-afe9-8695-2acb" name="Prismatic Palisade" hidden="false" collective="false" targetId="7ae1-8e71-327d-0893" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="a552-c469-ecd4-90f5" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="b859-8f0e-848c-c403" name="Purple Sun of Shyish" hidden="false" collective="false" targetId="6e7b-ce3f-9348-58e1" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="dc0e-94d3-e4cc-cf13" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="5678-094b-9e38-abeb" name="Quicksilver Swords" hidden="false" collective="false" targetId="bc18-4df9-1a28-2df9" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="456b-cbcf-187e-e182" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="f231-d21f-2768-4263" name="Ravenak&apos;s Gnashing Jaws" hidden="false" collective="false" targetId="a99d-b987-6fa6-96f6" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="7990-96d6-3a1f-16bb" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="5bc9-f716-3ec8-3e62" name="Shards of Valagharr" hidden="false" collective="false" targetId="58a3-4afb-62c5-dd39" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="843c-0a6f-44be-762a" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="5f00-7f5a-9d87-a0d4" name="Soulscream Bridge" hidden="false" collective="false" targetId="98da-d52f-7608-3034" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="2a79-8f0d-4785-aa39" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="857f-aa6c-227e-b1f8" name="Soulsnare Shackles" hidden="false" collective="false" targetId="ec18-8377-8f6b-2591" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="56ee-27fa-24d6-b548" name="Malign Sorcery" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="432a-de1d-1d97-f4f2" name="Suffocating﻿﻿ Gravetide﻿" hidden="false" collective="false" targetId="d6de-646a-4dcc-e37d" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="8dca-2e27-a312-1002" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="3b5f-6153-8453-ecae" name="The B﻿urning Head﻿﻿﻿" hidden="false" collective="false" targetId="3ad9-857b-32ff-e44e" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="a795-b9f6-5518-72bc" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="5094-7652-a4bc-244c" name="Umbral Sp﻿ellporta﻿l﻿﻿" hidden="false" collective="false" targetId="d2dc-7e1a-c2e7-4cff" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="f865-805f-d0d2-56bb" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -865,17 +950,6 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7e27-867f-400c-b20b" name="Endless Spells" hidden="false" collective="false" type="upgrade">
-      <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8070-21a7-c79e-a493" type="max"/>
-      </constraints>
-      <entryLinks>
-        <entryLink id="cd0f-1b79-de92-e5ca" name="Endless Spells" hidden="false" collective="false" targetId="8ea1-6791-75d8-aba3" type="selectionEntryGroup"/>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="35ce-f528-13ad-8cea" name="Realm of Battle" hidden="false" collective="false" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="63d3-b671-c649-faf6" type="max"/>
@@ -885,6 +959,740 @@
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="98c8-838b-2c8a-a9f7" name="Endless Spell: Aethervoid Pendulum" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a657-de49-e2b9-d312" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="b2ad-28b6-8c19-2bd7" name="Summon Aethervoid Pendulum" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
+          <characteristics>
+            <characteristic name="Casting Value" typeId="2508-b604-1258-a920">6</characteristic>
+            <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, set up an Aethervoid Pendulum model wholly within 6&quot; of the caster so that it points lengthways in the direction you wish it to move.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="21f3-0955-0b5b-632a" name="Predatory" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">An Aethervoid Pendulum is a predatory endless spell. It can move up to 8&quot; and can fly. </characteristic>
+          </characteristics>
+        </profile>
+        <profile id="a0f5-049e-5f6b-92f7" name="Slicing Into Reality" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">When this model is set up, the player who set it up can immediately make a move with it.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="75ab-d1f9-8312-4930" name="Scything Blade" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">After this model has moved, each unit that has any models it passed across, and each other unit that is within 1&quot; of it at the end of its move, suffers D6 mortal wounds. </characteristic>
+          </characteristics>
+        </profile>
+        <profile id="2577-0a57-fc04-cbb1" name="Unstoppable Mechanism" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Whenever you set up an Aethervoid Pendulum, you must place it lengthways in the direction you wish it to move. Whenever it moves, move it in a straight line in that direction.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="bcfe-fca6-6bb7-9d98" name="Fly" hidden="false" targetId="8e0c-cbe4-27be-8a30" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="c336-90ff-ebdd-cdd6" name="New CategoryLink" hidden="false" targetId="31f4-2067-3ade-e6f8" primary="false"/>
+        <categoryLink id="bd9a-3f79-0b5f-7f8f" name="AETHERVOID PENDULUM" hidden="false" targetId="5647-b7a8-9716-1d17" primary="false"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="40.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="98b9-64b2-7123-b7a2" name="Endless Spell: Balewind Vortex" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8106-c203-2ed0-e575" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="6979-410e-f790-d43c" name="Summon Balewind Vortex" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
+          <characteristics>
+            <characteristic name="Casting Value" typeId="2508-b604-1258-a920">6</characteristic>
+            <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">WIZARDS with a Wounds characteristic of 9 or more, that are part of a unit of two or more models, or that are already on a Balewind Vortex, cannot attempt to cast this spell. If successfully cast, set up a Balewind Vortex model within 1&quot; of the caster and more than 3&quot; from any enemy models, and then place the caster on the upper platform.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="1ef7-6e77-e5be-458b" name="Against the Aetheric Wind" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Add 1 to save rolls for a WIZARD on a Balewind Vortex. </characteristic>
+          </characteristics>
+        </profile>
+        <profile id="4fa2-0a57-2616-95cb" name="Arcane Invigoration" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">A WIZARD on a Balewind Vortex can attempt to cast an additional spell in each of their hero phases (including the turn in which the Summon Balewind Vortex spell was cast), and you can add 6&quot; to the range of any spells that the WIZARD casts.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="c269-8e7f-d52f-96ab" name="Balewind Vortex" hidden="false">
+          <description>As long as the Balewind Vortex remains on the battlefield, the caster and the Balewind Vortex are treated as being a single model
+from the caster’s army that uses the caster’s warscroll as well as the endless spells rules. It is treated as an enemy model by the opposing player’s army. A WIZARD on a Balewind Vortex cannot move. 
+
+If a WIZARD on a Balewind Vortex attempts to dispel it, the attempt is automatically successful (do not roll any dice). This uses up the additional spell that the WIZARD would have received in that hero phase, and still counts as the single attempt they can make to dispel an endless spell this hero phase, but allows them to use any remaining spell casting attempts normally. 
+
+If the WIZARD on the Balewind Vortex is slain, then the Balewind Vortex is immediately dispelled and removed from play along with the slain WIZARD. 
+
+If a Balewind Vortex is dispelled and the WIZARD on it has not been slain, set up the WIZARD wholly within 6&quot; of the Balewind
+Vortex and more than 3&quot; from any enemy models, and then remove the Balewind Vortex model from play. If it is impossible
+to set up the WIZARD, then the WIZARD is slain.</description>
+        </rule>
+      </rules>
+      <categoryLinks>
+        <categoryLink id="e1e7-a6e3-fb42-c5fa" name="New CategoryLink" hidden="false" targetId="31f4-2067-3ade-e6f8" primary="false"/>
+        <categoryLink id="6fd4-dff6-47c4-10f8" name="BALEWIND VORTEX" hidden="false" targetId="0ac5-cc94-b7fe-7160" primary="false"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="40.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4a8c-091f-84b5-47aa" name="Endless Spell: Chronomatic Cogs" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="437a-85d6-7962-09c8" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="9590-acdc-1b4e-0963" name="Summon Chronomatic Cogs" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
+          <characteristics>
+            <characteristic name="Casting Value" typeId="2508-b604-1258-a920">7</characteristic>
+            <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, set up a Chronomantic Cogs model wholly within 12&quot; of the caster. </characteristic>
+          </characteristics>
+        </profile>
+        <profile id="4fe0-7a89-9044-9495" name="Mechanisms of Time" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">In their controlling player’s hero phase, a single Wizard within 9&quot; of this model may manipulate the cogs to increase or decrease the flow of time. They may do this in the same phase as the Chronomantic Cogs are set up. If they do so, choose one of the effects opposite. The effect lasts until their next hero phase, or until an enemy Wizard chooses to manipulate the cogs.  Speed Up Time: Add 2&quot; to the Move characteristic of all units on the battlefield. In addition, add 2 to charge rolls for all units on the battlefield.  Slow Down Time: The wizard manipulating the cogs can cast 1 additional spell in this hero phase. In addition, re-roll failed save rolls for that wizard.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink id="0d18-2233-939e-757f" name="New CategoryLink" hidden="false" targetId="31f4-2067-3ade-e6f8" primary="false"/>
+        <categoryLink id="6f75-84c2-00df-710e" name="AZYR" hidden="false" targetId="bed0-e4a0-f704-1eab" primary="false"/>
+        <categoryLink id="c22f-fc01-e217-f01d" name="CHRONOMANTIC COGS" hidden="false" targetId="1619-fea5-de7e-8a67" primary="false"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="60.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ec28-3ec9-f2fa-82e5" name="Endless Spell: Emerald Lifeswarm" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="41d8-6605-1f4e-1c94" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="e8c0-ded6-d453-a796" name="Summon Emerald Lifeswarm" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
+          <characteristics>
+            <characteristic name="Casting Value" typeId="2508-b604-1258-a920">6</characteristic>
+            <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, set up an Emerald Lifeswarm model wholly within 15&quot; of the caster. </characteristic>
+          </characteristics>
+        </profile>
+        <profile id="6183-1ed2-30a1-468a" name="Predatory" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">An Emerald Lifeswarm is a predatory endless spell. Emerald Lifeswarms can move up to 10&quot; and can fly.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="1ee9-f13f-669c-33d7" name="Bounteous Healing" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">After this model is set up or after it has moved, pick 1 unit within 1&quot; of it. You can either heal D3 wounds that have been allocated to that unit or, if no wounds are currently allocated to the unit, you may return a number of slain models to it that have a combined Wounds characteristic equal to or less than the roll of a D3. </characteristic>
+          </characteristics>
+        </profile>
+        <profile id="ffac-9035-e86e-fceb" name="Empowered by Ghyran" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If your battle is taking place in the Realm of Life, roll a D6 to determine the number of wounds healed or wounds worth of slain models returned by the Emerald Lifeswarm’s Bounteous Healing ability. </characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="b7b7-b4c4-2ba6-3533" name="Fly" hidden="false" targetId="8e0c-cbe4-27be-8a30" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="78da-51b4-4e2c-a0db" name="New CategoryLink" hidden="false" targetId="31f4-2067-3ade-e6f8" primary="false"/>
+        <categoryLink id="2101-d7be-8a1f-4b6c" name="EMERALD LIFESWORM" hidden="false" targetId="14d2-605b-536f-dd47" primary="false"/>
+        <categoryLink id="50fa-7469-e5cc-8169" name="GHYRAN" hidden="false" targetId="0b26-9340-45cf-07ee" primary="false"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="60.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1ce8-9373-9c22-75a0" name="Endless Spell: Geminids of Uhl-Gyish" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f50a-76ec-115a-6e1d" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="048c-412c-c308-90f9" name="Summon Geminids of Uhl-Gyish" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
+          <characteristics>
+            <characteristic name="Casting Value" typeId="2508-b604-1258-a920">7</characteristic>
+            <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, set up both models within 6&quot; of each other and both wholly within 18&quot; of the caster. You must then nominate one model to be the Light Geminid and the other to be the Shadow Geminid.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="8b3d-a71a-02e8-e999" name="Unleashed" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">When this model is set up, the player who set it up can immediately make a move with it. </characteristic>
+          </characteristics>
+        </profile>
+        <profile id="c00d-5d8c-b48a-92d0" name="Tendrils of Shadow and Light" publicationId="e51d-b1a3-pubEFCFK" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">After the Shadow Geminid model has moved, each unit that has any models it passed across suffers D3 mortal wounds. In addition, subtract 1 (to a minimum of 1) from the Attacks characteristic of melee weapons used by each unit that has any models it passed across until the end of the battle round. A unit is not affected by the Shadow Geminid model if it has been passed across by the Light Geminid model earlier in the same battle round. After the Light Geminid model has moved, each unit that has any models it passed across suffers D3 mortal wounds. In addition, subtract 1 from hit rolls for each unit that has any models it passed across until the end of the battle round. A unit is not affected by the Light Geminid model if it has been passed across by the Shadow Geminind model earlier in the same battle round (a unit can be affected by one or other of the models each battle round, but not both).</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="13d9-73c9-ffcc-5cfb" name="Empowered by Hysh" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If your battle is taking place in the Realm of Light, you can re-roll the dice to determine the number of mortal wounds suffered by a unit that has any models passed across by the Light Geminid.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="5842-43e3-814d-ff9f" name="Empowered by Ulgu" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If your battle is taking place in the Realm of Shadow, you can re-roll the dice to determine the number of mortal wounds suffered by a unit that has any models passed across by the Shadow Geminid.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="634a-99d6-067a-57e1" name="Predatory" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Geminids of Uhl-Gysh is a predatory endless spell. They can move up to 8&quot; and can fly. When you move this endless spell, the second model must finish its move within 6&quot; of the first. If this is impossible, this spell is dispelled. </characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="70c3-a871-2959-3f48" name="Fly" hidden="false" targetId="8e0c-cbe4-27be-8a30" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="4c38-6913-009e-bc41" name="New CategoryLink" hidden="false" targetId="31f4-2067-3ade-e6f8" primary="false"/>
+        <categoryLink id="6b24-fde1-af25-367b" name="GEMINIDS OF UHL-GYSH" hidden="false" targetId="722d-a8ac-da30-e6be" primary="false"/>
+        <categoryLink id="a697-9700-8b40-b082" name="HYSH" hidden="false" targetId="2b18-8032-739f-7929" primary="false"/>
+        <categoryLink id="6e8c-7f5e-3e2e-fc43" name="ULGU" hidden="false" targetId="3f66-cb68-8afb-ce99" primary="false"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="40.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="befc-365b-06f8-5575" name="Endless Spell: Horrorghast" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1106-8e19-e64d-9a0a" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="1fb0-73e9-129c-891c" name="Summon Horrorghast" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
+          <characteristics>
+            <characteristic name="Casting Value" typeId="2508-b604-1258-a920">6</characteristic>
+            <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, set up a Horrorghast model wholly within 12&quot; of the caster.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="ea2b-6e1d-a138-8396" name="Prey on Fear" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Subtract 1 from the Bravery characteristic of units while they are within 12&quot; of this model. Subtract 2 instead from the Bravery characteristic of units while they are within 6&quot; of this model.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="9346-aa17-cae4-7273" name="Empowered by Shyish" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If your battle is taking place in the Realm of Death, this model can move up to 12&quot; instead of up to 9&quot;.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e908-33ca-d3e1-dbcb" name="Predatory" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">A Horrorghast is a predatory endless spell. It can move up to 9&quot; and can fly. </characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="b6c5-3639-29e8-2d96" name="Fly" hidden="false" targetId="8e0c-cbe4-27be-8a30" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="e16b-e04d-41ad-aa44" name="ENDLESS SPELL" hidden="false" targetId="31f4-2067-3ade-e6f8" primary="false"/>
+        <categoryLink id="6f84-3b9b-a972-b2f5" name="HORRORGHAST" hidden="false" targetId="9945-bd78-56ea-5cde" primary="false"/>
+        <categoryLink id="66e7-40f4-73ab-dd04" name="SHYISH" hidden="false" targetId="2cc9-0867-b2e3-da55" primary="false"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="60.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1f68-29ac-db98-ff85" name="Endless Spell: Lauchon the Soulseeker" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b648-223d-ea42-50c8" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="801d-6be1-0510-970e" name="Summon Lauchon the Soulseeker" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
+          <characteristics>
+            <characteristic name="Casting Value" typeId="2508-b604-1258-a920">6</characteristic>
+            <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, set up a Lauchon the Soulseeker model wholly within 12&quot; of the caster.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="203f-cce0-0c04-21cc" name="Navigate Deathly Tides" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">When this model is set up, the player who set it up can immediately make a move with it.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="a466-232b-e51d-b504" name="Empowered by Shyish" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If your battle is taking place in the Realm of Death, this model can move up to 18&quot; instead of up to 12&quot;.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="227e-905e-a8a2-360c" name="Soul Price" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Before a player makes a move with this model, that player can pick a friendly unit wholly within 3&quot; of this model. Remove that unit and place it to one side. After this model has moved, set that unit up again wholly within 3&quot; of this model and more than 9&quot; from any enemy units. Once that unit has been set up, 1 model from that unit is immediately slain.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="bcbf-2a21-bf34-e39c" name="Predatory" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Lauchon the Soulseeker is a predatory endless spell. It can move up to 12&quot; and can fly. </characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="1ea1-53b4-1328-493e" name="Fly" hidden="false" targetId="8e0c-cbe4-27be-8a30" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="e2c8-ee2b-6a8a-3bfc" name="ENDLESS SPELL" hidden="false" targetId="31f4-2067-3ade-e6f8" primary="false"/>
+        <categoryLink id="6877-c245-4af4-c221" name="LAUCHON THE SOULSEEKER" hidden="false" targetId="3b54-23ed-a577-ea1f" primary="false"/>
+        <categoryLink id="5d52-d94b-a444-45b1" name="SHYISH" hidden="false" targetId="2cc9-0867-b2e3-da55" primary="false"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="60.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="37a1-b025-6723-3fe1" name="Endless Spell: Malevolent Maelstrom" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="84f5-216e-20fd-46e5" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="e2a0-be45-7c5a-1d9c" name="Summon Malevolent Maelstrom" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
+          <characteristics>
+            <characteristic name="Casting Value" typeId="2508-b604-1258-a920">7</characteristic>
+            <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, set up a Malevolent Maelstrom model wholly within 18&quot; of the caster.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="af8c-d343-e2c2-d9e6" name="Predatory" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">A Malevolent Maelstrom is a predatory endless spell. It can move up to 8&quot; and can fly.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="abb3-1c3a-812b-214c" name="Devourerer of Sorcery and Souls" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If a WIZARD successfully casts a spell within 12&quot; of a Malevolent Maelstrom, and that spell is not unbound, the Malevolent Maelstrom will attempt to steal the energies of the spell. Make an additional unbinding roll for that spell. If this unbinding roll is successful, the spell is unbound and 1 energy point is allocated to this model.  In addition, 1 energy point is allocated to this model for each unit destroyed within 6&quot; of this model. </characteristic>
+          </characteristics>
+        </profile>
+        <profile id="4eff-d80f-28d3-c7fb" name="Morbid Detonation" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">At the end of each battle round, roll a dice for each Malevolent Maelstrom and add the number of energy points allocated to that model to the roll. On a 7+ that Malevolent Maelstrom explodes. Each unit within 3D6&quot; of the model that exploded suffers D3 mortal wounds. The model that exploded is then dispelled.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="5226-8299-4978-2ab2" name="Empowered by Shyish" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If your battle is taking place in the Realm of Death, allocate 1 additional energy point to this model at the start of each battle round.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="be2f-86ff-e6bb-7cad" name="Fly" hidden="false" targetId="8e0c-cbe4-27be-8a30" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="8cfd-261e-8d93-fdf3" name="New CategoryLink" hidden="false" targetId="31f4-2067-3ade-e6f8" primary="false"/>
+        <categoryLink id="0d07-0be5-1093-dfe4" name="MALEVOLENT MAELSTROM" hidden="false" targetId="aeb3-e51f-7f02-619e" primary="false"/>
+        <categoryLink id="8e0f-7122-1605-3505" name="SHYISH" hidden="false" targetId="2cc9-0867-b2e3-da55" primary="false"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7ae1-8e71-327d-0893" name="Endless Spell: Prismatic Palisade" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="af02-c60b-9133-fa30" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="34d7-8e3b-b9ac-04ca" name="Summon Prismatic Palisade" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
+          <characteristics>
+            <characteristic name="Casting Value" typeId="2508-b604-1258-a920">5</characteristic>
+            <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, set up a Prismatic Palisade model wholly within 18&quot; of the caster.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="73bc-6abe-4c52-6d23" name="Blinding Light" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">At the start of each turn, roll a dice for each unit within 6&quot; of this model. On a 5+ subtract 1 from hit rolls for attacks made by that unit until the end of the turn.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="5bb4-5949-0d90-e76f" name="Dazzling Brilliance" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">A model cannot see another model if an imaginary straight line, 1mm wide, drawn from the centre of its base to the centre of the other model’s base passes over this model.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="2038-0249-055a-7b7c" name="Empowered by Hysh" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If your battle is taking place in the Realm of Light, add 1 to rolls made to determine if a unit is affected by this model’s Blinding Light ability.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink id="4b8d-dbd9-17eb-66ec" name="New CategoryLink" hidden="false" targetId="31f4-2067-3ade-e6f8" primary="false"/>
+        <categoryLink id="39d0-a731-4fe8-84b8" name="HYSH" hidden="false" targetId="2b18-8032-739f-7929" primary="false"/>
+        <categoryLink id="9d46-498d-22f1-9b94" name="PRISMATIC PALISADE" hidden="false" targetId="316f-32e5-0c7c-72af" primary="false"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="30.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6e7b-ce3f-9348-58e1" name="Endless Spell: Purple Sun of Shyish" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="607a-4963-04ba-d79f" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="8677-969c-7c16-007d" name="Summon Purple Sun of Shyish" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
+          <characteristics>
+            <characteristic name="Casting Value" typeId="2508-b604-1258-a920">8</characteristic>
+            <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, set up a Purple Sun of Shyish model wholly within 6&quot; of the caster.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="9a94-5efa-6797-25e6" name="Predatory" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">The Purple Sun of Shyish is a predatory endless spell. It can move up to 9&quot; and can fly. </characteristic>
+          </characteristics>
+        </profile>
+        <profile id="376e-119b-d822-4395" name="Swirling Death" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">When this model is set up, the player who set it up can immediately make a move with it.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="2e18-4510-9f25-b7cb" name="End Given Form" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">After this model has moved, each unit that has any models it passed across, and each other unit that is within 1&quot; of it at the end of its move, is subjected to the Purple Sun’s baleful energies. For each unit subjected to the baleful energies, roll a number of dice equal to the number of models in that unit. For each 6+ one model in that unit is slain. If the unit has Wounds characteristic of 6 or more, it suffers 2D6 mortal wounds instead.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="ea13-5990-3792-14cb" name="Visage of Xereus" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Subtract 1 from the Bravery characteristic of all units while they are within 6&quot; of this model.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="eb5c-ce49-e22f-6df3" name="Empowered by Shyish" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If your battle is taking place in the Realm of Death, this model can move 12&quot; instead of 9&quot;. </characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="c5b4-0486-5a71-dcd8" name="Fly" hidden="false" targetId="8e0c-cbe4-27be-8a30" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="b230-aaa9-f19e-b2ce" name="New CategoryLink" hidden="false" targetId="31f4-2067-3ade-e6f8" primary="false"/>
+        <categoryLink id="9f4f-9cb2-6618-21f4" name="PURPLE SUN OF SHYISH" hidden="false" targetId="7eb6-e91d-bf00-1c84" primary="false"/>
+        <categoryLink id="3a3c-213b-2d2d-10f2" name="SHYISH" hidden="false" targetId="2cc9-0867-b2e3-da55" primary="false"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="100.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bc18-4df9-1a28-2df9" name="Endless Spell: Quicksilver Swords" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4e19-66ea-d689-4ae3" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="b191-e4f0-c10b-2543" name="Summon Quicksilver Swords" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
+          <characteristics>
+            <characteristic name="Casting Value" typeId="2508-b604-1258-a920">6</characteristic>
+            <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, set up a Quicksilver Swords model wholly within 10&quot; of the caster.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="035d-bc7f-cc14-3cc0" name="Predatory" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Quicksilver Swords is a predatory endless spell. It can move up to 8&quot; and can fly.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="0f8f-9119-6422-7799" name="Volley of Blades" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">When this model is set up, the player who set it up can immediately make a move with it.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="c023-e731-5488-7bf0" name="Dancing Blades" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">After this model has moved, you can pick 1 unit within 6&quot; of it and roll 12 dice. For each roll of 6+ that unit suffers 1 mortal wound. If the unit being rolled for is a CHAOS unit, it suffers 1 mortal wound for each roll of 5+ instead.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="ead7-9952-e01f-b3b3" name="Empowered by Chamon" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If your battle is taking place in the Realm of Metal, you can roll 15 dice for this model’s Dancing Blades ability instead of 12.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="acd4-e86a-ad0a-7bcb" name="Fly" hidden="false" targetId="8e0c-cbe4-27be-8a30" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="d12a-56b2-d233-8d17" name="New CategoryLink" hidden="false" targetId="31f4-2067-3ade-e6f8" primary="false"/>
+        <categoryLink id="8724-127d-eb92-f9d0" name="CHAMON" hidden="false" targetId="97c8-2ca9-2b12-327f" primary="false"/>
+        <categoryLink id="29f1-5754-fb05-5361" name="QUICKSILVER SWORDS" hidden="false" targetId="65dc-260f-90f3-8a5a" primary="false"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a99d-b987-6fa6-96f6" name="Endless Spell: Ravenak&apos;s Gnashing Jaws" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="88dc-7fbb-a0af-313d" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="8123-c8c4-8bc6-cf0f" name="Summon Ravenak&apos;s Gnashing Jaws" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
+          <characteristics>
+            <characteristic name="Casting Value" typeId="2508-b604-1258-a920">8</characteristic>
+            <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, set up a Ravenak’s Gnashing Jaws model wholly within 6&quot; of the caster.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="0222-5edd-ad18-48a4" name="Predatory" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Ravenak’s Gnashing Jaws is a predatory endless spell. It can move up to 12&quot; and can fly.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="983f-75f4-4a12-f26b" name="Endless Appetite" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">When this model is set up, the player who set it up can immediately make a move with it. </characteristic>
+          </characteristics>
+        </profile>
+        <profile id="2237-adf9-c281-2916" name="Ravening Hunger" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">After this model has moved, each unit that has any models it passed across, and each other unit that is within 1&quot; of it at the end of its move, suffers D3 mortal wounds. In addition, subtract 1 from the Bravery characteristic of each unit that each unit that has any models it passed across until the end of the battle round.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d633-25a6-2f08-6116" name="Empowered by Ghur" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If your battle is taking place in the Realm of Beasts, this model can move up to D6+12&quot; instead of 12&quot;.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="c529-22c8-4413-2bea" name="Fly" hidden="false" targetId="8e0c-cbe4-27be-8a30" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="8e10-5498-a55f-0a68" name="New CategoryLink" hidden="false" targetId="31f4-2067-3ade-e6f8" primary="false"/>
+        <categoryLink id="abfa-4fae-5cbd-f9fc" name="GHUR" hidden="false" targetId="c33b-1c2d-83d9-53df" primary="false"/>
+        <categoryLink id="8064-0362-4e5d-1ed0" name="RAVENAK&apos;S GNASHING JAWS" hidden="false" targetId="8b8e-c0b7-d668-19f2" primary="false"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="40.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="58a3-4afb-62c5-dd39" name="Endless Spell: Shards of Valagharr" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0021-b32d-ca2b-f4f9" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="6b93-3b5f-92bd-87df" name="Summon Shards of Valagharr" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
+          <characteristics>
+            <characteristic name="Casting Value" typeId="2508-b604-1258-a920">5</characteristic>
+            <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, set up the first Shards of Valagharr model wholly within 6&quot; of the caster, and then set up the second Shards of Valagharr model wholly within 12&quot; of the first.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="01e5-7b2f-ac0e-5ec3" name="Ensnaring Soul-drain" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">At the start of the movement phase, draw an imaginary straight line 1mm wide between the closest parts of the bases of the two Shards of Valagharr models from this endless spell. Each unit passed across by this line is ensnared until the end of that turn. Halve the Move characteristic of a unit that is ensnared. In addition, subtract 1 from hit rolls for attacks made by units that are ensnared.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="77e0-b51d-00d4-aa72" name="Twilight Translocation" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">At the start of the battle round, after determining who has the first turn, the players must roll off. The winner can remove one Shards of Valagharr model from this endless spell from the battlefield and set it up again anywhere on the battlefield wholly within 12&quot; of the other Shards of Valagharr model from this endless spell.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="fac8-201d-3681-0dac" name="Empowered by Shyish" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If your battle is taking place in the Realm of Death, the first Shards of Valagharr model can be set up wholly within 12&quot; of the caster, instead of 6&quot;.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink id="057a-08ae-cbb8-08b7" name="ENDLESS SPELL" hidden="false" targetId="31f4-2067-3ade-e6f8" primary="false"/>
+        <categoryLink id="1a41-5fe0-2b91-319a" name="SHYISH" hidden="false" targetId="2cc9-0867-b2e3-da55" primary="false"/>
+        <categoryLink id="430e-40d4-1072-bd3a" name="SHARDS OF VALAGHARR" hidden="false" targetId="cff6-06c5-3294-b74b" primary="false"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="40.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="98da-d52f-7608-3034" name="Endless Spell: Soulscream Bridge" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bb75-934b-daee-022e" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="8bc3-efdf-b033-2e24" name="Summon Soulscream Bridge" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
+          <characteristics>
+            <characteristic name="Casting Value" typeId="2508-b604-1258-a920">6</characteristic>
+            <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, set up the first Soulscream Bridge model wholly within 6&quot; of the caster, and then set up the second Soulscream Bridge model wholly within 12&quot; of the first.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="3cd2-74a2-532b-25a5" name="Deathly Passage" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">At the start of your movement phase, friendly units wholly within 6&quot; of one Soulscream Bridge model from this endless spell can travel across the Soulscream Bridge. If they do so, remove that unit from the battlefield and set it up again wholly within 6&quot; of the other Soulscream Bridge model from this endless spell, more than 9&quot; from any enemy units. That unit cannot make a normal move that phase. </characteristic>
+          </characteristics>
+        </profile>
+        <profile id="eb78-8010-9568-2703" name="Nightmarish Construct" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Subtract 1 from the Bravery characteristic of enemy units while they are within 6&quot; of a Soulscream Bridge model. This ability has no effect on DEATH units.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="01c1-54ee-b341-4681" name="Empowered by Shyish" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If your battle is taking place in the Realm of Death, the second Soulscream Bridge model can be set up wholly within 24&quot; of the first, instead of within 12&quot; of the first.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink id="4201-3b80-3b82-7bc5" name="ENDLESS SPELL" hidden="false" targetId="31f4-2067-3ade-e6f8" primary="false"/>
+        <categoryLink id="173d-484d-26a5-168a" name="SOULSCREAM BRIDGE" hidden="false" targetId="1d34-b962-7c7b-f287" primary="false"/>
+        <categoryLink id="c390-75ad-8a01-32d9" name="SHYISH" hidden="false" targetId="2cc9-0867-b2e3-da55" primary="false"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="80.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ec18-8377-8f6b-2591" name="Endless Spell: Soulsnare Shackles" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6a82-fc9b-c487-a064" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="f12d-a1e0-5270-2892" name="Summon Soulsnare Shackles" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
+          <characteristics>
+            <characteristic name="Casting Value" typeId="2508-b604-1258-a920">5</characteristic>
+            <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, set up a Soulsnare Shackles model wholly within 12&quot; of the caster, then set up the second and third Soulsnare Shackles models wholly within 6&quot; of the first.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="0df7-ad58-26dc-d044" name="Bound for the Great Oubliette" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">At the start of the movement phase, roll a dice for each unit within 6&quot; of any Soulsnare Shackles models. On a 3+ halve the move characteristic of that unit until the end of that phase. On a 6 that unit also suffers D3 mortal wounds. </characteristic>
+          </characteristics>
+        </profile>
+        <profile id="33a8-200f-b7a1-472b" name="Empowered by Shyish" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If your battle is taking place in the Realm of Death, the second and third Soulsnare Shackles models can be set up wholly within 9&quot; of the first, instead of 6&quot;.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink id="5096-dc8d-80b5-d6bf" name="New CategoryLink" hidden="false" targetId="31f4-2067-3ade-e6f8" primary="false"/>
+        <categoryLink id="e50d-523f-1fd1-b8f5" name="SHYISH" hidden="false" targetId="2cc9-0867-b2e3-da55" primary="false"/>
+        <categoryLink id="b32d-20d2-77e4-2013" name="SOULSNARE SHACKLES" hidden="false" targetId="4949-2041-939a-baa6" primary="false"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d6de-646a-4dcc-e37d" name="Endless Spell: Suffocating﻿﻿ Gravetide﻿" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0d42-657b-97ab-f23f" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="09f9-9e4f-449d-b8f2" name="Summon Suffocating﻿﻿ Gravetide﻿" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
+          <characteristics>
+            <characteristic name="Casting Value" typeId="2508-b604-1258-a920">6</characteristic>
+            <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, set up a Suffocating Gravetide model wholly within 4&quot; of the caster. </characteristic>
+          </characteristics>
+        </profile>
+        <profile id="2bc2-6e1b-9c63-97c5" name="Necrotic Tide" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">When this model is set up, the player who set it up can immediately make a move with it. </characteristic>
+          </characteristics>
+        </profile>
+        <profile id="9421-3b1a-c93b-4ecc" name="Pulled to the Grave" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">After this model has moved, each unit that has any models it passed across suffers D3 mortal wounds. In addition, subtract 1 from the Bravery characteristic of each unit that has any models it passed across until the end of the battle round.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="5c60-1bf5-7aab-1539" name="Rolling Barricade" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">When a missile weapon targets a unit that has all of its models within 1&quot; of this model, the target unit receives the benefit of cover if the attacking unit is closer to this model than it is to the target unit. </characteristic>
+          </characteristics>
+        </profile>
+        <profile id="4846-a1b3-6a09-82f7" name="Empowered by Shyish" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If your battle is taking place in the Realm of Death, this model can move up to 12&quot; instead of 8&quot;.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="3a60-d81a-79c4-dee0" name="Predatory" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">A Suffocating Gravetide is a predatory endless spell. It can move up to 8&quot; and can fly. </characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="c070-aff0-0add-0d50" name="Fly" hidden="false" targetId="8e0c-cbe4-27be-8a30" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="27d3-7de8-58e3-bea7" name="New CategoryLink" hidden="false" targetId="31f4-2067-3ade-e6f8" primary="false"/>
+        <categoryLink id="a275-1818-5888-8a79" name="SHYISH" hidden="false" targetId="2cc9-0867-b2e3-da55" primary="false"/>
+        <categoryLink id="7c7b-031f-df94-fe46" name="SUFFOCATING GRAVETIDE" hidden="false" targetId="8e84-834f-0c7d-0d45" primary="false"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="30.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3ad9-857b-32ff-e44e" name="Endless Spell: The B﻿urning Head﻿﻿﻿" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="99ee-e3e1-6970-f451" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="d37a-5a1b-11ad-fb89" name="Summon B﻿urning Head﻿﻿﻿" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
+          <characteristics>
+            <characteristic name="Casting Value" typeId="2508-b604-1258-a920">7</characteristic>
+            <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, set up a Burning Head model wholly within 3&quot; of the caster.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="c2a1-0a2c-f5ce-467b" name="Predatory" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">The Burning Head is a predatory endless spell. It can move up to 9&quot; and can fly.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7de4-5c93-a18e-9d5f" name="Fiery Missile" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">When this model is set up, the player who set it up can immediately make a move with it. </characteristic>
+          </characteristics>
+        </profile>
+        <profile id="c7f4-81b1-042a-8e6e" name="Flaming Skull" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">After this model has moved, each unit that has any models it passed across, and each other unit that is within 1&quot; of it at the end of its move, suffers D3 mortal wounds. </characteristic>
+          </characteristics>
+        </profile>
+        <profile id="637c-9ac5-610d-9f17" name="Wrathful Aura" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Re-roll hit rolls of 1 for attacks made by units while they are wholly within 9&quot; of this model. </characteristic>
+          </characteristics>
+        </profile>
+        <profile id="6171-ca22-0e67-91db" name="Empowered by Aqshy" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If your battle is taking place in the Realm of Fire, add 1 to the number of mortal wounds inflicted by the Flaming Skull ability.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="0fd6-1afc-c9db-70f3" name="Fly" hidden="false" targetId="8e0c-cbe4-27be-8a30" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="45c3-0350-c231-e9b8" name="New CategoryLink" hidden="false" targetId="31f4-2067-3ade-e6f8" primary="false"/>
+        <categoryLink id="93e5-b28e-ad25-98e9" name="AQSHY" hidden="false" targetId="f760-2ebe-1af7-ff48" primary="false"/>
+        <categoryLink id="ec33-7fb2-331b-c7cb" name="THE BURNING HEAD" hidden="false" targetId="3115-9f9c-85db-1d63" primary="false"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="40.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d2dc-7e1a-c2e7-4cff" name="Endless Spell: Umbral Sp﻿ellporta﻿l﻿﻿" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="339b-832b-1f41-84f3" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="c3e6-0504-1147-d44a" name="Summon Umbral Sp﻿ellporta﻿l﻿﻿" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
+          <characteristics>
+            <characteristic name="Casting Value" typeId="2508-b604-1258-a920">5</characteristic>
+            <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, set up the first Umbral Spellportal model wholly within 12&quot; of the caster, and then set up the second Umbral Spellportal model wholly within 18&quot; of the first.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="0a1a-1532-0887-c5d7" name="Arcane Passage" publicationId="e51d-b1a3-pubEFCFK" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If a Wizard successfully casts a spell while they are within 1&quot; of an Umbral Spellportal model, the range and visibility of the spell can be measured from the other Umbral Spellportal model from this endless spell. After the range and visibility for a spell has been measured from an Umbral Spellportal, you cannot use the Arcane Passage ability again for that Umbral Spellportal in that phase. If a predatory endless spell finishes a move within 6&quot; of an Umbral Spellportal model, remove it from the battlefield and set it up again anywhere within 6&quot; of the other Umbral Spellportal model from this endless spell. After an endless spell finishes a move within 6&quot; of an Umbral Spellportal and is set up again, it cannot move again in that phase, and you cannot use the Arcane Passage ability again for that Umbral Spellportal in that phase.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="f61c-06bd-bd2e-6ce5" name="Empowered by Ulgu" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If your battle is taking place in the Realm of Shadow, the second Umbral Spellportal model can be set up anywhere on the battlefield, instead of within 18&quot; of the first.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink id="9713-d6b1-54c8-4ee4" name="New CategoryLink" hidden="false" targetId="31f4-2067-3ade-e6f8" primary="false"/>
+        <categoryLink id="2e53-4dfd-098a-3465" name="ULGU" hidden="false" targetId="3f66-cb68-8afb-ce99" primary="false"/>
+        <categoryLink id="5724-bd35-df7f-13c8" name="UMBRAL SPELLPORTAL" hidden="false" targetId="82b0-19da-b868-9f6c" primary="false"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="60.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -3618,747 +4426,6 @@
         <selectionEntry id="ca54-0d07-72c2-d26f" name="No Points or Battlerole Validation (Open)" hidden="false" collective="false" type="upgrade">
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-    </selectionEntryGroup>
-    <selectionEntryGroup id="8ea1-6791-75d8-aba3" name="Endless Spells" hidden="false" collective="false">
-      <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a642-3e9b-21a9-ec96" type="min"/>
-      </constraints>
-      <selectionEntries>
-        <selectionEntry id="982a-a39f-ef3f-4720" name="Balewind Vortex" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef45-b059-9863-72c3" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="4a04-ce81-a394-26d2" name="Summon Balewind Vortex" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
-              <characteristics>
-                <characteristic name="Casting Value" typeId="2508-b604-1258-a920">6</characteristic>
-                <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">WIZARDS with a Wounds characteristic of 9 or more, that are part of a unit of two or more models, or that are already on a Balewind Vortex, cannot attempt to cast this spell. If successfully cast, set up a Balewind Vortex model within 1&quot; of the caster and more than 3&quot; from any enemy models, and then place the caster on the upper platform.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="cb85-22fc-4c5c-25df" name="Against the Aetheric Wind" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Add 1 to save rolls for a WIZARD on a Balewind Vortex. </characteristic>
-              </characteristics>
-            </profile>
-            <profile id="9b47-3d3c-feee-7332" name="Arcane Invigoration" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">A WIZARD on a Balewind Vortex can attempt to cast an additional spell in each of their hero phases (including the turn in which the Summon Balewind Vortex spell was cast), and you can add 6&quot; to the range of any spells that the WIZARD casts.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules>
-            <rule id="029c-ba9f-e0c9-5988" name="Balewind Vortex" hidden="false">
-              <description>As long as the Balewind Vortex remains on the battlefield, the caster and the Balewind Vortex are treated as being a single model
-from the caster’s army that uses the caster’s warscroll as well as the endless spells rules. It is treated as an enemy model by the opposing player’s army. A WIZARD on a Balewind Vortex cannot move. 
-
-If a WIZARD on a Balewind Vortex attempts to dispel it, the attempt is automatically successful (do not roll any dice). This uses up the additional spell that the WIZARD would have received in that hero phase, and still counts as the single attempt they can make to dispel an endless spell this hero phase, but allows them to use any remaining spell casting attempts normally. 
-
-If the WIZARD on the Balewind Vortex is slain, then the Balewind Vortex is immediately dispelled and removed from play along with the slain WIZARD. 
-
-If a Balewind Vortex is dispelled and the WIZARD on it has not been slain, set up the WIZARD wholly within 6&quot; of the Balewind
-Vortex and more than 3&quot; from any enemy models, and then remove the Balewind Vortex model from play. If it is impossible
-to set up the WIZARD, then the WIZARD is slain.</description>
-            </rule>
-          </rules>
-          <categoryLinks>
-            <categoryLink id="e035-7e9d-b2fe-88c8" name="New CategoryLink" hidden="false" targetId="31f4-2067-3ade-e6f8" primary="false"/>
-            <categoryLink id="dfa8-9a75-84a0-b762" name="BALEWIND VORTEX" hidden="false" targetId="0ac5-cc94-b7fe-7160" primary="false"/>
-          </categoryLinks>
-          <costs>
-            <cost name="pts" typeId="points" value="40.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="a09c-d5d6-81b7-5786" name="Aethervoid Pendulum" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c56d-2b1e-13df-e2c4" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="e0e5-efed-e187-864b" name="Summon Aethervoid Pendulum" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
-              <characteristics>
-                <characteristic name="Casting Value" typeId="2508-b604-1258-a920">6</characteristic>
-                <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, set up an Aethervoid Pendulum model wholly within 6&quot; of the caster so that it points lengthways in the direction you wish it to move.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="0153-e77d-010e-2cbb" name="Predatory" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">An Aethervoid Pendulum is a predatory endless spell. It can move up to 8&quot; and can fly. </characteristic>
-              </characteristics>
-            </profile>
-            <profile id="4040-1250-26f7-bc80" name="Slicing Into Reality" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">When this model is set up, the player who set it up can immediately make a move with it.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="18f9-0fe9-0f67-6035" name="Scything Blade" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">After this model has moved, each unit that has any models it passed across, and each other unit that is within 1&quot; of it at the end of its move, suffers D6 mortal wounds. </characteristic>
-              </characteristics>
-            </profile>
-            <profile id="e980-657b-8217-c235" name="Unstoppable Mechanism" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Whenever you set up an Aethervoid Pendulum, you must place it lengthways in the direction you wish it to move. Whenever it moves, move it in a straight line in that direction.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <infoLinks>
-            <infoLink id="231c-cd93-5dc5-c424" name="Fly" hidden="false" targetId="8e0c-cbe4-27be-8a30" type="profile"/>
-          </infoLinks>
-          <categoryLinks>
-            <categoryLink id="5fd3-8482-c9c6-16d1" name="New CategoryLink" hidden="false" targetId="31f4-2067-3ade-e6f8" primary="false"/>
-            <categoryLink id="9174-0ecd-a99d-872a" name="AETHERVOID PENDULUM" hidden="false" targetId="5647-b7a8-9716-1d17" primary="false"/>
-          </categoryLinks>
-          <costs>
-            <cost name="pts" typeId="points" value="40.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="88d8-6a1f-8483-b6ea" name="Chronomatic Cogs" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ee5-eb5e-b0dd-56c6" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="d450-442d-f4bc-596c" name="Summon Chronomatic Cogs" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
-              <characteristics>
-                <characteristic name="Casting Value" typeId="2508-b604-1258-a920">7</characteristic>
-                <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, set up a Chronomantic Cogs model wholly within 12&quot; of the caster. </characteristic>
-              </characteristics>
-            </profile>
-            <profile id="9575-69c3-78c5-9937" name="Mechanisms of Time" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">In their controlling player’s hero phase, a single Wizard within 9&quot; of this model may manipulate the cogs to increase or decrease the flow of time. They may do this in the same phase as the Chronomantic Cogs are set up. If they do so, choose one of the effects opposite. The effect lasts until their next hero phase, or until an enemy Wizard chooses to manipulate the cogs.  Speed Up Time: Add 2&quot; to the Move characteristic of all units on the battlefield. In addition, add 2 to charge rolls for all units on the battlefield.  Slow Down Time: The wizard manipulating the cogs can cast 1 additional spell in this hero phase. In addition, re-roll failed save rolls for that wizard.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <categoryLinks>
-            <categoryLink id="f35f-fab0-729b-5bb9" name="New CategoryLink" hidden="false" targetId="31f4-2067-3ade-e6f8" primary="false"/>
-            <categoryLink id="02d1-a9c7-4396-b90d" name="AZYR" hidden="false" targetId="bed0-e4a0-f704-1eab" primary="false"/>
-            <categoryLink id="9cc5-6780-8953-61aa" name="CHRONOMANTIC COGS" hidden="false" targetId="1619-fea5-de7e-8a67" primary="false"/>
-          </categoryLinks>
-          <costs>
-            <cost name="pts" typeId="points" value="60.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="7c3d-e67e-928b-10cc" name="Emerald Lifeswarm" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09f5-f937-401d-ee13" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="1820-904c-ab47-f3ad" name="Summon Emerald Lifeswarm" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
-              <characteristics>
-                <characteristic name="Casting Value" typeId="2508-b604-1258-a920">6</characteristic>
-                <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, set up an Emerald Lifeswarm model wholly within 15&quot; of the caster. </characteristic>
-              </characteristics>
-            </profile>
-            <profile id="9a33-3b30-d7da-472d" name="Predatory" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">An Emerald Lifeswarm is a predatory endless spell. Emerald Lifeswarms can move up to 10&quot; and can fly.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="9148-f96b-19db-e885" name="Bounteous Healing" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">After this model is set up or after it has moved, pick 1 unit within 1&quot; of it. You can either heal D3 wounds that have been allocated to that unit or, if no wounds are currently allocated to the unit, you may return a number of slain models to it that have a combined Wounds characteristic equal to or less than the roll of a D3. </characteristic>
-              </characteristics>
-            </profile>
-            <profile id="c1fe-5b0f-4b16-5dfc" name="Empowered by Ghyran" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If your battle is taking place in the Realm of Life, roll a D6 to determine the number of wounds healed or wounds worth of slain models returned by the Emerald Lifeswarm’s Bounteous Healing ability. </characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <infoLinks>
-            <infoLink id="2b18-2f4f-a24f-e828" name="Fly" hidden="false" targetId="8e0c-cbe4-27be-8a30" type="profile"/>
-          </infoLinks>
-          <categoryLinks>
-            <categoryLink id="c9e7-8860-645a-2ac0" name="New CategoryLink" hidden="false" targetId="31f4-2067-3ade-e6f8" primary="false"/>
-            <categoryLink id="f2db-2be5-ace8-d6ce" name="EMERALD LIFESWORM" hidden="false" targetId="14d2-605b-536f-dd47" primary="false"/>
-            <categoryLink id="16e1-e0d9-3073-3a8a" name="GHYRAN" hidden="false" targetId="0b26-9340-45cf-07ee" primary="false"/>
-          </categoryLinks>
-          <costs>
-            <cost name="pts" typeId="points" value="60.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="ffa3-5211-7c11-afc6" name="Geminids of Uhl-Gyish" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a707-d029-6cfd-17c7" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="5620-ddd2-449f-e2d2" name="Summon Geminids of Uhl-Gyish" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
-              <characteristics>
-                <characteristic name="Casting Value" typeId="2508-b604-1258-a920">7</characteristic>
-                <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, set up both models within 6&quot; of each other and both wholly within 18&quot; of the caster. You must then nominate one model to be the Light Geminid and the other to be the Shadow Geminid.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="6fea-3e30-c272-a3cb" name="Unleashed" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">When this model is set up, the player who set it up can immediately make a move with it. </characteristic>
-              </characteristics>
-            </profile>
-            <profile id="72c5-5472-f2f9-2532" name="Tendrils of Shadow and Light" publicationId="e51d-b1a3-pubEFCFK" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">After the Shadow Geminid model has moved, each unit that has any models it passed across suffers D3 mortal wounds. In addition, subtract 1 (to a minimum of 1) from the Attacks characteristic of melee weapons used by each unit that has any models it passed across until the end of the battle round. A unit is not affected by the Shadow Geminid model if it has been passed across by the Light Geminid model earlier in the same battle round. After the Light Geminid model has moved, each unit that has any models it passed across suffers D3 mortal wounds. In addition, subtract 1 from hit rolls for each unit that has any models it passed across until the end of the battle round. A unit is not affected by the Light Geminid model if it has been passed across by the Shadow Geminind model earlier in the same battle round (a unit can be affected by one or other of the models each battle round, but not both).</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="3429-c00a-619d-471f" name="Empowered by Hysh" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If your battle is taking place in the Realm of Light, you can re-roll the dice to determine the number of mortal wounds suffered by a unit that has any models passed across by the Light Geminid.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="3fe3-19d5-e61c-f13e" name="Empowered by Ulgu" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If your battle is taking place in the Realm of Shadow, you can re-roll the dice to determine the number of mortal wounds suffered by a unit that has any models passed across by the Shadow Geminid.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="4aa0-8031-eff6-7a9c" name="Predatory" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Geminids of Uhl-Gysh is a predatory endless spell. They can move up to 8&quot; and can fly. When you move this endless spell, the second model must finish its move within 6&quot; of the first. If this is impossible, this spell is dispelled. </characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <infoLinks>
-            <infoLink id="6b47-2286-38ec-5a46" name="Fly" hidden="false" targetId="8e0c-cbe4-27be-8a30" type="profile"/>
-          </infoLinks>
-          <categoryLinks>
-            <categoryLink id="9d3d-a6fa-2ff9-a847" name="New CategoryLink" hidden="false" targetId="31f4-2067-3ade-e6f8" primary="false"/>
-            <categoryLink id="17a0-61e7-608e-a4df" name="GEMINIDS OF UHL-GYSH" hidden="false" targetId="722d-a8ac-da30-e6be" primary="false"/>
-            <categoryLink id="c74d-c99b-8514-b4bc" name="HYSH" hidden="false" targetId="2b18-8032-739f-7929" primary="false"/>
-            <categoryLink id="cb77-2ff1-f6d2-fdeb" name="ULGU" hidden="false" targetId="3f66-cb68-8afb-ce99" primary="false"/>
-          </categoryLinks>
-          <costs>
-            <cost name="pts" typeId="points" value="40.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="90d3-f76c-d63e-7eeb" name="Malevolent Maelstrom" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a941-10ef-6a07-91ac" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="e591-6106-2a1d-a035" name="Summon Malevolent Maelstrom" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
-              <characteristics>
-                <characteristic name="Casting Value" typeId="2508-b604-1258-a920">7</characteristic>
-                <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, set up a Malevolent Maelstrom model wholly within 18&quot; of the caster.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="e720-d684-8fb2-f535" name="Predatory" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">A Malevolent Maelstrom is a predatory endless spell. It can move up to 8&quot; and can fly.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="0803-0c8b-e322-1d22" name="Devourerer of Sorcery and Souls" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If a WIZARD successfully casts a spell within 12&quot; of a Malevolent Maelstrom, and that spell is not unbound, the Malevolent Maelstrom will attempt to steal the energies of the spell. Make an additional unbinding roll for that spell. If this unbinding roll is successful, the spell is unbound and 1 energy point is allocated to this model.  In addition, 1 energy point is allocated to this model for each unit destroyed within 6&quot; of this model. </characteristic>
-              </characteristics>
-            </profile>
-            <profile id="e15f-4551-895e-c294" name="Morbid Detonation" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">At the end of each battle round, roll a dice for each Malevolent Maelstrom and add the number of energy points allocated to that model to the roll. On a 7+ that Malevolent Maelstrom explodes. Each unit within 3D6&quot; of the model that exploded suffers D3 mortal wounds. The model that exploded is then dispelled.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="f134-5989-3ed3-e240" name="Empowered by Shyish" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If your battle is taking place in the Realm of Death, allocate 1 additional energy point to this model at the start of each battle round.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <infoLinks>
-            <infoLink id="7801-fff9-999e-8216" name="Fly" hidden="false" targetId="8e0c-cbe4-27be-8a30" type="profile"/>
-          </infoLinks>
-          <categoryLinks>
-            <categoryLink id="1061-013e-90fb-b4be" name="New CategoryLink" hidden="false" targetId="31f4-2067-3ade-e6f8" primary="false"/>
-            <categoryLink id="8759-c4b0-4dc5-5745" name="MALEVOLENT MAELSTROM" hidden="false" targetId="aeb3-e51f-7f02-619e" primary="false"/>
-            <categoryLink id="ff3e-2491-783f-e276" name="SHYISH" hidden="false" targetId="2cc9-0867-b2e3-da55" primary="false"/>
-          </categoryLinks>
-          <costs>
-            <cost name="pts" typeId="points" value="20.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="ec40-8615-4669-6c17" name="Prismatic Palisade" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c90b-e6e2-7e45-cd52" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="62ae-f9b8-4819-d952" name="Summon Prismatic Palisade" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
-              <characteristics>
-                <characteristic name="Casting Value" typeId="2508-b604-1258-a920">5</characteristic>
-                <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, set up a Prismatic Palisade model wholly within 18&quot; of the caster.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="b821-b2f5-1e1c-7a84" name="Blinding Light" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">At the start of each turn, roll a dice for each unit within 6&quot; of this model. On a 5+ subtract 1 from hit rolls for attacks made by that unit until the end of the turn.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="6a3f-cdd4-d5a1-6c5f" name="Dazzling Brilliance" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">A model cannot see another model if an imaginary straight line, 1mm wide, drawn from the centre of its base to the centre of the other model’s base passes over this model.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="62f6-e2e8-97ed-782c" name="Empowered by Hysh" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If your battle is taking place in the Realm of Light, add 1 to rolls made to determine if a unit is affected by this model’s Blinding Light ability.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <categoryLinks>
-            <categoryLink id="15f0-05f3-1141-4495" name="New CategoryLink" hidden="false" targetId="31f4-2067-3ade-e6f8" primary="false"/>
-            <categoryLink id="002f-5a18-5494-b718" name="HYSH" hidden="false" targetId="2b18-8032-739f-7929" primary="false"/>
-            <categoryLink id="9c8d-860a-364f-6277" name="PRISMATIC PALISADE" hidden="false" targetId="316f-32e5-0c7c-72af" primary="false"/>
-          </categoryLinks>
-          <costs>
-            <cost name="pts" typeId="points" value="30.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="2e2e-a332-031d-8499" name="Purple Sun of Shyish" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="596f-683c-9f6a-fd1d" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="cb80-3282-1bed-8311" name="Summon Purple Sun of Shyish" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
-              <characteristics>
-                <characteristic name="Casting Value" typeId="2508-b604-1258-a920">8</characteristic>
-                <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, set up a Purple Sun of Shyish model wholly within 6&quot; of the caster.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="570f-e6e0-3bae-971b" name="Predatory" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">The Purple Sun of Shyish is a predatory endless spell. It can move up to 9&quot; and can fly. </characteristic>
-              </characteristics>
-            </profile>
-            <profile id="adf3-e540-fd67-3c7e" name="Swirling Death" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">When this model is set up, the player who set it up can immediately make a move with it.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="6a78-37ad-442b-df7f" name="End Given Form" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">After this model has moved, each unit that has any models it passed across, and each other unit that is within 1&quot; of it at the end of its move, is subjected to the Purple Sun’s baleful energies. For each unit subjected to the baleful energies, roll a number of dice equal to the number of models in that unit. For each 6+ one model in that unit is slain. If the unit has Wounds characteristic of 6 or more, it suffers 2D6 mortal wounds instead.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="9b16-5704-3bbe-43a6" name="Visage of Xereus" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Subtract 1 from the Bravery characteristic of all units while they are within 6&quot; of this model.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="e8ac-84e4-055a-a17d" name="Empowered by Shyish" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If your battle is taking place in the Realm of Death, this model can move 12&quot; instead of 9&quot;. </characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <infoLinks>
-            <infoLink id="f062-e87f-918b-cb46" name="Fly" hidden="false" targetId="8e0c-cbe4-27be-8a30" type="profile"/>
-          </infoLinks>
-          <categoryLinks>
-            <categoryLink id="0158-8b5a-c54a-a150" name="New CategoryLink" hidden="false" targetId="31f4-2067-3ade-e6f8" primary="false"/>
-            <categoryLink id="cc75-efec-a099-5971" name="PURPLE SUN OF SHYISH" hidden="false" targetId="7eb6-e91d-bf00-1c84" primary="false"/>
-            <categoryLink id="792d-e0aa-ab5f-423d" name="SHYISH" hidden="false" targetId="2cc9-0867-b2e3-da55" primary="false"/>
-          </categoryLinks>
-          <costs>
-            <cost name="pts" typeId="points" value="100.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="6273-9b6e-e4c9-127a" name="Quicksilver Swords" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b23-5718-2087-a52e" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="c4ba-901a-4f4e-36dd" name="Summon Quicksilver Swords" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
-              <characteristics>
-                <characteristic name="Casting Value" typeId="2508-b604-1258-a920">6</characteristic>
-                <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, set up a Quicksilver Swords model wholly within 10&quot; of the caster.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="182b-ab2b-1a20-df95" name="Predatory" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Quicksilver Swords is a predatory endless spell. It can move up to 8&quot; and can fly.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="70f3-e631-8288-1c6a" name="Volley of Blades" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">When this model is set up, the player who set it up can immediately make a move with it.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="c92c-4e29-513a-d270" name="Dancing Blades" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">After this model has moved, you can pick 1 unit within 6&quot; of it and roll 12 dice. For each roll of 6+ that unit suffers 1 mortal wound. If the unit being rolled for is a CHAOS unit, it suffers 1 mortal wound for each roll of 5+ instead.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="af67-7816-b4f4-186e" name="Empowered by Chamon" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If your battle is taking place in the Realm of Metal, you can roll 15 dice for this model’s Dancing Blades ability instead of 12.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <infoLinks>
-            <infoLink id="69a9-1293-52b6-3429" name="Fly" hidden="false" targetId="8e0c-cbe4-27be-8a30" type="profile"/>
-          </infoLinks>
-          <categoryLinks>
-            <categoryLink id="a6f4-2f68-1f18-8d77" name="New CategoryLink" hidden="false" targetId="31f4-2067-3ade-e6f8" primary="false"/>
-            <categoryLink id="c494-41da-ed2d-de01" name="CHAMON" hidden="false" targetId="97c8-2ca9-2b12-327f" primary="false"/>
-            <categoryLink id="778f-09dd-3832-ff4e" name="QUICKSILVER SWORDS" hidden="false" targetId="65dc-260f-90f3-8a5a" primary="false"/>
-          </categoryLinks>
-          <costs>
-            <cost name="pts" typeId="points" value="20.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="ab9b-dc68-e256-9260" name="Ravenak&apos;s Gnashing Jaws" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d72-47d7-38dc-1197" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="4703-b694-7146-af34" name="Summon Ravenak&apos;s Gnashing Jaws" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
-              <characteristics>
-                <characteristic name="Casting Value" typeId="2508-b604-1258-a920">8</characteristic>
-                <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, set up a Ravenak’s Gnashing Jaws model wholly within 6&quot; of the caster.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="87c8-39d2-3514-3d40" name="Predatory" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Ravenak’s Gnashing Jaws is a predatory endless spell. It can move up to 12&quot; and can fly.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="bbe5-b9cc-d728-dc9f" name="Endless Appetite" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">When this model is set up, the player who set it up can immediately make a move with it. </characteristic>
-              </characteristics>
-            </profile>
-            <profile id="d1bd-f8e0-1ab6-26ae" name="Ravening Hunger" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">After this model has moved, each unit that has any models it passed across, and each other unit that is within 1&quot; of it at the end of its move, suffers D3 mortal wounds. In addition, subtract 1 from the Bravery characteristic of each unit that each unit that has any models it passed across until the end of the battle round.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="3cea-6f6c-2004-bef4" name="Empowered by Ghur" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If your battle is taking place in the Realm of Beasts, this model can move up to D6+12&quot; instead of 12&quot;.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <infoLinks>
-            <infoLink id="bfbd-dce8-c445-2fa3" name="Fly" hidden="false" targetId="8e0c-cbe4-27be-8a30" type="profile"/>
-          </infoLinks>
-          <categoryLinks>
-            <categoryLink id="72bd-48bb-86f1-3a13" name="New CategoryLink" hidden="false" targetId="31f4-2067-3ade-e6f8" primary="false"/>
-            <categoryLink id="4eac-423a-29c5-e8ca" name="GHUR" hidden="false" targetId="c33b-1c2d-83d9-53df" primary="false"/>
-            <categoryLink id="b13c-e0e2-f1a0-28f3" name="RAVENAK&apos;S GNASHING JAWS" hidden="false" targetId="8b8e-c0b7-d668-19f2" primary="false"/>
-          </categoryLinks>
-          <costs>
-            <cost name="pts" typeId="points" value="40.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="db2b-0d75-3bab-ff3a" name="Soulsnare Shackles" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7246-5d11-6654-59ce" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="e410-bdf4-7d5e-bcca" name="Summon Soulsnare Shackles" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
-              <characteristics>
-                <characteristic name="Casting Value" typeId="2508-b604-1258-a920">5</characteristic>
-                <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, set up a Soulsnare Shackles model wholly within 12&quot; of the caster, then set up the second and third Soulsnare Shackles models wholly within 6&quot; of the first.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="1d56-f5e7-5f62-4b13" name="Bound for the Great Oubliette" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">At the start of the movement phase, roll a dice for each unit within 6&quot; of any Soulsnare Shackles models. On a 3+ halve the move characteristic of that unit until the end of that phase. On a 6 that unit also suffers D3 mortal wounds. </characteristic>
-              </characteristics>
-            </profile>
-            <profile id="b3c1-0e0f-c7f7-e8ac" name="Empowered by Shyish" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If your battle is taking place in the Realm of Death, the second and third Soulsnare Shackles models can be set up wholly within 9&quot; of the first, instead of 6&quot;.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <categoryLinks>
-            <categoryLink id="8c78-abb4-360b-b040" name="New CategoryLink" hidden="false" targetId="31f4-2067-3ade-e6f8" primary="false"/>
-            <categoryLink id="31cd-52c1-a704-d17e" name="SHYISH" hidden="false" targetId="2cc9-0867-b2e3-da55" primary="false"/>
-            <categoryLink id="18f5-8968-f663-f433" name="SOULSNARE SHACKLES" hidden="false" targetId="4949-2041-939a-baa6" primary="false"/>
-          </categoryLinks>
-          <costs>
-            <cost name="pts" typeId="points" value="20.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="849e-470b-05c2-19b7" name="Suffocating﻿﻿ Gravetide﻿" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9211-4404-c522-c9d3" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="7c5c-6b46-4e13-0e09" name="Summon Suffocating﻿﻿ Gravetide﻿" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
-              <characteristics>
-                <characteristic name="Casting Value" typeId="2508-b604-1258-a920">6</characteristic>
-                <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, set up a Suffocating Gravetide model wholly within 4&quot; of the caster. </characteristic>
-              </characteristics>
-            </profile>
-            <profile id="61a1-7f89-3102-5efa" name="Necrotic Tide" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">When this model is set up, the player who set it up can immediately make a move with it. </characteristic>
-              </characteristics>
-            </profile>
-            <profile id="6dc9-4242-3911-cc8d" name="Pulled to the Grave" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">After this model has moved, each unit that has any models it passed across suffers D3 mortal wounds. In addition, subtract 1 from the Bravery characteristic of each unit that has any models it passed across until the end of the battle round.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="3a53-36f7-af78-d22d" name="Rolling Barricade" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">When a missile weapon targets a unit that has all of its models within 1&quot; of this model, the target unit receives the benefit of cover if the attacking unit is closer to this model than it is to the target unit. </characteristic>
-              </characteristics>
-            </profile>
-            <profile id="2758-912b-2b7e-9c71" name="Empowered by Shyish" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If your battle is taking place in the Realm of Death, this model can move up to 12&quot; instead of 8&quot;.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="a1ff-7da4-247a-398b" name="Predatory" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">A Suffocating Gravetide is a predatory endless spell. It can move up to 8&quot; and can fly. </characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <infoLinks>
-            <infoLink id="5eb4-83b7-8837-72a6" name="Fly" hidden="false" targetId="8e0c-cbe4-27be-8a30" type="profile"/>
-          </infoLinks>
-          <categoryLinks>
-            <categoryLink id="e1f8-276e-104f-06cd" name="New CategoryLink" hidden="false" targetId="31f4-2067-3ade-e6f8" primary="false"/>
-            <categoryLink id="db9e-703a-7d92-6f04" name="SHYISH" hidden="false" targetId="2cc9-0867-b2e3-da55" primary="false"/>
-            <categoryLink id="ca79-7b4b-45f5-dd18" name="SUFFOCATING GRAVETIDE" hidden="false" targetId="8e84-834f-0c7d-0d45" primary="false"/>
-          </categoryLinks>
-          <costs>
-            <cost name="pts" typeId="points" value="30.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="270a-b509-6851-5e75" name="The B﻿urning Head﻿﻿﻿" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2647-60fd-5c01-b15b" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="26f1-440d-9725-e22e" name="Summon B﻿urning Head﻿﻿﻿" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
-              <characteristics>
-                <characteristic name="Casting Value" typeId="2508-b604-1258-a920">7</characteristic>
-                <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, set up a Burning Head model wholly within 3&quot; of the caster.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="4658-af10-16ac-63b8" name="Predatory" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">The Burning Head is a predatory endless spell. It can move up to 9&quot; and can fly.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="b267-b8b7-58a4-e8cd" name="Fiery Missile" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">When this model is set up, the player who set it up can immediately make a move with it. </characteristic>
-              </characteristics>
-            </profile>
-            <profile id="7b96-fcef-dad1-ca07" name="Flaming Skull" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">After this model has moved, each unit that has any models it passed across, and each other unit that is within 1&quot; of it at the end of its move, suffers D3 mortal wounds. </characteristic>
-              </characteristics>
-            </profile>
-            <profile id="7a2f-23be-596b-2eea" name="Wrathful Aura" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Re-roll hit rolls of 1 for attacks made by units while they are wholly within 9&quot; of this model. </characteristic>
-              </characteristics>
-            </profile>
-            <profile id="875b-5f6d-b51c-d8f0" name="Empowered by Aqshy" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If your battle is taking place in the Realm of Fire, add 1 to the number of mortal wounds inflicted by the Flaming Skull ability.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <infoLinks>
-            <infoLink id="1ed6-cd6e-ad53-088e" name="Fly" hidden="false" targetId="8e0c-cbe4-27be-8a30" type="profile"/>
-          </infoLinks>
-          <categoryLinks>
-            <categoryLink id="f18e-4646-16b4-3c84" name="New CategoryLink" hidden="false" targetId="31f4-2067-3ade-e6f8" primary="false"/>
-            <categoryLink id="8291-5f42-f2b9-9203" name="AQSHY" hidden="false" targetId="f760-2ebe-1af7-ff48" primary="false"/>
-            <categoryLink id="099a-b013-c8e0-9d4b" name="THE BURNING HEAD" hidden="false" targetId="3115-9f9c-85db-1d63" primary="false"/>
-          </categoryLinks>
-          <costs>
-            <cost name="pts" typeId="points" value="40.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="e6ec-45ee-65b8-8520" name="Umbral Sp﻿ellporta﻿l﻿﻿" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51c1-19b9-7107-59cb" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="db2d-60a4-c86b-1c32" name="Summon Umbral Sp﻿ellporta﻿l﻿﻿" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
-              <characteristics>
-                <characteristic name="Casting Value" typeId="2508-b604-1258-a920">5</characteristic>
-                <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, set up the first Umbral Spellportal model wholly within 12&quot; of the caster, and then set up the second Umbral Spellportal model wholly within 18&quot; of the first.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="aa9a-0aa6-d8a3-98d0" name="Arcane Passage" publicationId="e51d-b1a3-pubEFCFK" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If a Wizard successfully casts a spell while they are within 1&quot; of an Umbral Spellportal model, the range and visibility of the spell can be measured from the other Umbral Spellportal model from this endless spell. After the range and visibility for a spell has been measured from an Umbral Spellportal, you cannot use the Arcane Passage ability again for that Umbral Spellportal in that phase. If a predatory endless spell finishes a move within 6&quot; of an Umbral Spellportal model, remove it from the battlefield and set it up again anywhere within 6&quot; of the other Umbral Spellportal model from this endless spell. After an endless spell finishes a move within 6&quot; of an Umbral Spellportal and is set up again, it cannot move again in that phase, and you cannot use the Arcane Passage ability again for that Umbral Spellportal in that phase.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="6418-d37c-76e2-8d1b" name="Empowered by Ulgu" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If your battle is taking place in the Realm of Shadow, the second Umbral Spellportal model can be set up anywhere on the battlefield, instead of within 18&quot; of the first.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <categoryLinks>
-            <categoryLink id="9f49-9937-cd19-f89d" name="New CategoryLink" hidden="false" targetId="31f4-2067-3ade-e6f8" primary="false"/>
-            <categoryLink id="4482-73ef-bf46-f961" name="ULGU" hidden="false" targetId="3f66-cb68-8afb-ce99" primary="false"/>
-            <categoryLink id="4c48-fe5e-df85-e11f" name="UMBRAL SPELLPORTAL" hidden="false" targetId="82b0-19da-b868-9f6c" primary="false"/>
-          </categoryLinks>
-          <costs>
-            <cost name="pts" typeId="points" value="60.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="f360-5eae-2f8f-41ea" name="Soulscream Bridge" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="49b3-46b7-5938-851a" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="52de-2eaf-5a15-0d0c" name="Summon Soulscream Bridge" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
-              <characteristics>
-                <characteristic name="Casting Value" typeId="2508-b604-1258-a920">6</characteristic>
-                <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, set up the first Soulscream Bridge model wholly within 6&quot; of the caster, and then set up the second Soulscream Bridge model wholly within 12&quot; of the first.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="842c-e4e0-ce87-b92e" name="Deathly Passage" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">At the start of your movement phase, friendly units wholly within 6&quot; of one Soulscream Bridge model from this endless spell can travel across the Soulscream Bridge. If they do so, remove that unit from the battlefield and set it up again wholly within 6&quot; of the other Soulscream Bridge model from this endless spell, more than 9&quot; from any enemy units. That unit cannot make a normal move that phase. </characteristic>
-              </characteristics>
-            </profile>
-            <profile id="cd12-1e5e-5940-baca" name="Nightmarish Construct" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Subtract 1 from the Bravery characteristic of enemy units while they are within 6&quot; of a Soulscream Bridge model. This ability has no effect on DEATH units.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="a1a5-5af5-c5ee-2e7f" name="Empowered by Shyish" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If your battle is taking place in the Realm of Death, the second Soulscream Bridge model can be set up wholly within 24&quot; of the first, instead of within 12&quot; of the first.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <categoryLinks>
-            <categoryLink id="7c6c-7c71-f3a4-76a5" name="ENDLESS SPELL" hidden="false" targetId="31f4-2067-3ade-e6f8" primary="false"/>
-            <categoryLink id="94aa-92b4-2dbb-5c67" name="SOULSCREAM BRIDGE" hidden="false" targetId="1d34-b962-7c7b-f287" primary="false"/>
-            <categoryLink id="0481-8acf-bf84-e22f" name="SHYISH" hidden="false" targetId="2cc9-0867-b2e3-da55" primary="false"/>
-          </categoryLinks>
-          <costs>
-            <cost name="pts" typeId="points" value="80.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="6652-54f8-a7ea-21ff" name="Shards of Valagharr" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd54-8090-e5e8-ca30" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="b603-29ee-60c0-ca6d" name="Summon Shards of Valagharr" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
-              <characteristics>
-                <characteristic name="Casting Value" typeId="2508-b604-1258-a920">5</characteristic>
-                <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, set up the first Shards of Valagharr model wholly within 6&quot; of the caster, and then set up the second Shards of Valagharr model wholly within 12&quot; of the first.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="787b-09cf-5379-66d8" name="Ensnaring Soul-drain" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">At the start of the movement phase, draw an imaginary straight line 1mm wide between the closest parts of the bases of the two Shards of Valagharr models from this endless spell. Each unit passed across by this line is ensnared until the end of that turn. Halve the Move characteristic of a unit that is ensnared. In addition, subtract 1 from hit rolls for attacks made by units that are ensnared.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="4c96-7470-086d-ae2f" name="Twilight Translocation" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">At the start of the battle round, after determining who has the first turn, the players must roll off. The winner can remove one Shards of Valagharr model from this endless spell from the battlefield and set it up again anywhere on the battlefield wholly within 12&quot; of the other Shards of Valagharr model from this endless spell.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="584f-1bfc-a9ea-a28f" name="Empowered by Shyish" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If your battle is taking place in the Realm of Death, the first Shards of Valagharr model can be set up wholly within 12&quot; of the caster, instead of 6&quot;.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <categoryLinks>
-            <categoryLink id="5883-f0aa-e0dc-153a" name="ENDLESS SPELL" hidden="false" targetId="31f4-2067-3ade-e6f8" primary="false"/>
-            <categoryLink id="0609-b54b-d58f-6293" name="SHYISH" hidden="false" targetId="2cc9-0867-b2e3-da55" primary="false"/>
-            <categoryLink id="1642-0187-e35f-57a6" name="SHARDS OF VALAGHARR" hidden="false" targetId="cff6-06c5-3294-b74b" primary="false"/>
-          </categoryLinks>
-          <costs>
-            <cost name="pts" typeId="points" value="40.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="f87d-63bc-ce04-ff23" name="Lauchon the Soulseeker" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="145b-85ea-dfcf-2b49" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="c6ba-718c-7e25-f95c" name="Summon Lauchon the Soulseeker" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
-              <characteristics>
-                <characteristic name="Casting Value" typeId="2508-b604-1258-a920">6</characteristic>
-                <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, set up a Lauchon the Soulseeker model wholly within 12&quot; of the caster.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="237f-dc91-3d07-86c3" name="Navigate Deathly Tides" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">When this model is set up, the player who set it up can immediately make a move with it.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="928e-b821-7143-96fd" name="Empowered by Shyish" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If your battle is taking place in the Realm of Death, this model can move up to 18&quot; instead of up to 12&quot;.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="69ab-3e78-cd1d-73dc" name="Soul Price" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Before a player makes a move with this model, that player can pick a friendly unit wholly within 3&quot; of this model. Remove that unit and place it to one side. After this model has moved, set that unit up again wholly within 3&quot; of this model and more than 9&quot; from any enemy units. Once that unit has been set up, 1 model from that unit is immediately slain.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="9845-aef9-09dd-bcc4" name="Predatory" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Lauchon the Soulseeker is a predatory endless spell. It can move up to 12&quot; and can fly. </characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <infoLinks>
-            <infoLink id="f79f-27f5-ec24-8b0a" name="Fly" hidden="false" targetId="8e0c-cbe4-27be-8a30" type="profile"/>
-          </infoLinks>
-          <categoryLinks>
-            <categoryLink id="ef30-11e3-e32e-cfeb" name="ENDLESS SPELL" hidden="false" targetId="31f4-2067-3ade-e6f8" primary="false"/>
-            <categoryLink id="8aa7-4fa7-be95-e935" name="LAUCHON THE SOULSEEKER" hidden="false" targetId="3b54-23ed-a577-ea1f" primary="false"/>
-            <categoryLink id="3aff-3708-66e4-6bd6" name="SHYISH" hidden="false" targetId="2cc9-0867-b2e3-da55" primary="false"/>
-          </categoryLinks>
-          <costs>
-            <cost name="pts" typeId="points" value="60.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="0ce2-6f29-eeaf-8a4c" name="Horrorghast" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="532a-b1ef-ddbf-bd28" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="0f09-45ab-d1cc-7839" name="Summon Horrorghast" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
-              <characteristics>
-                <characteristic name="Casting Value" typeId="2508-b604-1258-a920">6</characteristic>
-                <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, set up a Horrorghast model wholly within 12&quot; of the caster.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="69b9-2771-a750-4dda" name="Prey on Fear" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Subtract 1 from the Bravery characteristic of units while they are within 12&quot; of this model. Subtract 2 instead from the Bravery characteristic of units while they are within 6&quot; of this model.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="22c9-d971-d3a9-786b" name="Empowered by Shyish" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If your battle is taking place in the Realm of Death, this model can move up to 12&quot; instead of up to 9&quot;.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="b31c-1d9a-1b65-5822" name="Predatory" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">A Horrorghast is a predatory endless spell. It can move up to 9&quot; and can fly. </characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <infoLinks>
-            <infoLink id="5a0b-2dec-23e0-92e5" name="Fly" hidden="false" targetId="8e0c-cbe4-27be-8a30" type="profile"/>
-          </infoLinks>
-          <categoryLinks>
-            <categoryLink id="18b4-1516-f7a2-e087" name="ENDLESS SPELL" hidden="false" targetId="31f4-2067-3ade-e6f8" primary="false"/>
-            <categoryLink id="5802-10e0-2a73-ad7f" name="HORRORGHAST" hidden="false" targetId="9945-bd78-56ea-5cde" primary="false"/>
-            <categoryLink id="97f6-8d08-0414-8b17" name="SHYISH" hidden="false" targetId="2cc9-0867-b2e3-da55" primary="false"/>
-          </categoryLinks>
-          <costs>
-            <cost name="pts" typeId="points" value="60.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>

--- a/Chaos - Beasts of Chaos - Data.cat
+++ b/Chaos - Beasts of Chaos - Data.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="a990-882b-7e62-27e9" name="Chaos - Beasts of Chaos - Data" revision="4" battleScribeVersion="2.02" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="true" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="a990-882b-7e62-27e9" name="Chaos - Beasts of Chaos - Data" revision="5" battleScribeVersion="2.02" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="true" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="c9b2-1fe6-pubN65537" name="Battletome: Beasts of Chaos"/>
     <publication id="c9b2-1fe6-pubN83353" name="1"/>
@@ -4799,6 +4799,9 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="a5f8-f319-4988-5cfa" name="Endless Spell: Ravening Direflock" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7d75-046f-14e3-3af3" type="max"/>
+      </constraints>
       <profiles>
         <profile id="ef2d-7693-9f24-673e" name="Summon Ravening Direflock" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
           <characteristics>
@@ -4825,10 +4828,13 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="ced1-4557-660d-4219" name="Endless Spell: Wildfire Taurus" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8849-5487-5d79-01f2" type="max"/>
+      </constraints>
       <profiles>
         <profile id="5777-5512-6b05-4127" name="Predatory" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">The Wildfire Taurus is a predatory endless spell. It can move up to 12&quot; and can fly</characteristic>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">The Wildfire Taurus is a predatory endless spell. It can move up to 12&quot; and can fly.</characteristic>
           </characteristics>
         </profile>
         <profile id="facd-4317-60f1-7414" name="Summon Wildfire Taurus" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
@@ -4856,6 +4862,9 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="b9b7-48f9-740e-f1d4" name="Endless Spell: Doomblast Dirgehorn" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7dbe-c490-aa59-48b6" type="max"/>
+      </constraints>
       <profiles>
         <profile id="8d0e-52cd-4467-6f47" name="Summon Doomblast Dirgehorn" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
           <characteristics>
@@ -4897,17 +4906,6 @@
       <categoryLinks>
         <categoryLink id="ae40-3899-67a2-2965" name="SCENERY" hidden="false" targetId="8910-7c1d-6c74-37ff" primary="false"/>
       </categoryLinks>
-      <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="6a4b-2ef5-480e-678b" name="Endless Spells: Beasts of Chaos" hidden="false" collective="false" type="upgrade">
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="71b8-c1d8-3d0d-73e8" type="max"/>
-      </constraints>
-      <entryLinks>
-        <entryLink id="ae82-78f2-a45b-63a2" name="Endless Spells: Beasts of Chaos" hidden="false" collective="false" targetId="20c1-5cc5-2d3a-3914" type="selectionEntryGroup"/>
-      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
@@ -5982,25 +5980,6 @@
           </costs>
         </selectionEntry>
       </selectionEntries>
-    </selectionEntryGroup>
-    <selectionEntryGroup id="20c1-5cc5-2d3a-3914" name="Endless Spells: Beasts of Chaos" hidden="false" collective="false">
-      <entryLinks>
-        <entryLink id="d8a3-a5ab-f07e-254f" name="Endless Spell: Ravening Direflock" hidden="false" collective="false" targetId="a5f8-f319-4988-5cfa" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd11-4220-e6c7-db56" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="3f96-31c9-915b-befb" name="Endless Spell: Doomblast Dirgehorn" hidden="false" collective="false" targetId="b9b7-48f9-740e-f1d4" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2bde-649d-4f3f-9287" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="91a6-bacf-bd1b-c8d8" name="Endless Spell: Wildfire Taurus" hidden="false" collective="false" targetId="ced1-4557-660d-4219" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a0ed-14a4-13e0-e748" type="max"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedProfiles>

--- a/Chaos - Beasts of Chaos.cat
+++ b/Chaos - Beasts of Chaos.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="c9b2-1fe6-2c3e-3b27" name="Chaos - Beasts of Chaos" revision="4" battleScribeVersion="2.02" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="c9b2-1fe6-2c3e-3b27" name="Chaos - Beasts of Chaos" revision="5" battleScribeVersion="2.02" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="c9b2-1fe6-pubN65537" name="Battletome: Beasts of Chaos"/>
     <publication id="c9b2-1fe6-pubN83353" name="1"/>
@@ -278,6 +278,21 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="a7b2-b334-b9d8-e228" name="Ghorgon" hidden="false" collective="false" targetId="f321-87b5-12d6-29b4" type="selectionEntry"/>
+    <entryLink id="1266-ce6c-bab1-0f5e" name="Endless Spell: Doomblast Dirgehorn" hidden="false" collective="false" targetId="b9b7-48f9-740e-f1d4" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="dabe-0c1b-d913-18e9" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="cf00-8eff-c0b3-b923" name="Endless Spell: Ravening Direflock" hidden="false" collective="false" targetId="a5f8-f319-4988-5cfa" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="4aa7-6e2c-1467-8910" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="8f34-20f3-6bed-e7a1" name="Endless Spell: Wildfire Taurus" hidden="false" collective="false" targetId="ced1-4557-660d-4219" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="31fb-a9da-6087-46f6" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
+    </entryLink>
   </entryLinks>
   <catalogueLinks>
     <catalogueLink id="3b9a-1b91-5e03-b8f6" name="Chaos - Beasts of Chaos - Data" targetId="a990-882b-7e62-27e9" type="catalogue"/>

--- a/Chaos - Khorne.cat
+++ b/Chaos - Khorne.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cac4-1eec-d548-b34d" name="Chaos - Khorne" revision="36" battleScribeVersion="2.02" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="19" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="cac4-1eec-d548-b34d" name="Chaos - Khorne" revision="37" battleScribeVersion="2.02" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="19" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="cac4-1eec-pubN65537" name="Chaos Battletome: Blades of Khorne"/>
     <publication id="cac4-1eec-pubN105675" name="Grand Alliance: Chaos"/>
@@ -701,7 +701,7 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="2549-37a4-9999-4228" name="Skull Altar" hidden="false" collective="false" targetId="3bff-8d6b-bf69-fc6c" type="selectionEntry"/>
-    <entryLink id="ea9a-b20d-c6f8-f59e" name="Judgements of Khorne" hidden="false" collective="false" targetId="b424-3ed7-87f7-928d" type="selectionEntry">
+    <entryLink id="ea9a-b20d-c6f8-f59e" name="Judgement: Bleeding Icon" hidden="false" collective="false" targetId="b9e5-d82c-126d-7dc7" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="e71b-4479-a31e-a804" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
       </categoryLinks>
@@ -772,6 +772,16 @@
         <categoryLink id="8b77-a556-b4e7-ca18" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
     </entryLink>
+    <entryLink id="35ac-5eb9-bd26-c88c" name="Judgement: Hexgorger Skulls" hidden="false" collective="false" targetId="ebf5-a5f2-89cc-f846" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="4c4c-081b-1456-6d4f" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="16f4-0b65-a1d5-8690" name="Judgement: Wrath-Axe" hidden="false" collective="false" targetId="3d95-cf6d-c8cc-1a6c" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="87cd-71f9-d26d-104c" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
+    </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="7ab9-de0a-88c2-4fd1" name="General" hidden="false" collective="false" type="upgrade">
@@ -807,7 +817,7 @@
         </modifier>
       </modifiers>
       <profiles>
-        <profile id="52cf-10b1-737e-a42f" name="Aspiring Deathbringer" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="01 Unit">
+        <profile id="52cf-10b1-737e-a42f" name="Aspiring Deathbringer" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
             <characteristic name="Move" typeId="8655-6213-2824-1752">5&quot;</characteristic>
             <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">5</characteristic>
@@ -815,12 +825,12 @@
             <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">4+</characteristic>
           </characteristics>
         </profile>
-        <profile id="a455-aa4d-6f28-8f34" name="Slaughter Incarnate" hidden="false" typeId="f71f-b0a4-730e-ced3" typeName="07 Ability (Command)">
+        <profile id="a455-aa4d-6f28-8f34" name="Slaughter Incarnate" hidden="false" typeId="f71f-b0a4-730e-ced3" typeName="Command Abilities">
           <characteristics>
             <characteristic name="Command Ability Details" typeId="1b71-4c83-4e8c-093f">You can use this command ability at the start of the combat phase. If you do so, pick a friendly model with this command ability. Until the end of that phase, add 1 to the Attacks characteristic of melee weapons used by friendly KHORNE MORTAL units while they are wholly within 12&quot; of that model. You cannot pick the same unit to benefit from this command ability more than once per phase.</characteristic>
           </characteristics>
         </profile>
-        <profile id="d0f7-aafe-ae08-7b09" name="Bane of Cowards" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+        <profile id="d0f7-aafe-ae08-7b09" name="Bane of Cowards" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If an enemy unit fails a battleshock test within 3&quot; of this model, add D3 to the number of models that flee.</characteristic>
           </characteristics>
@@ -853,7 +863,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="852e-8cba-a1d0-bc46" type="max"/>
               </constraints>
               <profiles>
-                <profile id="6fe7-db7c-ee41-167a" name="Bloodaxe" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+                <profile id="6fe7-db7c-ee41-167a" name="Bloodaxe" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                     <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
@@ -864,7 +874,7 @@
                     <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
                   </characteristics>
                 </profile>
-                <profile id="8b51-deb0-4a18-bde9" name="Wrath-hammer" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+                <profile id="8b51-deb0-4a18-bde9" name="Wrath-hammer" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                     <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">3&quot;</characteristic>
@@ -885,7 +895,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="463a-257d-e699-de57" type="max"/>
               </constraints>
               <profiles>
-                <profile id="11e6-3b6f-784b-3cc6" name="Goreaxe" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+                <profile id="11e6-3b6f-784b-3cc6" name="Goreaxe" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                     <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
@@ -896,7 +906,7 @@
                     <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
                   </characteristics>
                 </profile>
-                <profile id="e8fa-0406-8bad-eb16" name="Skullhammer" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+                <profile id="e8fa-0406-8bad-eb16" name="Skullhammer" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                     <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">3&quot;</characteristic>
@@ -1351,7 +1361,7 @@
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9884-0298-4f2b-7743" type="max"/>
       </constraints>
       <profiles>
-        <profile id="fbd0-c517-2490-054c" name="Hellblades" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+        <profile id="fbd0-c517-2490-054c" name="Hellblades" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
           <characteristics>
             <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
             <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
@@ -1362,7 +1372,7 @@
             <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
           </characteristics>
         </profile>
-        <profile id="d71b-35b5-5fe8-17d6" name="Decapitating Blow" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+        <profile id="d71b-35b5-5fe8-17d6" name="Decapitating Blow" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If the unmodified hit roll for an attack made with a Hellblade is 6, that attack inflicts 1 mortal wound on the target in addition to any normal damage.</characteristic>
           </characteristics>
@@ -1472,7 +1482,7 @@
         </modifier>
       </modifiers>
       <profiles>
-        <profile id="49e4-3721-a679-6056" name="Blood Warrior" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="01 Unit">
+        <profile id="49e4-3721-a679-6056" name="Blood Warrior" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
             <characteristic name="Move" typeId="8655-6213-2824-1752">5&quot;</characteristic>
             <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">2</characteristic>
@@ -1480,12 +1490,12 @@
             <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">4+</characteristic>
           </characteristics>
         </profile>
-        <profile id="e674-6b12-4e9b-1db5" name="Chaos Champion" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+        <profile id="e674-6b12-4e9b-1db5" name="Chaos Champion" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">1 model in this unit can be a Chaos Champion. Add 1 to the Attacks characteristic of that model&apos;s Goreaxe(s).</characteristic>
           </characteristics>
         </profile>
-        <profile id="9255-e045-eda9-bf3b" name="No Respite" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+        <profile id="9255-e045-eda9-bf3b" name="No Respite" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If a model from this unit is slain in the combat phase, before that model is removed from play, that model can make a pile-in move and then attack wtih all of the melee weapons it is armed with.</characteristic>
           </characteristics>
@@ -1527,7 +1537,7 @@
             <constraint field="selections" scope="9361-fa26-31b7-4a10" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e1d8-8965-6392-c3ae" type="max"/>
           </constraints>
           <profiles>
-            <profile id="286e-5d6a-5cd2-146f" name="Goreglaive" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+            <profile id="286e-5d6a-5cd2-146f" name="Goreglaive" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                 <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
@@ -1548,7 +1558,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a0e-43ed-18c2-96ff" type="max"/>
           </constraints>
           <profiles>
-            <profile id="8cdd-d7cc-bf5e-3d7b" name="Icon Bearers" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+            <profile id="8cdd-d7cc-bf5e-3d7b" name="Icon Bearers" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
               <characteristics>
                 <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">1 in every 10 models in this unit can be an Icon Bearer. Add 1 to the Bravery characteristic of this unit while it includes any Icon Bearers.</characteristic>
               </characteristics>
@@ -1571,7 +1581,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9720-3e37-4e6a-6300" type="max"/>
               </constraints>
               <profiles>
-                <profile id="00d4-fb47-87f9-e61d" name="Gorefists" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+                <profile id="00d4-fb47-87f9-e61d" name="Gorefists" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
                   <characteristics>
                     <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If an unmodified save roll for an attack made with a melee weapon that targets a unit that includes any models armed with a Goreaxe and Gorefist is 6, the attacking unit suffers 1 mortal wound after all of its attacks have been resolved.</characteristic>
                   </characteristics>
@@ -1589,7 +1599,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d433-eb74-bf51-7823" type="max"/>
               </constraints>
               <profiles>
-                <profile id="87b5-b99f-67af-eb41" name="Goreaxes" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+                <profile id="87b5-b99f-67af-eb41" name="Goreaxes" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
                   <characteristics>
                     <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">You can re-roll hit rolls of 1 for models armed with a pair of Goreaxes.</characteristic>
                   </characteristics>
@@ -1906,7 +1916,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c7bf-8503-af1b-e0d1" type="max"/>
           </constraints>
           <profiles>
-            <profile id="b28d-d277-360c-7718" name="Icon Bearer" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+            <profile id="b28d-d277-360c-7718" name="Icon Bearer" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
               <characteristics>
                 <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">1 in every 3 models in this unit can be an Icon Bearer. If an unmodified battleshock roll of 1 is made for this unit while it includees any Icon Bearers, you can add 1 model to this unit, and no models from this unit will flee in that phase.</characteristic>
               </characteristics>
@@ -1921,7 +1931,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="115f-bad2-afac-343b" type="max"/>
           </constraints>
           <profiles>
-            <profile id="705a-7d2e-e2fb-aaa2" name="Hornblower" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+            <profile id="705a-7d2e-e2fb-aaa2" name="Hornblower" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
               <characteristics>
                 <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">1 in every 3 models in this unit can be a Hornblower.  While this model contains any Hornblowers, if the unmodified roll for a battleshock test for an enemy unit that is within 8&quot; of this unit is 1, that battleshock test must be re-rolled.</characteristic>
               </characteristics>
@@ -2051,17 +2061,17 @@
         </modifier>
       </modifiers>
       <profiles>
-        <profile id="a590-e2cf-8f5b-341e" name="Bloodreaper" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+        <profile id="a590-e2cf-8f5b-341e" name="Bloodreaper" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">1 Model in this unit can be a Bloodreaper. Add 1 to the Attacks characteristic of that model&apos;s Hellblade.</characteristic>
           </characteristics>
         </profile>
-        <profile id="182c-a85c-7994-0b5e" name="Murderous Tide" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+        <profile id="182c-a85c-7994-0b5e" name="Murderous Tide" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">You can add 1 to hit rolls for attacks made by this unit while this unit has at least 20 models.</characteristic>
           </characteristics>
         </profile>
-        <profile id="896b-6633-48a8-bfa3" name="Bloodletters" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="01 Unit">
+        <profile id="896b-6633-48a8-bfa3" name="Bloodletters" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
             <characteristic name="Move" typeId="8655-6213-2824-1752">5&quot;</characteristic>
             <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">1</characteristic>
@@ -2098,7 +2108,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a920-b2c4-bb41-1155" type="max"/>
           </constraints>
           <profiles>
-            <profile id="17d9-f82e-650b-c1ce" name="Standard Bearers" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+            <profile id="17d9-f82e-650b-c1ce" name="Standard Bearers" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
               <characteristics>
                 <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">1 in every 10 models in this unit can be an Icon Bearer or a Standard Bearer.</characteristic>
               </characteristics>
@@ -2115,7 +2125,7 @@
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="72e2-7854-ca79-0103" type="max"/>
                   </constraints>
                   <profiles>
-                    <profile id="8294-6806-49f9-bd79" name="Gore-drenched Icon" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+                    <profile id="8294-6806-49f9-bd79" name="Gore-drenched Icon" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
                       <characteristics>
                         <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If an unmodified battleshock roll of 1 is made for this unit while it includes any Gore-drenched Icon Bearers, you can add D6 models to this unit, and no models from this unit will flee in that phase.</characteristic>
                       </characteristics>
@@ -2152,7 +2162,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70b2-9f21-ab23-d91d" type="max"/>
           </constraints>
           <profiles>
-            <profile id="b824-5d2c-4cd2-0717" name="Hornblower" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+            <profile id="b824-5d2c-4cd2-0717" name="Hornblower" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
               <characteristics>
                 <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">1 in every 10 models in this unit can be a Hornblower. While this unit includes any Hornblowers, if the unmodified roll for a battleshock test for an enemy unit that is within 8&quot; of this unit is 1, that battleshock test must be re-rolled.</characteristic>
               </characteristics>
@@ -2234,7 +2244,7 @@
     </selectionEntry>
     <selectionEntry id="78be-9de2-98c0-1b84" name="Bloodreavers" hidden="false" collective="false" type="unit">
       <profiles>
-        <profile id="bbad-ee68-91fe-51a2" name="Bloodreaver" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="01 Unit">
+        <profile id="bbad-ee68-91fe-51a2" name="Bloodreaver" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
             <characteristic name="Move" typeId="8655-6213-2824-1752">6&quot;</characteristic>
             <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">1</characteristic>
@@ -2242,12 +2252,12 @@
             <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">6+</characteristic>
           </characteristics>
         </profile>
-        <profile id="ddb4-7cf6-da0e-67da" name="Chieftain" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+        <profile id="ddb4-7cf6-da0e-67da" name="Chieftain" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">1 model in this unit can be a Chieftain. Add 1 to the Attacks characteristic of that model&apos;s melee weapons.</characteristic>
           </characteristics>
         </profile>
-        <profile id="5190-b17d-b718-5294" name="Frenzied Devotion" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+        <profile id="5190-b17d-b718-5294" name="Frenzied Devotion" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Add 1 to the Attacks characteristic of this unit&apos;s melee weapons while this unit is wholly within 16&quot; of any friendly KHORNE TOTEMS.</characteristic>
           </characteristics>
@@ -2282,7 +2292,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="873f-07c6-0b68-d554" type="max"/>
           </constraints>
           <profiles>
-            <profile id="04b5-bbf6-9d18-c6e7" name="Hornblowers" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+            <profile id="04b5-bbf6-9d18-c6e7" name="Hornblowers" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
               <characteristics>
                 <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">1 in every 10 models in this unit can be a Hornblower. Add 1 to run and charge rolls for this unit while it includes any Hornblowers.</characteristic>
               </characteristics>
@@ -2297,7 +2307,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe35-2b64-91bb-b9b2" type="max"/>
           </constraints>
           <profiles>
-            <profile id="a38c-3eda-4500-1da1" name="Icon Bearers" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+            <profile id="a38c-3eda-4500-1da1" name="Icon Bearers" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
               <characteristics>
                 <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">1 in every 10 models in this unit can be an Icon Bearer. Add 1 to the Bravery characteristic of this unit while it includes any Icon Bearers.</characteristic>
               </characteristics>
@@ -2317,7 +2327,7 @@
           <selectionEntries>
             <selectionEntry id="4b24-bb27-15f1-f660" name="Reaver Blades" hidden="false" collective="false" type="upgrade">
               <profiles>
-                <profile id="295f-fad0-6d9c-188d" name="Reaver Blades" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+                <profile id="295f-fad0-6d9c-188d" name="Reaver Blades" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                     <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
@@ -2328,7 +2338,7 @@
                     <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
                   </characteristics>
                 </profile>
-                <profile id="9ee9-21b9-7457-17df" name="Reaver Blades" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+                <profile id="9ee9-21b9-7457-17df" name="Reaver Blades" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
                   <characteristics>
                     <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">You can re-roll hit rolls of 1 for models attacks made with Reaver Blades.</characteristic>
                   </characteristics>
@@ -2340,7 +2350,7 @@
             </selectionEntry>
             <selectionEntry id="2624-b2c0-152b-63ee" name="Meatripper Axes" hidden="false" collective="false" type="upgrade">
               <profiles>
-                <profile id="7c83-9106-22a6-8bef" name="Meatripper Axe" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+                <profile id="7c83-9106-22a6-8bef" name="Meatripper Axe" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                     <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
@@ -2365,7 +2375,7 @@
     </selectionEntry>
     <selectionEntry id="56be-4ba7-aa8b-81d6" name="Bloodsecrator" hidden="false" collective="false" type="unit">
       <profiles>
-        <profile id="97f0-3252-8074-a95f" name="Bloodsecrator" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="01 Unit">
+        <profile id="97f0-3252-8074-a95f" name="Bloodsecrator" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
             <characteristic name="Move" typeId="8655-6213-2824-1752">4&quot;</characteristic>
             <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">5</characteristic>
@@ -2400,7 +2410,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b297-aa08-46d5-9cf7" type="max"/>
           </constraints>
           <profiles>
-            <profile id="a0dd-75ed-487c-78cc" name="Ensorcelled Axe" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+            <profile id="a0dd-75ed-487c-78cc" name="Ensorcelled Axe" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                 <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
@@ -2428,7 +2438,7 @@
     </selectionEntry>
     <selectionEntry id="7ee0-2ba0-c052-200a" name="Bloodstoker" hidden="false" collective="false" type="unit">
       <profiles>
-        <profile id="aea2-47b8-dfd2-813d" name="Bloodstoker" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="01 Unit">
+        <profile id="aea2-47b8-dfd2-813d" name="Bloodstoker" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
             <characteristic name="Move" typeId="8655-6213-2824-1752">6&quot;</characteristic>
             <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">5</characteristic>
@@ -2436,7 +2446,7 @@
             <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">4+</characteristic>
           </characteristics>
         </profile>
-        <profile id="dce3-8466-de3f-b81c" name="Whipped to Fury" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+        <profile id="dce3-8466-de3f-b81c" name="Whipped to Fury" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">At the start ofyour movement phase, you can pick 1 other friendly KHORNE MORTAL unit whollyn within 8&quot; of this model. Until your next movement phase, you can add 3&quot; to run and charge rolls made for that unit. In addition, until your next movement phase you can re-roll wound rolls for attacks made by that unit. A unit cannot be picked to benefit from this ability more than once per turn.</characteristic>
           </characteristics>
@@ -2457,7 +2467,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6ec-6b5a-5f2a-dbdd" type="max"/>
           </constraints>
           <profiles>
-            <profile id="7ead-cc4b-c496-1e94" name="Torture Blade" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+            <profile id="7ead-cc4b-c496-1e94" name="Torture Blade" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                 <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
@@ -2479,7 +2489,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9183-0e7a-f616-48ea" type="max"/>
           </constraints>
           <profiles>
-            <profile id="9ac6-6ae1-b252-00d7" name="Blood Whip" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+            <profile id="9ac6-6ae1-b252-00d7" name="Blood Whip" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                 <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">3&quot;</characteristic>
@@ -3202,7 +3212,7 @@
         </modifier>
       </modifiers>
       <profiles>
-        <profile id="9c82-0d90-2043-fe25" name="Exalted Deathbringer" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="01 Unit">
+        <profile id="9c82-0d90-2043-fe25" name="Exalted Deathbringer" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
             <characteristic name="Move" typeId="8655-6213-2824-1752">5&quot;</characteristic>
             <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">5</characteristic>
@@ -3210,12 +3220,12 @@
             <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">4+</characteristic>
           </characteristics>
         </profile>
-        <profile id="4038-864b-a028-21af" name="Blooded Lieutenant" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+        <profile id="4038-864b-a028-21af" name="Blooded Lieutenant" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If this model is not your general, add 2 to the Attacks characteristic of this model&apos;s melee weapons while it is wholly within 12&quot; of a friendly KHORNE general.</characteristic>
           </characteristics>
         </profile>
-        <profile id="c722-e315-4770-5ea4" name="Brutal Command" hidden="false" typeId="f71f-b0a4-730e-ced3" typeName="07 Ability (Command)">
+        <profile id="c722-e315-4770-5ea4" name="Brutal Command" hidden="false" typeId="f71f-b0a4-730e-ced3" typeName="Command Abilities">
           <characteristics>
             <characteristic name="Command Ability Details" typeId="1b71-4c83-4e8c-093f">You can use this command ability at the start of the battleshock phase. If you do so, pick a friendly model with this command ability. until the end of that pase, you do not have to take battleshock tests for friendly KHORNE MORTAL units that are wholly within 18&quot; of that model.</characteristic>
           </characteristics>
@@ -3241,7 +3251,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="af9e-97e2-4e9e-e8b8" type="max"/>
               </constraints>
               <profiles>
-                <profile id="febe-ed7f-7494-4119" name="Bloodbite Axe" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+                <profile id="febe-ed7f-7494-4119" name="Bloodbite Axe" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                     <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
@@ -3252,7 +3262,7 @@
                     <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
                   </characteristics>
                 </profile>
-                <profile id="af7c-688a-2b0c-f463" name="Runemarked Shield" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+                <profile id="af7c-688a-2b0c-f463" name="Runemarked Shield" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
                   <characteristics>
                     <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Roll a dice each time you allocate a wound or mortal wound to this model that was inflicted by a spell. On a 2+ that wound or mortal wound is negated.</characteristic>
                   </characteristics>
@@ -3267,7 +3277,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7a26-3945-cb09-2a4d" type="max"/>
               </constraints>
               <profiles>
-                <profile id="c6fd-1b5e-6df4-b13c" name="Ruinous Axe" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+                <profile id="c6fd-1b5e-6df4-b13c" name="Ruinous Axe" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                     <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
@@ -3278,7 +3288,7 @@
                     <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">2</characteristic>
                   </characteristics>
                 </profile>
-                <profile id="6955-7655-5297-8488" name="Skullgouger" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+                <profile id="6955-7655-5297-8488" name="Skullgouger" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
                   <characteristics>
                     <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">In the combat phase, if the unmodified save roll for an attack that targets this model is 6, the attacking unit suffers D3 mortal wounds after all of its attacks have been resolved.</characteristic>
                   </characteristics>
@@ -3293,12 +3303,12 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1145-70ca-00b7-e661" type="max"/>
               </constraints>
               <profiles>
-                <profile id="4d2c-3a44-3914-a8ed" name="Brutal Impalement" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+                <profile id="4d2c-3a44-3914-a8ed" name="Brutal Impalement" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
                   <characteristics>
                     <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">if the unmodified roll for an attack made with an Impaling Spear is 6, that attack inflicts D3 mortal wounds on the target in addition to any normal damage.</characteristic>
                   </characteristics>
                 </profile>
-                <profile id="4894-0980-fbc9-a1af" name="Impaling Spear" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+                <profile id="4894-0980-fbc9-a1af" name="Impaling Spear" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                     <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">2&quot;</characteristic>
@@ -3897,7 +3907,7 @@
     </selectionEntry>
     <selectionEntry id="86c6-8197-045c-d1bb" name="Khorgoraths" hidden="false" collective="false" type="unit">
       <profiles>
-        <profile id="69c7-ac5c-b05d-6381" name="Khorgorath" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="01 Unit">
+        <profile id="69c7-ac5c-b05d-6381" name="Khorgorath" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
             <characteristic name="Move" typeId="8655-6213-2824-1752">6&quot;</characteristic>
             <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">8</characteristic>
@@ -3905,12 +3915,12 @@
             <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">4+</characteristic>
           </characteristics>
         </profile>
-        <profile id="f923-6a57-02f9-bdcd" name="Horrific Predator" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+        <profile id="f923-6a57-02f9-bdcd" name="Horrific Predator" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Add 1 to battleshock rolls for units that has any models slain by attacks made by KHORGORATHS in the same turn.</characteristic>
           </characteristics>
         </profile>
-        <profile id="6369-782e-4c8d-7320" name="Taker of Heads" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+        <profile id="6369-782e-4c8d-7320" name="Taker of Heads" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">At the end of the combat phase, if any enemy models were slain by this unit&apos;s attacks in that combat phase, you can heal 1 wound allocated to this unit.</characteristic>
           </characteristics>
@@ -3936,7 +3946,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="196d-338f-afc6-89dd" type="max"/>
               </constraints>
               <profiles>
-                <profile id="6952-3ac6-c96c-756d" name="Claws and Fangs" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+                <profile id="6952-3ac6-c96c-756d" name="Claws and Fangs" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                     <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
@@ -3958,7 +3968,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15d3-d1c6-9772-7f6e" type="max"/>
               </constraints>
               <profiles>
-                <profile id="7cc3-a2a9-2e0e-b4d0" name="Bone Tentacles" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+                <profile id="7cc3-a2a9-2e0e-b4d0" name="Bone Tentacles" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Type" typeId="655c-362e-a663-3e50">Missle</characteristic>
                     <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">6&quot;</characteristic>
@@ -4046,7 +4056,7 @@
                 <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">D3</characteristic>
               </characteristics>
             </profile>
-            <profile id="4ad5-29b3-75ac-fa72" name="Reality-splitting Axe" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+            <profile id="4ad5-29b3-75ac-fa72" name="Reality-splitting Axe" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
               <characteristics>
                 <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">At the end of any phase, if any wounds inflicted by this model&apos;s Axe of Khorne in that phase were allocated to an enemy model and not negated, and that enemy model has not been slain, roll a dice. On a 5+ that enemy model is slain.</characteristic>
               </characteristics>
@@ -4088,7 +4098,7 @@
     </selectionEntry>
     <selectionEntry id="f423-90c7-d450-d22b" name="Lord of Khorne on Juggernaut" hidden="false" collective="false" type="unit">
       <profiles>
-        <profile id="4159-93a4-1e3e-5491" name="Lord of Khorne on Juggernaut" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="01 Unit">
+        <profile id="4159-93a4-1e3e-5491" name="Lord of Khorne on Juggernaut" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
             <characteristic name="Move" typeId="8655-6213-2824-1752">8&quot;</characteristic>
             <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">8</characteristic>
@@ -4096,17 +4106,17 @@
             <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">3+</characteristic>
           </characteristics>
         </profile>
-        <profile id="9f1a-11ef-6a89-4aff" name="Brass-clad Shield" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+        <profile id="9f1a-11ef-6a89-4aff" name="Brass-clad Shield" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Roll a dice each time you allocate a wound or mortal wound to this model that was inflicted by a spell. On a 5+ that wound or mortal wound is negated.</characteristic>
           </characteristics>
         </profile>
-        <profile id="ad30-f939-b9b2-b377" name="Slaughterous Charge" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+        <profile id="ad30-f939-b9b2-b377" name="Slaughterous Charge" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">After this model makes a charge move, you can pick 1 enemy unit within 1&quot; of it and roll a dice. On a 2+ that enemy unit suffers D3 mortal wounds.</characteristic>
           </characteristics>
         </profile>
-        <profile id="e3d4-ba23-433d-79a2" name="Blood Stampede" hidden="false" typeId="f71f-b0a4-730e-ced3" typeName="07 Ability (Command)">
+        <profile id="e3d4-ba23-433d-79a2" name="Blood Stampede" hidden="false" typeId="f71f-b0a4-730e-ced3" typeName="Command Abilities">
           <characteristics>
             <characteristic name="Command Ability Details" typeId="1b71-4c83-4e8c-093f">You can use this command ability at the start of the combat phase. If you do so, pick up to 3 friendly KHORNE MORTAL units that made a charge move in that turn and are wholly within 16&quot; of a model with this command ability. You can re-roll wound rolls of 1 for attacks made by those units in that combat phase.</characteristic>
           </characteristics>
@@ -4127,7 +4137,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0806-76a1-69c1-5c50" type="max"/>
           </constraints>
           <profiles>
-            <profile id="dcf9-8a51-8d5d-a833" name="Wrathforged Axe" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+            <profile id="dcf9-8a51-8d5d-a833" name="Wrathforged Axe" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                 <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
@@ -4138,7 +4148,7 @@
                 <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">D3</characteristic>
               </characteristics>
             </profile>
-            <profile id="4f1a-022b-fc51-ea3e" name="Daemonic Axe" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+            <profile id="4f1a-022b-fc51-ea3e" name="Daemonic Axe" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
               <characteristics>
                 <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If the unmodified wound roll for an attack made by this model&apos;s Wrathforged Axe is 6, the Damage characteristic for that attack is 3 instead of D3.</characteristic>
               </characteristics>
@@ -4184,7 +4194,7 @@
     </selectionEntry>
     <selectionEntry id="50ba-f44c-8f95-a084" name="Mighty Lord of Khorne" hidden="false" collective="false" type="unit">
       <profiles>
-        <profile id="0ae9-b2ad-88d8-9e33" name="Mighty Lord of Khorne" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="01 Unit">
+        <profile id="0ae9-b2ad-88d8-9e33" name="Mighty Lord of Khorne" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
             <characteristic name="Move" typeId="8655-6213-2824-1752">5&quot;</characteristic>
             <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">6</characteristic>
@@ -4192,7 +4202,7 @@
             <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">3+</characteristic>
           </characteristics>
         </profile>
-        <profile id="3282-1573-42c4-ce3e" name="Gorelord" hidden="false" typeId="f71f-b0a4-730e-ced3" typeName="07 Ability (Command)">
+        <profile id="3282-1573-42c4-ce3e" name="Gorelord" hidden="false" typeId="f71f-b0a4-730e-ced3" typeName="Command Abilities">
           <characteristics>
             <characteristic name="Command Ability Details" typeId="1b71-4c83-4e8c-093f">You can use this command ability at the start of the charge phase. If you do so, pick a friendly model with this command ability. Until the end of that phase, you can re-roll charge rolls for friendly KHORNE MORTAL units wholly within 16&quot; of that model when the charge roll is made.</characteristic>
           </characteristics>
@@ -4213,7 +4223,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0967-0727-bd65-e8f1" type="max"/>
           </constraints>
           <profiles>
-            <profile id="322f-a7ed-2695-2a41" name="Axe of Khorne" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+            <profile id="322f-a7ed-2695-2a41" name="Axe of Khorne" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                 <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
@@ -4224,7 +4234,7 @@
                 <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">D3</characteristic>
               </characteristics>
             </profile>
-            <profile id="500a-9986-4772-e7cc" name="Reality-splitting Axe" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+            <profile id="500a-9986-4772-e7cc" name="Reality-splitting Axe" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
               <characteristics>
                 <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">At the end of any phase, if any wounds inflicted by this model&apos;s Axe of Khorne in that phase were allocated to an enemy model and not negated, and that enemy model has not been slain, roll a dice. On a 5+ that enemy model is slain.</characteristic>
               </characteristics>
@@ -4240,7 +4250,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1c75-4185-decf-8382" type="max"/>
           </constraints>
           <profiles>
-            <profile id="efd5-0b4f-36c5-4a70" name="Flesh Hound&apos;s Blood-dark Claws" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+            <profile id="efd5-0b4f-36c5-4a70" name="Flesh Hound&apos;s Blood-dark Claws" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                 <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
@@ -4251,7 +4261,7 @@
                 <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
               </characteristics>
             </profile>
-            <profile id="a288-310c-f970-1c16" name="Collar of Khorne" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+            <profile id="a288-310c-f970-1c16" name="Collar of Khorne" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
               <characteristics>
                 <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">This model can attempt to unbind one spell in the enemy hero phase in the same manner as a WIZARD. In addition, this model can attempt to dispel one endless spell at the start of your hero phase in the same manner as a WIZARD. </characteristic>
               </characteristics>
@@ -4273,7 +4283,7 @@
     </selectionEntry>
     <selectionEntry id="f22b-7afb-d696-5145" name="Mighty Skullcrushers" hidden="false" collective="false" type="unit">
       <profiles>
-        <profile id="00ea-c487-6759-ed68" name="Mighty Skullcrusher" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="01 Unit">
+        <profile id="00ea-c487-6759-ed68" name="Mighty Skullcrusher" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
             <characteristic name="Move" typeId="8655-6213-2824-1752">8&quot;</characteristic>
             <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">5</characteristic>
@@ -4281,7 +4291,7 @@
             <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">3+</characteristic>
           </characteristics>
         </profile>
-        <profile id="eb39-a14f-7990-c1ce" name="Skullhunter" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+        <profile id="eb39-a14f-7990-c1ce" name="Skullhunter" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">1 model in this unit can be a Skullhunter. Add 1 to the Attacks characteristic of that model&apos;s melee weapons.</characteristic>
           </characteristics>
@@ -4314,7 +4324,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ff1-8d35-c91c-fd84" type="max"/>
           </constraints>
           <profiles>
-            <profile id="6a02-7f40-bc17-9834" name="Hornblowers" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+            <profile id="6a02-7f40-bc17-9834" name="Hornblowers" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
               <characteristics>
                 <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">1 in every 3 models in this unit can be a Hornblower. Add 1 to run and charge rolls made for this unit while it includes any Hornblowers.</characteristic>
               </characteristics>
@@ -4329,7 +4339,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8af0-d780-7887-8efe" type="max"/>
           </constraints>
           <profiles>
-            <profile id="722e-034e-12c7-4b05" name="Standard Bearers" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+            <profile id="722e-034e-12c7-4b05" name="Standard Bearers" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
               <characteristics>
                 <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">1 in every 3 models in this unit can be a Standard Bearer. Add 2 to the Bravery characteristic of this unit while it includes any Standard Bearers.</characteristic>
               </characteristics>
@@ -4349,7 +4359,7 @@
           <selectionEntries>
             <selectionEntry id="0d40-7ae5-da68-4bf7" name="Bloodglaive" hidden="false" collective="false" type="upgrade">
               <profiles>
-                <profile id="1f0c-41c7-fb48-6fb8" name="Bloodglaive" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+                <profile id="1f0c-41c7-fb48-6fb8" name="Bloodglaive" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                     <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
@@ -4367,7 +4377,7 @@
             </selectionEntry>
             <selectionEntry id="905a-077e-51b8-1b5c" name="Ensorcelled Axe" hidden="false" collective="false" type="upgrade">
               <profiles>
-                <profile id="ff5f-6e19-e782-f78b" name="Ensorcelled Axe" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+                <profile id="ff5f-6e19-e782-f78b" name="Ensorcelled Axe" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                     <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
@@ -4639,7 +4649,7 @@
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1e21-4d96-031a-c079" type="max"/>
       </constraints>
       <profiles>
-        <profile id="a18d-5108-2877-16cf" name="Scyla Anfingrimm" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="01 Unit">
+        <profile id="a18d-5108-2877-16cf" name="Scyla Anfingrimm" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
             <characteristic name="Move" typeId="8655-6213-2824-1752">8&quot;</characteristic>
             <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">8</characteristic>
@@ -4647,17 +4657,17 @@
             <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">5+</characteristic>
           </characteristics>
         </profile>
-        <profile id="4be1-8676-b729-3c7c" name="Brass Collar of Khorne" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+        <profile id="4be1-8676-b729-3c7c" name="Brass Collar of Khorne" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">This unit can attempt to unbind one spell in each enemy hero phase in the same manner as a WIZARD. In addition, this unit can attempt to dispel one endless spell at the start of your hero phase in the same manner as a WIZARD.</characteristic>
           </characteristics>
         </profile>
-        <profile id="48d9-e036-a47a-b5da" name="Raging Fury" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+        <profile id="48d9-e036-a47a-b5da" name="Raging Fury" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">When rolling to determine the Attacks characteristic of this model&apos;s Brutal Fists, add 1 to the roll for each wound allocated to this model that was not negated and has not been healed.</characteristic>
           </characteristics>
         </profile>
-        <profile id="40ea-64e2-585b-4b7f" name="Bestial Leap" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+        <profile id="40ea-64e2-585b-4b7f" name="Bestial Leap" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">This model is eligible to fight in the combat phase if it is within 8&quot; of an enemy unit instead of 3&quot;, and can move an extra 5&quot; when it piles in.</characteristic>
           </characteristics>
@@ -4678,7 +4688,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e2f-6860-d869-3431" type="max"/>
           </constraints>
           <profiles>
-            <profile id="e4e2-945f-cf2d-f3b2" name="Brutal Fists" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+            <profile id="e4e2-945f-cf2d-f3b2" name="Brutal Fists" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                 <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">2&quot;</characteristic>
@@ -4700,7 +4710,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1cdf-bfe2-8fb8-7362" type="max"/>
           </constraints>
           <profiles>
-            <profile id="fd43-f8c5-31c7-2da8" name="Serpentine Tail" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+            <profile id="fd43-f8c5-31c7-2da8" name="Serpentine Tail" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                 <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">3&quot;</characteristic>
@@ -4894,7 +4904,7 @@
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bce7-962e-8b94-dc78" type="max"/>
       </constraints>
       <profiles>
-        <profile id="41c6-b84c-b2ef-23d1" name="Skarr Bloodwrath" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="01 Unit">
+        <profile id="41c6-b84c-b2ef-23d1" name="Skarr Bloodwrath" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
             <characteristic name="Move" typeId="8655-6213-2824-1752">5&quot;</characteristic>
             <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">5</characteristic>
@@ -4902,12 +4912,12 @@
             <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">4+</characteristic>
           </characteristics>
         </profile>
-        <profile id="97d5-f527-838c-d20e" name="The Slaughterborn" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+        <profile id="97d5-f527-838c-d20e" name="The Slaughterborn" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">At the end of the movement phase, if this model has been slain, roll 2D6. On an 8+ you can set up this model anywhere on the battlefield more than 9&quot; away from an enemy units, with all wounds allocated to it removed.</characteristic>
           </characteristics>
         </profile>
-        <profile id="da59-0f7f-061b-9b4f" name="Slaughterstorm" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+        <profile id="da59-0f7f-061b-9b4f" name="Slaughterstorm" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">The Attacks characteristic of this model&apos;s Bloodstorm Blades is either 5, or equal to the number of enemy models within 3&quot; of this model when the number of attacks made with the weapon is determined (whichever is higher).</characteristic>
           </characteristics>
@@ -4929,7 +4939,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a9c9-856d-bb6a-e44c" type="max"/>
           </constraints>
           <profiles>
-            <profile id="836d-8512-88fe-82d9" name="Bloodstorm Blades" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+            <profile id="836d-8512-88fe-82d9" name="Bloodstorm Blades" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                 <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">3&quot;</characteristic>
@@ -4955,7 +4965,7 @@
     </selectionEntry>
     <selectionEntry id="e167-7729-8c8b-bf26" name="Skullgrinder" hidden="false" collective="false" type="unit">
       <profiles>
-        <profile id="d82a-d56a-c516-223d" name="Skullgrinder" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="01 Unit">
+        <profile id="d82a-d56a-c516-223d" name="Skullgrinder" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
             <characteristic name="Move" typeId="8655-6213-2824-1752">5&quot;</characteristic>
             <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">5</characteristic>
@@ -4963,12 +4973,12 @@
             <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">4+</characteristic>
           </characteristics>
         </profile>
-        <profile id="0f95-fb77-0603-de19" name="Fiery Anvil" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+        <profile id="0f95-fb77-0603-de19" name="Fiery Anvil" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">At the end of the combat phase, y ou can pick 1 enemy HERO or MONSTER within 2&quot; of this model and roll a dice. On a 2+ that enemy unit suffers D3 mortal wounds.</characteristic>
           </characteristics>
         </profile>
-        <profile id="c7ca-de5a-c791-beff" name="Favoured by Khorne" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+        <profile id="c7ca-de5a-c791-beff" name="Favoured by Khorne" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Add 1 to the Bravery characteristic of friendly KHORNE MORTAL units wholly within 12&quot; of any friendly models with this ability.</characteristic>
           </characteristics>
@@ -4989,7 +4999,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8583-e4fb-2c44-5e88" type="max"/>
           </constraints>
           <profiles>
-            <profile id="279b-ef8c-9da0-fc76" name="Brazen Anvil" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+            <profile id="279b-ef8c-9da0-fc76" name="Brazen Anvil" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                 <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">2&quot;</characteristic>
@@ -5108,7 +5118,7 @@
     </selectionEntry>
     <selectionEntry id="be0c-d1b0-5f46-48c4" name="Skullreapers" hidden="false" collective="false" type="unit">
       <profiles>
-        <profile id="85cc-b1bb-d209-33e7" name="Skullreaper" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="01 Unit">
+        <profile id="85cc-b1bb-d209-33e7" name="Skullreaper" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
             <characteristic name="Move" typeId="8655-6213-2824-1752">5&quot;</characteristic>
             <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">3</characteristic>
@@ -5116,12 +5126,12 @@
             <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">4+</characteristic>
           </characteristics>
         </profile>
-        <profile id="f80e-90e3-ce35-ac6c" name="Skullseeker" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+        <profile id="f80e-90e3-ce35-ac6c" name="Skullseeker" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">1 model in this unit is a Skullseeker. That model is armed with a Vicious Mutation in addition to its other weapons.</characteristic>
           </characteristics>
         </profile>
-        <profile id="5917-8006-124a-a2d6" name="Vicious Mutation" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+        <profile id="5917-8006-124a-a2d6" name="Vicious Mutation" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
           <characteristics>
             <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
             <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
@@ -5132,17 +5142,17 @@
             <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">D3</characteristic>
           </characteristics>
         </profile>
-        <profile id="4fb3-a6ba-1716-00dd" name="Trial of Skulls" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+        <profile id="4fb3-a6ba-1716-00dd" name="Trial of Skulls" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">You can re-roll hit rolls for attacks made by this unit if the target unit has 5 or more models.</characteristic>
           </characteristics>
         </profile>
-        <profile id="c3ae-2258-4491-9832" name="Murderous to the Last" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+        <profile id="c3ae-2258-4491-9832" name="Murderous to the Last" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Do not take battleshock tests for this unit. In addition, roll a dice each time a model from this unit is slain by an attack made with a melee weapon, before the model is removed from play. ON a 5+ pick 1 enemy unit within 1&quot; of the slain model. That unit suffers D3 mortal wounds after all of its attacks have been resolved.</characteristic>
           </characteristics>
         </profile>
-        <profile id="e9c9-4552-54f2-8876" name="Daemonforged Weapons" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+        <profile id="e9c9-4552-54f2-8876" name="Daemonforged Weapons" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If the unmodified hit roll for an attack made with this unit&apos;s Gore-slick Blades, Daemonblades, Spinecleavers, and Soultearers is 6, that attack inflicts 1 mortal wound in addition to any normal damage.</characteristic>
           </characteristics>
@@ -5170,7 +5180,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6ad1-8572-728d-15db" type="max"/>
           </constraints>
           <profiles>
-            <profile id="bd5d-c1ac-7896-b8d2" name="Icon Bearers" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+            <profile id="bd5d-c1ac-7896-b8d2" name="Icon Bearers" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
               <characteristics>
                 <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">1 in every 5 models in this unit can be an Icon Bearer. Add 1 to charge rolls for this unit whil it includes any Icon Bearers.</characteristic>
               </characteristics>
@@ -5677,12 +5687,12 @@
             <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">4+</characteristic>
           </characteristics>
         </profile>
-        <profile id="eb12-25ff-e00d-4e88" name="Runes of Binding" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Ability (Unit)">
+        <profile id="eb12-25ff-e00d-4e88" name="Runes of Binding" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">When you set up a Slaughterbrute of Khorne, you can pick a KHORNE MORTAL HERO in your army to be its master (a model cannot be the master of more than one Slaughterbrute - the effort required would be fatal). As long as the Slaughterbrute&apos;s master is on the battlefield, the Slaughterbrute&apos;s melee weapons hit on rolls of 3+ rather than 4+.</characteristic>
           </characteristics>
         </profile>
-        <profile id="8721-2bae-f32d-799f" name="Beast Unbound" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Ability (Unit)">
+        <profile id="8721-2bae-f32d-799f" name="Beast Unbound" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">A slaughterbrute without a master is a terrifying force of destruction, running rampant and attacking anything that comes near. If a Slaughterbrute does not have a master on the battlefield in the charge phase, roll a dice. If the result is 3 or less it lashes out in a wild berserk fury at the nearest model, friend or foe, within 3&quot;. That model&apos;s unit immediately suffers D3 mortal wounds.</characteristic>
           </characteristics>
@@ -5814,7 +5824,7 @@
     </selectionEntry>
     <selectionEntry id="b805-6a44-d7ec-92e0" name="Slaughterpriest" hidden="false" collective="false" type="unit">
       <profiles>
-        <profile id="2bd6-3070-712b-7d4e" name="Slaughterpriest" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="01 Unit">
+        <profile id="2bd6-3070-712b-7d4e" name="Slaughterpriest" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
             <characteristic name="Move" typeId="8655-6213-2824-1752">6&quot;</characteristic>
             <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">6</characteristic>
@@ -5822,7 +5832,7 @@
             <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">5+</characteristic>
           </characteristics>
         </profile>
-        <profile id="7170-5f82-7e6a-75ae" name="Scorn of Sorcery" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+        <profile id="7170-5f82-7e6a-75ae" name="Scorn of Sorcery" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">This model can attempt to unbind one spell in the enemy hero phase in the same manner as a WIZARD. In addition, this model can attempt to dispel one endless spell at the start of your hero phase in the same manner as a WIZARD.</characteristic>
           </characteristics>
@@ -5864,7 +5874,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="81d5-dc2a-7865-ad6b" type="max"/>
               </constraints>
               <profiles>
-                <profile id="83a9-f656-dc97-76c5" name="Hackblade" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+                <profile id="83a9-f656-dc97-76c5" name="Hackblade" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                     <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
@@ -5875,7 +5885,7 @@
                     <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
                   </characteristics>
                 </profile>
-                <profile id="78be-aadd-7b5c-2040" name="Wrath-hammer" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+                <profile id="78be-aadd-7b5c-2040" name="Wrath-hammer" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                     <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">3&quot;</characteristic>
@@ -5896,7 +5906,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f806-ff4e-175f-2455" type="max"/>
               </constraints>
               <profiles>
-                <profile id="5f42-2e1a-17e9-2d5d" name="Bloodbathed Axe" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+                <profile id="5f42-2e1a-17e9-2d5d" name="Bloodbathed Axe" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                     <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">2&quot;</characteristic>
@@ -5930,7 +5940,7 @@
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4ae3-287a-8bd9-ce00" type="max"/>
       </constraints>
       <profiles>
-        <profile id="5c7a-7cb9-d790-214d" name="Valkia the Bloody" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="01 Unit">
+        <profile id="5c7a-7cb9-d790-214d" name="Valkia the Bloody" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
             <characteristic name="Move" typeId="8655-6213-2824-1752">12&quot;</characteristic>
             <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">5</characteristic>
@@ -5938,12 +5948,12 @@
             <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">3+</characteristic>
           </characteristics>
         </profile>
-        <profile id="6211-1c0d-6221-5b5b" name="The Gaze of Khorne" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+        <profile id="6211-1c0d-6221-5b5b" name="The Gaze of Khorne" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">You can re-roll battleshock tests for friendly KHORNE MORTAL units wholly within 16&quot; of this model. However, if you do so and that unit still fails the battleshock test after the re-roll has been made, add D3 to the number of models that flee.</characteristic>
           </characteristics>
         </profile>
-        <profile id="fd1d-5b4c-00d3-6ee6" name="Daemonshield" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+        <profile id="fd1d-5b4c-00d3-6ee6" name="Daemonshield" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Subtract 1 from wound rolls for attacks made with melee weapons that target this model.</characteristic>
           </characteristics>
@@ -5973,7 +5983,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c95-c70c-95e8-bd55" type="max"/>
           </constraints>
           <profiles>
-            <profile id="68c0-a5f6-3749-3de9" name="Slaupnir" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+            <profile id="68c0-a5f6-3749-3de9" name="Slaupnir" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                 <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">2&quot;</characteristic>
@@ -5984,7 +5994,7 @@
                 <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
               </characteristics>
             </profile>
-            <profile id="aacc-d080-0e1b-e39a" name="The Spear Slaupnir" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+            <profile id="aacc-d080-0e1b-e39a" name="The Spear Slaupnir" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
               <characteristics>
                 <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Slaupnir has a Damage characteristic of D3 instead of 1 if this model made a charge move in the same turn.</characteristic>
               </characteristics>
@@ -6164,7 +6174,7 @@
     </selectionEntry>
     <selectionEntry id="4fc6-7808-d334-a716" name="Wrathmongers" hidden="false" collective="false" type="unit">
       <profiles>
-        <profile id="75c1-6898-67e9-13c2" name="Wrathmonger" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="01 Unit">
+        <profile id="75c1-6898-67e9-13c2" name="Wrathmonger" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
             <characteristic name="Move" typeId="8655-6213-2824-1752">5&quot;</characteristic>
             <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">3</characteristic>
@@ -6172,17 +6182,17 @@
             <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">5+</characteristic>
           </characteristics>
         </profile>
-        <profile id="5dd8-4b27-6605-2992" name="Wrathmaster" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+        <profile id="5dd8-4b27-6605-2992" name="Wrathmaster" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">1 model in this unit can be a Wrathmaster. Add 1 to the Attacks characteristic of that model&apos;s Wrath-flails.</characteristic>
           </characteristics>
         </profile>
-        <profile id="1a10-e5b6-f319-6702" name="Crimson Haze" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+        <profile id="1a10-e5b6-f319-6702" name="Crimson Haze" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Add 1 to the Attacks characteristic of melee weapons used by KHORNE units while they are wholly within 8&quot; of any units with this ability. This ability has no effect on WRATHMONGERS.</characteristic>
           </characteristics>
         </profile>
-        <profile id="0858-2443-a610-441c" name="Bloodfury" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+        <profile id="0858-2443-a610-441c" name="Bloodfury" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If a model in this unit is slain, before it is removed from play roll a dice for each enemy uniit within 1&quot; of that model. Add 1 to the dice roll if 2 or more models from that enemy unit are within 1&quot; of the slain model. On a 1 nothing happens. On a 2-5 that enemy unit suffers 1 mortal wound after all of its attacks have been resolved. On a 6+ that enemy unit suffers D3 mortal wounds after all of its attacks have been resolved.</characteristic>
           </characteristics>
@@ -6216,7 +6226,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c95f-d964-2b73-2834" type="max"/>
           </constraints>
           <profiles>
-            <profile id="8bbc-f5c7-1bb6-c729" name="Wrath-flails" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+            <profile id="8bbc-f5c7-1bb6-c729" name="Wrath-flails" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                 <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">2&quot;</characteristic>
@@ -6370,35 +6380,35 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f21c-ea3c-b9c8-8c19" type="min"/>
           </constraints>
           <profiles>
-            <profile id="8395-ca45-a218-f86e" name="00-04" hidden="false" typeId="cb2f-d4ea-a554-595e" typeName="Exalted Greater Daemon of Khorne">
+            <profile id="8395-ca45-a218-f86e" name="00-04" hidden="false" typeId="cb2f-d4ea-a554-595e" typeName="Daemon of Khorne Wounds">
               <characteristics>
                 <characteristic name="Move" typeId="84ef-e141-575e-918a">12&quot;</characteristic>
                 <characteristic name="Lash of Khorne" typeId="170b-aaaa-ada1-3cb6">5</characteristic>
                 <characteristic name="Migthy Axe of Khorne" typeId="93c1-59b7-c07b-e82a">2+</characteristic>
               </characteristics>
             </profile>
-            <profile id="7be1-edc5-84a8-2733" name="05-08" hidden="false" typeId="cb2f-d4ea-a554-595e" typeName="Exalted Greater Daemon of Khorne">
+            <profile id="7be1-edc5-84a8-2733" name="05-08" hidden="false" typeId="cb2f-d4ea-a554-595e" typeName="Daemon of Khorne Wounds">
               <characteristics>
                 <characteristic name="Move" typeId="84ef-e141-575e-918a">10&quot;</characteristic>
                 <characteristic name="Lash of Khorne" typeId="170b-aaaa-ada1-3cb6">4</characteristic>
                 <characteristic name="Migthy Axe of Khorne" typeId="93c1-59b7-c07b-e82a">2+</characteristic>
               </characteristics>
             </profile>
-            <profile id="969c-4c81-03a8-3743" name="09-12" hidden="false" typeId="cb2f-d4ea-a554-595e" typeName="Exalted Greater Daemon of Khorne">
+            <profile id="969c-4c81-03a8-3743" name="09-12" hidden="false" typeId="cb2f-d4ea-a554-595e" typeName="Daemon of Khorne Wounds">
               <characteristics>
                 <characteristic name="Move" typeId="84ef-e141-575e-918a">9&quot;</characteristic>
                 <characteristic name="Lash of Khorne" typeId="170b-aaaa-ada1-3cb6">4</characteristic>
                 <characteristic name="Migthy Axe of Khorne" typeId="93c1-59b7-c07b-e82a">3+</characteristic>
               </characteristics>
             </profile>
-            <profile id="17b5-2125-02db-a560" name="13-16" hidden="false" typeId="cb2f-d4ea-a554-595e" typeName="Exalted Greater Daemon of Khorne">
+            <profile id="17b5-2125-02db-a560" name="13-16" hidden="false" typeId="cb2f-d4ea-a554-595e" typeName="Daemon of Khorne Wounds">
               <characteristics>
                 <characteristic name="Move" typeId="84ef-e141-575e-918a">8&quot;</characteristic>
                 <characteristic name="Lash of Khorne" typeId="170b-aaaa-ada1-3cb6">3</characteristic>
                 <characteristic name="Migthy Axe of Khorne" typeId="93c1-59b7-c07b-e82a">3+</characteristic>
               </characteristics>
             </profile>
-            <profile id="0657-b04e-2718-f77c" name="17+" hidden="false" typeId="cb2f-d4ea-a554-595e" typeName="Exalted Greater Daemon of Khorne">
+            <profile id="0657-b04e-2718-f77c" name="17+" hidden="false" typeId="cb2f-d4ea-a554-595e" typeName="Daemon of Khorne Wounds">
               <characteristics>
                 <characteristic name="Move" typeId="84ef-e141-575e-918a">7&quot;</characteristic>
                 <characteristic name="Lash of Khorne" typeId="170b-aaaa-ada1-3cb6">3</characteristic>
@@ -6434,7 +6444,7 @@
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a6fb-2573-cd24-8e11" type="max"/>
       </constraints>
       <profiles>
-        <profile id="2f8a-b830-fa9a-6ed1" name="No Respite" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+        <profile id="2f8a-b830-fa9a-6ed1" name="No Respite" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If a model from this unit is slain inthe combat phase, before that model is removed formplay, that model can make a pile-in move and then attack with all of the melee weapons it is armed with.</characteristic>
           </characteristics>
@@ -6610,7 +6620,7 @@
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4b33-9186-975a-e548" type="max"/>
       </constraints>
       <profiles>
-        <profile id="4340-39c9-2c1a-e2f5" name="Skaarac the Bloodborn" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="01 Unit">
+        <profile id="4340-39c9-2c1a-e2f5" name="Skaarac the Bloodborn" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
             <characteristic name="Move" typeId="8655-6213-2824-1752">*</characteristic>
             <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">16</characteristic>
@@ -6634,27 +6644,27 @@
             <characteristic name="Variable 4" typeId="ad26-bf56-95c4-80f1">7</characteristic>
           </characteristics>
         </profile>
-        <profile id="df50-a483-52ae-b672" name="Towering Horror" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+        <profile id="df50-a483-52ae-b672" name="Towering Horror" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Subtract 1 from the Bravery characteristic of enemy units while they are within 12&quot; of this model.</characteristic>
           </characteristics>
         </profile>
-        <profile id="e6c5-0e55-8d26-0786" name="Life Eater" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+        <profile id="e6c5-0e55-8d26-0786" name="Life Eater" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">At the end of the combat phase, if any enemy models were slain by wounds inflicted by this model’s attacks in that combat phase, you can heal up to D3 wounds allocated to this model.</characteristic>
           </characteristics>
         </profile>
-        <profile id="c792-aa5f-9a5a-5853" name="Infernal Iron" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+        <profile id="c792-aa5f-9a5a-5853" name="Infernal Iron" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Subtract 2 from casting rolls for enemy Wizards while they are within 12&quot; of this model.</characteristic>
           </characteristics>
         </profile>
-        <profile id="9276-658e-e5c8-cacb" name="Undying Hate" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+        <profile id="9276-658e-e5c8-cacb" name="Undying Hate" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If this model is slain, before removing the model from play, roll a dice for each enemy model within 3&quot; of this model. On a 4+, that model’s unit suffers 1 mortal wound. This model is then removed from play.</characteristic>
           </characteristics>
         </profile>
-        <profile id="6c8a-d121-e6ad-4a57" name="Call of the Skull Throne" hidden="false" typeId="f71f-b0a4-730e-ced3" typeName="07 Ability (Command)">
+        <profile id="6c8a-d121-e6ad-4a57" name="Call of the Skull Throne" hidden="false" typeId="f71f-b0a4-730e-ced3" typeName="Command Abilities">
           <characteristics>
             <characteristic name="Command Ability Details" typeId="1b71-4c83-4e8c-093f">You can use this command ability at the start of your charge phase if this model is on the battlefield. If you do so, you can re-roll charge rolls for friendly Khorne units while they are wholly within 12&quot; of this model in that charge phase.</characteristic>
           </characteristics>
@@ -6707,7 +6717,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1072-535a-8501-fb53" type="max"/>
           </constraints>
           <profiles>
-            <profile id="cb63-b56b-b37d-6de1" name="Burning Blood" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+            <profile id="cb63-b56b-b37d-6de1" name="Burning Blood" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Missle</characteristic>
                 <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">8&quot;</characteristic>
@@ -6729,7 +6739,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6fd-087a-6463-3b7a" type="max"/>
           </constraints>
           <profiles>
-            <profile id="40a9-daae-f616-95eb" name="Brutal Blades" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+            <profile id="40a9-daae-f616-95eb" name="Brutal Blades" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                 <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">2&quot;</characteristic>
@@ -6751,7 +6761,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f6b-3251-69b7-a483" type="max"/>
           </constraints>
           <profiles>
-            <profile id="f37d-34b5-6489-0132" name="Thunderous Hooves" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+            <profile id="f37d-34b5-6489-0132" name="Thunderous Hooves" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                 <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
@@ -6873,35 +6883,35 @@
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Each time a Hellforged Claw attack hits a HERO or a MONSTER, you and your opponent both secretly use a dice to select a number and hide it underneath your hand. Reveal the dice on the count of three; if they are the same, the model grabbed by the claw suffers 6 mortal wounds instead of resolving the damage normally.</characteristic>
           </characteristics>
         </profile>
-        <profile id="481b-b7e6-9c60-11da" name="00-03" hidden="false" typeId="9c58-8858-0964-2b7d" typeName="Soul Grinder Wound Table">
+        <profile id="481b-b7e6-9c60-11da" name="00-03" hidden="false" typeId="9c58-8858-0964-2b7d" typeName="Soul Grinder Wounds Suffered">
           <characteristics>
             <characteristic name="Move" typeId="b0a4-7abe-3239-c92a">12&quot;</characteristic>
             <characteristic name="Harvester Cannon" typeId="ebc9-9350-e12b-84a9">D6</characteristic>
             <characteristic name="Piston-driven Legs" typeId="1394-0752-952b-55e7">6</characteristic>
           </characteristics>
         </profile>
-        <profile id="2fcc-5854-2641-8757" name="04-06" hidden="false" typeId="9c58-8858-0964-2b7d" typeName="Soul Grinder Wound Table">
+        <profile id="2fcc-5854-2641-8757" name="04-06" hidden="false" typeId="9c58-8858-0964-2b7d" typeName="Soul Grinder Wounds Suffered">
           <characteristics>
             <characteristic name="Move" typeId="b0a4-7abe-3239-c92a">10&quot;</characteristic>
             <characteristic name="Harvester Cannon" typeId="ebc9-9350-e12b-84a9">D6</characteristic>
             <characteristic name="Piston-driven Legs" typeId="1394-0752-952b-55e7">5</characteristic>
           </characteristics>
         </profile>
-        <profile id="060e-f0bb-53f6-87d2" name="07-10" hidden="false" typeId="9c58-8858-0964-2b7d" typeName="Soul Grinder Wound Table">
+        <profile id="060e-f0bb-53f6-87d2" name="07-10" hidden="false" typeId="9c58-8858-0964-2b7d" typeName="Soul Grinder Wounds Suffered">
           <characteristics>
             <characteristic name="Move" typeId="b0a4-7abe-3239-c92a">8&quot;</characteristic>
             <characteristic name="Harvester Cannon" typeId="ebc9-9350-e12b-84a9">D3</characteristic>
             <characteristic name="Piston-driven Legs" typeId="1394-0752-952b-55e7">4</characteristic>
           </characteristics>
         </profile>
-        <profile id="0530-79b2-68f9-42e4" name="11-13" hidden="false" typeId="9c58-8858-0964-2b7d" typeName="Soul Grinder Wound Table">
+        <profile id="0530-79b2-68f9-42e4" name="11-13" hidden="false" typeId="9c58-8858-0964-2b7d" typeName="Soul Grinder Wounds Suffered">
           <characteristics>
             <characteristic name="Move" typeId="b0a4-7abe-3239-c92a">7&quot;</characteristic>
             <characteristic name="Harvester Cannon" typeId="ebc9-9350-e12b-84a9">D3</characteristic>
             <characteristic name="Piston-driven Legs" typeId="1394-0752-952b-55e7">3</characteristic>
           </characteristics>
         </profile>
-        <profile id="167d-3135-3715-2e4e" name="14+" hidden="false" typeId="9c58-8858-0964-2b7d" typeName="Soul Grinder Wound Table">
+        <profile id="167d-3135-3715-2e4e" name="14+" hidden="false" typeId="9c58-8858-0964-2b7d" typeName="Soul Grinder Wounds Suffered">
           <characteristics>
             <characteristic name="Move" typeId="b0a4-7abe-3239-c92a">6&quot;</characteristic>
             <characteristic name="Harvester Cannon" typeId="ebc9-9350-e12b-84a9">1</characteristic>
@@ -6923,7 +6933,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ae4-bee5-5923-8204" type="max"/>
           </constraints>
           <profiles>
-            <profile id="cef5-ed61-4010-ae63" name="Harvester Cannon" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+            <profile id="cef5-ed61-4010-ae63" name="Harvester Cannon" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Missile</characteristic>
                 <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">16&quot;</characteristic>
@@ -6945,7 +6955,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b02-93cd-ca84-881a" type="max"/>
           </constraints>
           <profiles>
-            <profile id="37cc-1ede-c533-bed7" name="Phlegm Bombardment" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+            <profile id="37cc-1ede-c533-bed7" name="Phlegm Bombardment" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Missile</characteristic>
                 <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">20&quot;</characteristic>
@@ -6967,7 +6977,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c363-8617-688f-1314" type="max"/>
           </constraints>
           <profiles>
-            <profile id="5a73-4777-7cc9-88fe" name="Hellforged Claw" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+            <profile id="5a73-4777-7cc9-88fe" name="Hellforged Claw" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                 <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">2&quot;</characteristic>
@@ -6989,7 +6999,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="793a-7d43-5061-b28b" type="max"/>
           </constraints>
           <profiles>
-            <profile id="ef06-3db7-b4ba-3642" name="Piston-driven Legs" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+            <profile id="ef06-3db7-b4ba-3642" name="Piston-driven Legs" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                 <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
@@ -7018,7 +7028,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="652f-2f9d-1c6e-8bb2" type="max"/>
               </constraints>
               <profiles>
-                <profile id="27be-55c7-a503-512b" name="Warpmetal Blade" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+                <profile id="27be-55c7-a503-512b" name="Warpmetal Blade" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                     <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">2&quot;</characteristic>
@@ -7039,7 +7049,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01e2-b1ae-e3cf-16dd" type="max"/>
               </constraints>
               <profiles>
-                <profile id="b2eb-71d2-1323-725d" name="Daemonbone Talon" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+                <profile id="b2eb-71d2-1323-725d" name="Daemonbone Talon" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                     <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">2&quot;</characteristic>
@@ -7072,31 +7082,31 @@
             <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">5+</characteristic>
           </characteristics>
         </profile>
-        <profile id="7cc2-2b5f-b44a-1cbe" name="00-02" hidden="false" typeId="65ac-ba71-6bc2-4365" typeName="Gigantic Chaos Spawn Wound Table">
+        <profile id="7cc2-2b5f-b44a-1cbe" name="00-02" hidden="false" typeId="65ac-ba71-6bc2-4365" typeName="Gigantic Chaos Spawn Wounds Suffered">
           <characteristics>
             <characteristic name="Move" typeId="4a7e-f7c8-6c21-acad">3D6&quot;</characteristic>
             <characteristic name="Crushing Jaws" typeId="8ea1-0116-40b5-1b41">-2</characteristic>
           </characteristics>
         </profile>
-        <profile id="33eb-9e44-5f66-fa7f" name="03-04" hidden="false" typeId="65ac-ba71-6bc2-4365" typeName="Gigantic Chaos Spawn Wound Table">
+        <profile id="33eb-9e44-5f66-fa7f" name="03-04" hidden="false" typeId="65ac-ba71-6bc2-4365" typeName="Gigantic Chaos Spawn Wounds Suffered">
           <characteristics>
             <characteristic name="Move" typeId="4a7e-f7c8-6c21-acad">2D6&quot;</characteristic>
             <characteristic name="Crushing Jaws" typeId="8ea1-0116-40b5-1b41">-2</characteristic>
           </characteristics>
         </profile>
-        <profile id="1194-899e-620d-ba10" name="05-07" hidden="false" typeId="65ac-ba71-6bc2-4365" typeName="Gigantic Chaos Spawn Wound Table">
+        <profile id="1194-899e-620d-ba10" name="05-07" hidden="false" typeId="65ac-ba71-6bc2-4365" typeName="Gigantic Chaos Spawn Wounds Suffered">
           <characteristics>
             <characteristic name="Move" typeId="4a7e-f7c8-6c21-acad">2D6&quot;</characteristic>
             <characteristic name="Crushing Jaws" typeId="8ea1-0116-40b5-1b41">-1</characteristic>
           </characteristics>
         </profile>
-        <profile id="6d31-c8d3-d0cd-d9f0" name="08-09" hidden="false" typeId="65ac-ba71-6bc2-4365" typeName="Gigantic Chaos Spawn Wound Table">
+        <profile id="6d31-c8d3-d0cd-d9f0" name="08-09" hidden="false" typeId="65ac-ba71-6bc2-4365" typeName="Gigantic Chaos Spawn Wounds Suffered">
           <characteristics>
             <characteristic name="Move" typeId="4a7e-f7c8-6c21-acad">D6&quot;</characteristic>
             <characteristic name="Crushing Jaws" typeId="8ea1-0116-40b5-1b41">-1</characteristic>
           </characteristics>
         </profile>
-        <profile id="ffdd-40b7-3626-8170" name="10+" hidden="false" typeId="65ac-ba71-6bc2-4365" typeName="Gigantic Chaos Spawn Wound Table">
+        <profile id="ffdd-40b7-3626-8170" name="10+" hidden="false" typeId="65ac-ba71-6bc2-4365" typeName="Gigantic Chaos Spawn Wounds Suffered">
           <characteristics>
             <characteristic name="Move" typeId="4a7e-f7c8-6c21-acad">D6&quot;</characteristic>
             <characteristic name="Crushing Jaws" typeId="8ea1-0116-40b5-1b41">-</characteristic>
@@ -7131,7 +7141,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7650-11cc-e1c7-d08f" type="max"/>
           </constraints>
           <profiles>
-            <profile id="1b7b-81af-48d9-87ba" name="Freakish Mutations" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+            <profile id="1b7b-81af-48d9-87ba" name="Freakish Mutations" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                 <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">2&quot;</characteristic>
@@ -7153,7 +7163,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="138a-8759-162c-20cc" type="max"/>
           </constraints>
           <profiles>
-            <profile id="d57e-9a48-0056-8edb" name="Slavering Maws" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+            <profile id="d57e-9a48-0056-8edb" name="Slavering Maws" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                 <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
@@ -8852,7 +8862,7 @@
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b58-3315-b9a3-3b1d" type="max"/>
       </constraints>
       <profiles>
-        <profile id="e789-734d-0ab4-a102" name="Hellblade" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="03 Weapon">
+        <profile id="e789-734d-0ab4-a102" name="Hellblade" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
           <characteristics>
             <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
             <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
@@ -8863,7 +8873,7 @@
             <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
           </characteristics>
         </profile>
-        <profile id="2254-f481-2177-140a" name="Decapitating Blow" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="08 Ability (Unit)">
+        <profile id="2254-f481-2177-140a" name="Decapitating Blow" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If the unmodified hit roll for an attack made with a Hellblade is 6, that attack inflicts 1 mortal wound on the target in addition to any normal damage.</characteristic>
           </characteristics>
@@ -8954,15 +8964,101 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b424-3ed7-87f7-928d" name="Judgements of Khorne" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="b9e5-d82c-126d-7dc7" name="Judgement: Bleeding Icon" hidden="false" collective="false" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5927-9ec9-7b17-bc38" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2ace-251e-68f3-c413" type="max"/>
       </constraints>
-      <entryLinks>
-        <entryLink id="39a0-37d9-9d16-a267" name="Judgements of Khorne" hidden="false" collective="false" targetId="a4eb-2401-1eb0-076c" type="selectionEntryGroup"/>
-      </entryLinks>
+      <profiles>
+        <profile id="316b-5e10-5ce0-655a" name="Summon Bleeding Icon" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
+          <characteristics>
+            <characteristic name="Casting Value" typeId="2508-b604-1258-a920">4+</characteristic>
+            <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If this judgement roll is successful, set up this model wholly within 8&quot; of the performing KHORNE PRIEST.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="55ac-ac9e-b8dd-f2fd" name="Drifting Menace" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">When this judgement is set up, the player who set it up can immediately make a move with it. In addition, at the start of each of their subsequent hero phases, the player who set this judgement up can make a move with it if it is still on the battlefield. When you move this judgement, it can move up to 8&quot; and can fly.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="dca6-bf86-5eb7-b305" name="Crushing Retribution" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">After this model has moved, each unit that has any models it passed across, and each other unit that is within 1&quot; of it at the end of its move, suffers D3 mortal wounds.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="f97e-8bf2-c45f-0e2e" name="Sigil of Doom" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If a unit fails a battleshock test within 3&quot; of any models with this ability, add D3 to the number of models that flee. This ability has no effect on KHORNE units.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="15f1-1f74-a24f-b55f" name="Fly" hidden="false" targetId="8e0c-cbe4-27be-8a30" type="profile"/>
+      </infoLinks>
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="40.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ebf5-a5f2-89cc-f846" name="Judgement: Hexgorger Skulls" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bd64-b4f4-763f-e447" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="266d-4849-95cc-8a93" name="Summon Hexgorger Skulls" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
+          <characteristics>
+            <characteristic name="Casting Value" typeId="2508-b604-1258-a920">3+</characteristic>
+            <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully performed set up both Hexgorger Skull models within 6&quot; of each other and wholly within 8&quot; of that KHORNE PRIEST.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="0059-674a-8999-3c5f" name="Compelled by Hate" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">When this judgement is set up, the player who set it up can immediately make a move with it. In addition, at the start of each of their subsequent hero phases, the player who set this judgement up can make a move with it if it is still on the battlefield. When you move this judgement, it can move up to 8&quot; and can fly. Both models from this judgement must finish any move within 6&quot; of each other. </characteristic>
+          </characteristics>
+        </profile>
+        <profile id="4def-ee5a-0167-46bf" name="Hexgorgers" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Subtract 2 from casting rolls for WIZARDS while they are within 12&quot; of any Hexgorger Skulls models. In addition, if a WIZARD attempts to cast a spell while it is within 12&quot; of both models from the same Hexgorger Skulls Judgement of Khorne, and the casting roll is an unmodified 8, then that casting attempt is not successful, that WIZARD no longer knows that spell, and each WIZARD within 12&quot; of that Judgement of Khorne suffers D6 mortal wounds. </characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="ce10-81ef-8f11-4370" name="Fly" hidden="false" targetId="8e0c-cbe4-27be-8a30" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="40.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3d95-cf6d-c8cc-1a6c" name="Judgement: Wrath-Axe" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8466-4929-aba1-605a" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="93fe-d5b5-be1d-89a6" name="Summon Wrath-Axe" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
+          <characteristics>
+            <characteristic name="Casting Value" typeId="2508-b604-1258-a920">5+</characteristic>
+            <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If the judgement roll is successful, set up this model wholly within 8&quot; of the performing KHORNE PRIEST.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="04dc-13cf-bc65-07af" name="Flung With Fury" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">When this judgement is set up, the player who set it up can immediately make a move with it. In addition, at the start of each of their subsequent hero phases, the player who set this judgement up can make a move with it if it is still on the battlefield. When you move this judgement, it can move up to 8&quot; and can fly.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="fda8-fbfb-d686-8f51" name="Hatred&apos;s Edge" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">After this model has moved, roll a dice for each unit that has any models it passed across. On a 2+ that unit suffers D3 mortal wounds. Then the player that set up this model picks 1 enemy unit within 3&quot; of this model and rolls a dice (the enemy unit may be one that this model passed across). On a 2+ that enemy unit suffers D6 mortal wounds.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="6f63-b341-6ec3-9c2c" name="Reality Cleaved" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Subtract 1 from hit rolls for attacks made by units within 3&quot; of this model. This ability has no effect on KHORNE units.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="973f-3808-3364-84ec" name="Fly" hidden="false" targetId="8e0c-cbe4-27be-8a30" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="60.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -9638,107 +9734,6 @@
           </categoryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-    </selectionEntryGroup>
-    <selectionEntryGroup id="a4eb-2401-1eb0-076c" name="Judgements of Khorne" hidden="false" collective="false">
-      <selectionEntries>
-        <selectionEntry id="6dc9-395e-b4f1-6286" name="Hexgorger Skulls" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51b9-4194-72e4-f2f5" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="c114-158d-aadd-4da0" name="Summon Hexgorger Skulls" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
-              <characteristics>
-                <characteristic name="Casting Value" typeId="2508-b604-1258-a920">3+</characteristic>
-                <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully performed set up both Hexgorger Skull models within 6&quot; of each other and wholly within 8&quot; of that KHORNE PRIEST.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="d58d-41e9-7ce7-27b1" name="Compelled by Hate" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">When this judgement is set up, the player who set it up can immediately make a move with it. In addition, at the start of each of their subsequent hero phases, the player who set this judgement up can make a move with it if it is still on the battlefield. When you move this judgement, it can move up to 8&quot; and can fly. Both models from this judgement must finish any move within 6&quot; of each other. </characteristic>
-              </characteristics>
-            </profile>
-            <profile id="b5a1-6cc8-c1c3-f934" name="Hexgorgers" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Subtract 2 from casting rolls for WIZARDS while they are within 12&quot; of any Hexgorger Skulls models. In addition, if a WIZARD attempts to cast a spell while it is within 12&quot; of both models from the same Hexgorger Skulls Judgement of Khorne, and the casting roll is an unmodified 8, then that casting attempt is not successful, that WIZARD no longer knows that spell, and each WIZARD within 12&quot; of that Judgement of Khorne suffers D6 mortal wounds. </characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <infoLinks>
-            <infoLink id="d10c-43ff-efc2-f338" name="Fly" hidden="false" targetId="8e0c-cbe4-27be-8a30" type="profile"/>
-          </infoLinks>
-          <costs>
-            <cost name="pts" typeId="points" value="40.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="b0ed-f8cb-5baf-5f6b" name="Bleeding Icon" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1bd-5297-8baf-a9b8" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="5621-1561-04a1-714d" name="Summon Bleeding Icon" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
-              <characteristics>
-                <characteristic name="Casting Value" typeId="2508-b604-1258-a920">4+</characteristic>
-                <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If this judgement roll is successful, set up this model wholly within 8&quot; of the performing KHORNE PRIEST.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="870d-8b9b-2bab-cac6" name="Drifting Menace" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">When this judgement is set up, the player who set it up can immediately make a move with it. In addition, at the start of each of their subsequent hero phases, the player who set this judgement up can make a move with it if it is still on the battlefield. When you move this judgement, it can move up to 8&quot; and can fly.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="21db-267d-3de6-9863" name="Crushing Retribution" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">After this model has moved, each unit that has any models it passed across, and each other unit that is within 1&quot; of it at the end of its move, suffers D3 mortal wounds.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="eef0-8b17-ee56-f488" name="Sigil of Doom" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If a unit fails a battleshock test within 3&quot; of any models with this ability, add D3 to the number of models that flee. This ability has no effect on KHORNE units.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <infoLinks>
-            <infoLink id="0a9e-009b-4c42-eb19" name="Fly" hidden="false" targetId="8e0c-cbe4-27be-8a30" type="profile"/>
-          </infoLinks>
-          <costs>
-            <cost name="pts" typeId="points" value="40.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="0011-a12e-7071-96ff" name="Wrath-Axe" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4fb8-a432-1f38-7065" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="81d2-ae28-9afd-6f67" name="Summon Wrath-Axe" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
-              <characteristics>
-                <characteristic name="Casting Value" typeId="2508-b604-1258-a920">5+</characteristic>
-                <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If the judgement roll is successful, set up this model wholly within 8&quot; of the performing KHORNE PRIEST.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="4552-bff4-6228-1055" name="Flung With Fury" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">When this judgement is set up, the player who set it up can immediately make a move with it. In addition, at the start of each of their subsequent hero phases, the player who set this judgement up can make a move with it if it is still on the battlefield. When you move this judgement, it can move up to 8&quot; and can fly.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="1223-e60a-f987-5e0b" name="Hatred&apos;s Edge" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">After this model has moved, roll a dice for each unit that has any models it passed across. On a 2+ that unit suffers D3 mortal wounds. Then the player that set up this model picks 1 enemy unit within 3&quot; of this model and rolls a dice (the enemy unit may be one that this model passed across). On a 2+ that enemy unit suffers D6 mortal wounds.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="ec75-35ae-5808-5bc5" name="Reality Cleaved" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Subtract 1 from hit rolls for attacks made by units within 3&quot; of this model. This ability has no effect on KHORNE units.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <infoLinks>
-            <infoLink id="2e30-4db2-2ce4-c9ac" name="Fly" hidden="false" targetId="8e0c-cbe4-27be-8a30" type="profile"/>
-          </infoLinks>
-          <costs>
-            <cost name="pts" typeId="points" value="60.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>

--- a/Chaos - Skaven.cat
+++ b/Chaos - Skaven.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="bcc4-c671-9435-d259" name="Chaos - Skaven" revision="22" battleScribeVersion="2.02" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://gitter.im/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="23" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="bcc4-c671-9435-d259" name="Chaos - Skaven" revision="23" battleScribeVersion="2.02" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://gitter.im/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="23" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="bcc4-c671-pubd1e1" name="Chaos Battletome: Skaven"/>
     <publication id="bcc4-c671-pubd1e6847" name="Forgeworld: Monstrous Arcanum"/>
@@ -1553,7 +1553,7 @@
         <categoryLink id="b3c8-474f-5ce2-2963" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="6984-1202-5615-27d8" name="Endless Spells: Skaven" hidden="false" collective="false" targetId="bbd0-f7c8-f09a-44ab" type="selectionEntry">
+    <entryLink id="6984-1202-5615-27d8" name="Endless Spell: Bell of Doom" hidden="false" collective="false" targetId="4fe6-46f9-96bb-8673" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="dd83-f0be-f239-d01e" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
       </categoryLinks>
@@ -1591,6 +1591,16 @@
     <entryLink id="8d37-5f2c-b117-d837" name="Battalion: Skratchnik&apos;s Warpcoven" hidden="false" collective="false" targetId="fb78-11f9-a9bd-6cff" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="f636-d633-e1ab-0168" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="fd93-0c87-c5df-1452" name="Endless Spell: Vermintide" hidden="false" collective="false" targetId="031f-bc9f-50b9-e33e" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="0f1f-e3e2-a332-d007" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="eb3c-4b67-ef69-9aec" name="Endless Spell: Warp Lightning Vortex" hidden="false" collective="false" targetId="7c5e-cf5a-0321-fa94" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="3949-670e-fe99-c7d1" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -9503,18 +9513,10 @@
         <cost name="pts" typeId="points" value="160.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="bbd0-f7c8-f09a-44ab" name="Endless Spells: Skaven" hidden="false" collective="false" type="upgrade">
-      <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eefb-6f99-3d18-7d61" type="max"/>
-      </constraints>
-      <entryLinks>
-        <entryLink id="ffad-0d35-5ae4-a3f6" name="Endless Spells: Skaven" hidden="false" collective="false" targetId="fc44-0fd4-7d56-adb8" type="selectionEntryGroup"/>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="031f-bc9f-50b9-e33e" name="Endless Spell: Vermintide" publicationId="bcc4-c671-pubd1e1" page="125" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="33ee-b399-385e-f0fd" type="max"/>
+      </constraints>
       <profiles>
         <profile id="8b90-4782-e4a3-fd7d" name="Summon Vermintide" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
           <characteristics>
@@ -9552,6 +9554,9 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="7c5e-cf5a-0321-fa94" name="Endless Spell: Warp Lightning Vortex" publicationId="bcc4-c671-pubd1e1" page="125" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="91a8-23e1-525a-e908" type="max"/>
+      </constraints>
       <profiles>
         <profile id="ced7-6f91-5cc7-a855" name="Summon Warp Lightning Vortex" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
           <characteristics>
@@ -9579,6 +9584,9 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="4fe6-46f9-96bb-8673" name="Endless Spell: Bell of Doom" publicationId="bcc4-c671-pubd1e1" page="126" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3dfe-4536-9992-ecd4" type="max"/>
+      </constraints>
       <profiles>
         <profile id="fe7e-280f-52dc-5cae" name="Apocolyptic Doom" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
@@ -10449,28 +10457,6 @@
           </costs>
         </selectionEntry>
       </selectionEntries>
-    </selectionEntryGroup>
-    <selectionEntryGroup id="fc44-0fd4-7d56-adb8" name="Endless Spells: Skaven" hidden="false" collective="false">
-      <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5dd1-3d25-15e4-b32d" type="min"/>
-      </constraints>
-      <entryLinks>
-        <entryLink id="c3ae-21bb-bea8-998a" name="Endless Spell: Bell of Doom" hidden="false" collective="false" targetId="4fe6-46f9-96bb-8673" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc92-ffaa-4c40-58e0" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="60f5-a9d6-266e-2237" name="Endless Spell: Vermintide" hidden="false" collective="false" targetId="031f-bc9f-50b9-e33e" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d925-918c-d76a-1a50" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="1d65-778d-fe0b-7ee4" name="Endless Spell: Warp Lightning Vortex" hidden="false" collective="false" targetId="7c5e-cf5a-0321-fa94" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f33f-1731-605e-b4ab" type="max"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="cddc-a28b-400e-345d" name="Traits: Treacherous Tactics (Clans Verminous)" hidden="false" collective="false">
       <modifiers>

--- a/Chaos - Slaanesh.cat
+++ b/Chaos - Slaanesh.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="357e-20c6-ad3a-d55d" name="Chaos - Slaanesh" revision="26" battleScribeVersion="2.02" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="23" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="357e-20c6-ad3a-d55d" name="Chaos - Slaanesh" revision="27" battleScribeVersion="2.02" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="23" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="357e-20c6-pubN65537" name="Grand Alliance Chaos"/>
     <publication id="357e-20c6-pubN71272" name="Grand Alliance: Chaos - Official Errata, December 2018"/>
@@ -220,7 +220,7 @@
         <categoryLink id="5c15-290f-48cd-2597" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="7924-6afc-c924-e09a" name="Endless Spells: Hedonites of Slaanesh" hidden="false" collective="false" targetId="4b13-7dc3-be7c-4dc8" type="selectionEntry">
+    <entryLink id="7924-6afc-c924-e09a" name="Endless Spell: Dreadful Visage" hidden="false" collective="false" targetId="a2b5-a614-1174-0ff6" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="f1ba-55ee-6ffc-f52d" name="Malign Sorcery" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
       </categoryLinks>
@@ -335,6 +335,16 @@
     <entryLink id="8d5f-05c5-39b9-8ddc" name="Fane of Slaanesh" hidden="false" collective="false" targetId="cba8-a2de-6bbf-6dcf" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="4b25-c81e-428c-54a1" name="SCENERY" hidden="false" targetId="8910-7c1d-6c74-37ff" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="06be-da00-93a8-a834" name="Endless Spell: Mesmerising Mirror" hidden="false" collective="false" targetId="c88a-81ae-8f7b-6bcc" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="b2a9-06e3-b2eb-7a2f" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="961a-6fc6-84ed-5350" name="Endless Spell: Wheels of Excruciation" hidden="false" collective="false" targetId="37c1-dc08-74bd-575f" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="5527-397c-11b5-46f4" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -2720,6 +2730,9 @@ If a unit that is affected by this ability is also affected by any rules that wo
       </costs>
     </selectionEntry>
     <selectionEntry id="a2b5-a614-1174-0ff6" name="Endless Spell: Dreadful Visage" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="80ae-b8f4-39b8-8c8a" type="max"/>
+      </constraints>
       <profiles>
         <profile id="ab93-e66d-496a-774e" name="Summon Dreadful Visage" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
           <characteristics>
@@ -2755,6 +2768,9 @@ If a unit that is affected by this ability is also affected by any rules that wo
       </costs>
     </selectionEntry>
     <selectionEntry id="c88a-81ae-8f7b-6bcc" name="Endless Spell: Mesmerising Mirror" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="521b-a625-ebe5-fb44" type="max"/>
+      </constraints>
       <profiles>
         <profile id="619e-03d2-c029-53a7" name="Summon Mesmerising Mirror" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
           <characteristics>
@@ -2791,6 +2807,9 @@ For example, if you rolled one 6 for a HERO, that HERO would suffer 1 x 1 = 1 mo
       </costs>
     </selectionEntry>
     <selectionEntry id="37c1-dc08-74bd-575f" name="Endless Spell: Wheels of Excruciation" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7664-1d4e-7abb-72c7" type="max"/>
+      </constraints>
       <profiles>
         <profile id="2131-d9ad-39dc-af26" name="Summon Wheels of Excruciation" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
           <characteristics>
@@ -3400,14 +3419,6 @@ If that HERO has an artefact of power, they can sacrifice that instead of suffer
         <cost name="pts" typeId="points" value="180.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="4b13-7dc3-be7c-4dc8" name="Endless Spells: Hedonites of Slaanesh" hidden="false" collective="false" type="upgrade">
-      <entryLinks>
-        <entryLink id="9aa5-f063-bf2d-5eb0" name="Endless Spells: Hedonites of Slaanesh" hidden="false" collective="false" targetId="413a-d65a-fbbc-02e7" type="selectionEntryGroup"/>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="c70c-2dcd-13c3-790c" name="Artefacts" hidden="false" collective="false">
@@ -3529,13 +3540,6 @@ If that HERO has an artefact of power, they can sacrifice that instead of suffer
             </modifier>
           </modifiers>
         </entryLink>
-      </entryLinks>
-    </selectionEntryGroup>
-    <selectionEntryGroup id="413a-d65a-fbbc-02e7" name="Endless Spells: Hedonites of Slaanesh" hidden="false" collective="false">
-      <entryLinks>
-        <entryLink id="cb24-f4e5-769b-af7a" name="Endless Spell: Dreadful Visage" hidden="false" collective="false" targetId="a2b5-a614-1174-0ff6" type="selectionEntry"/>
-        <entryLink id="7a20-fcd4-d7ab-ea94" name="Endless Spell: Mesmerising Mirror" hidden="false" collective="false" targetId="c88a-81ae-8f7b-6bcc" type="selectionEntry"/>
-        <entryLink id="d2e1-12a5-8e32-9a54" name="Endless Spell: Wheels of Excruciation" hidden="false" collective="false" targetId="37c1-dc08-74bd-575f" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="ead4-d349-3ccc-2c3e" name="Lores" hidden="false" collective="false">

--- a/Death - Flesh-eater Courts.cat
+++ b/Death - Flesh-eater Courts.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6d29-cde4-372b-08d3" name="Death: Flesh-eater Courts" revision="19" battleScribeVersion="2.02" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="7" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="6d29-cde4-372b-08d3" name="Death: Flesh-eater Courts" revision="20" battleScribeVersion="2.02" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="7" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="6d29-cde4-pubN65537" name="Battletome: Flesh-eater Courts 2019"/>
     <publication id="6d29-cde4-pubN65555" name="Battletome: Flesh-eater Courts"/>
@@ -428,7 +428,14 @@
         <categoryLink id="a883-deb2-c05f-f630" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="f2f6-3270-cf75-9c58" name="Endless Spells: Flesh-eater Courts" hidden="false" collective="false" targetId="141c-d056-e00c-32fe" type="selectionEntry">
+    <entryLink id="f2f6-3270-cf75-9c58" name="Endless Spell: Cadaverous Barricade" hidden="false" collective="false" targetId="b65c-000c-9036-af95" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="705f-02ae-f4f5-987a" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="2191-4f96-5e3c-edb5" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
       </categoryLinks>
@@ -488,6 +495,30 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="a5cd-e73d-f25f-2a62" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="051c-d0f6-e00b-a87b" name="Endless Spell: Chalice of Ushoran" hidden="false" collective="false" targetId="b750-d783-a5ab-95b4" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="705f-02ae-f4f5-987a" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="bb46-d80f-d7b4-93cc" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="72b0-8e12-6140-aa1c" name="Endless Spell: Corpsemare Stampede" hidden="false" collective="false" targetId="3756-b691-3bfa-a3f3" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="705f-02ae-f4f5-987a" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="7b52-ea5b-00b8-d233" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -3183,18 +3214,10 @@
         <cost name="pts" typeId="points" value="200.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="141c-d056-e00c-32fe" name="Endless Spells: Flesh-eater Courts" hidden="false" collective="false" type="upgrade">
-      <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="ac69-a3bd-71f3-2d62" type="max"/>
-      </constraints>
-      <entryLinks>
-        <entryLink id="02c4-5988-7239-4639" name="Endless Spells: Flesh-eater Courts" hidden="false" collective="false" targetId="8042-a0ba-eab9-0c0a" type="selectionEntryGroup"/>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="3756-b691-3bfa-a3f3" name="Endless Spell: Corpsemare Stampede" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="ec5f-03e8-f651-87d1" type="max"/>
+      </constraints>
       <profiles>
         <profile id="50b6-bce4-7249-61d8" name="Summon Corpsemare Stampede" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
           <characteristics>
@@ -3231,6 +3254,9 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="b750-d783-a5ab-95b4" name="Endless Spell: Chalice of Ushoran" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="0704-e4c3-899c-f2e5" type="max"/>
+      </constraints>
       <profiles>
         <profile id="3f63-6d15-0050-20ab" name="Summon Chalice of Ushoran" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
           <characteristics>
@@ -3254,6 +3280,9 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="b65c-000c-9036-af95" name="Endless Spell: Cadaverous Barricade" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="4a31-ad25-2b0d-0453" type="max"/>
+      </constraints>
       <profiles>
         <profile id="e52d-0f53-fd93-5747" name="Summon Cadaverous Barricade" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
           <characteristics>
@@ -4693,35 +4722,6 @@
           </costs>
         </selectionEntry>
       </selectionEntries>
-    </selectionEntryGroup>
-    <selectionEntryGroup id="8042-a0ba-eab9-0c0a" name="Endless Spells: Flesh-eater Courts" hidden="false" collective="false">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="705f-02ae-f4f5-987a" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="200d-b70c-6d09-00ee" type="min"/>
-      </constraints>
-      <entryLinks>
-        <entryLink id="0252-51bb-df24-0566" name="Endless Spell: Cadaverous Barricade" hidden="false" collective="false" targetId="b65c-000c-9036-af95" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8cd5-2df7-5a56-6159" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="3c97-5c44-0deb-0d7b" name="Endless Spell: Chalice of Ushoran" hidden="false" collective="false" targetId="b750-d783-a5ab-95b4" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5669-7355-39f9-146d" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="65c5-b289-777c-53f2" name="Endless Spell: Corpsemare Stampede" hidden="false" collective="false" targetId="3756-b691-3bfa-a3f3" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="031b-b25e-b67a-cf2d" type="max"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
 </catalogue>

--- a/Death - Legions of Nagash and Nighthaunt.cat
+++ b/Death - Legions of Nagash and Nighthaunt.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="e320-d5ec-ac8e-03dd" name="Death: Legions of Nagash and Nighthaunt" revision="43" battleScribeVersion="2.02" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="7" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="e320-d5ec-ac8e-03dd" name="Death: Legions of Nagash and Nighthaunt" revision="44" battleScribeVersion="2.02" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="7" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="e320-d5ec-pubN65537" name="Battletome: Legions of Nagash and Battletome: Nighthaunt"/>
     <publication id="e320-d5ec-pubN65555" name="Battletome: Nighthaunt"/>
@@ -3930,11 +3930,6 @@
         <categoryLink id="39ae-9fa8-c4b8-34de" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="e991-3dc3-86a3-020a" name="Endless Spells: Nighthaunt" hidden="false" collective="false" targetId="ca4b-1187-5120-b780" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="1b3f-256c-d147-06e1" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
-      </categoryLinks>
-    </entryLink>
     <entryLink id="112a-b929-6ec5-5526" name="The Briar Queen" hidden="false" collective="false" targetId="858e-ff08-a895-01e0" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
@@ -4083,6 +4078,21 @@
           </conditionGroups>
         </modifier>
       </modifiers>
+    </entryLink>
+    <entryLink id="310e-a0af-e590-e56a" name="Endless Spell: Mortalis Terminexus" hidden="false" collective="false" targetId="925f-f4ee-9c5e-2552" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="c4ac-1311-e6b4-039c" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="bb13-7325-9a3f-9ada" name="Endless Spell: Shyish Reaper" hidden="false" collective="false" targetId="b904-52ba-13d8-a3cf" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="ac94-7b5a-c6fa-5aca" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="f9c7-608e-5f74-f923" name="Endless Spell: Vault of Souls" hidden="false" collective="false" targetId="67ba-f5bf-62b6-08e6" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="2630-36a1-f160-11c1" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
     </entryLink>
   </entryLinks>
   <rules>
@@ -13988,6 +13998,9 @@ The slain models you return to a unit can only be set up withi 3&quot; of an ene
       </costs>
     </selectionEntry>
     <selectionEntry id="925f-f4ee-9c5e-2552" name="Endless Spell: Mortalis Terminexus" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="b627-37c3-f00c-5363" type="max"/>
+      </constraints>
       <profiles>
         <profile id="be6c-8155-ebb2-3b13" name="Summon Mortalis Terminexus" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
           <characteristics>
@@ -14000,15 +14013,19 @@ The slain models you return to a unit can only be set up withi 3&quot; of an ene
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">After this model is set up or has moved, the controlling player must decide whether the Mortalis Terminexus will reverse or hasten time. If they choose to reverse time, heal D3 wounds allocated to each unit within 6&quot; of this model. If they choose to hasten time, each unit within 6&quot; of this model suffers D3 mortal wounds.</characteristic>
           </characteristics>
         </profile>
-        <profile id="2fe7-f84e-5b7e-4a3d" name="Empowered by Shyish (Mortalis)" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+        <profile id="2fe7-f84e-5b7e-4a3d" name="Empowered by Shyish" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If your battle is being fought in the Realm of Shyish, the range of this model’s Keeper of Mortality ability – whether the controlling player chose to reverse or hasten time – is 12&quot; instead of 6&quot;.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="c7e5-d1cf-8893-d6a8" name="Predatory" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Mortalis Terminexus is a predatory endless spell. It can move 8&quot; and can fly.</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <infoLinks>
         <infoLink id="f917-6e16-92d0-d061" name="Fly" hidden="false" targetId="8e0c-cbe4-27be-8a30" type="profile"/>
-        <infoLink id="4780-e4b2-bb81-bd09" name="PREDATORY (Nighthaunt)" hidden="false" targetId="bc8c-ff0f-e8ee-f66c" type="profile"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="2c1f-a1e9-b08c-de22" name="New CategoryLink" hidden="false" targetId="6cdf-dd4f-0e91-e9c4" primary="false"/>
@@ -14019,6 +14036,9 @@ The slain models you return to a unit can only be set up withi 3&quot; of an ene
       </costs>
     </selectionEntry>
     <selectionEntry id="b904-52ba-13d8-a3cf" name="Endless Spell: Shyish Reaper" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="1df5-f5b8-7e14-23b3" type="max"/>
+      </constraints>
       <profiles>
         <profile id="54fc-91a8-4a94-c99e" name="Summon Shyish Reaper" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
           <characteristics>
@@ -14026,7 +14046,7 @@ The slain models you return to a unit can only be set up withi 3&quot; of an ene
             <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">Only Nagash, Supreme Lord of the Undead and Nighthaunt Wizards can attempt to cast Summon Shyish Reaper. [...] If successfully cast, set up a Shyish Reaper model wholly within 6&quot; of the caster.</characteristic>
           </characteristics>
         </profile>
-        <profile id="2493-7e1b-d06f-c02b" name="Empowered by Shyish (Reaper)" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+        <profile id="2493-7e1b-d06f-c02b" name="Empowered by Shyish" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If your battle is being fought in the Realm of Shyish, a Shyish Reaper can move 12&quot; instead of 8&quot;.</characteristic>
           </characteristics>
@@ -14041,9 +14061,13 @@ The slain models you return to a unit can only be set up withi 3&quot; of an ene
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Before moving a Shyish Reaper, pivot the model on the centre of its base so that it points lengthways in the direction you wish it to move. Then move it in a straight line in that direction. The initial pivot is free and does not count towards the distance the model moves. After this model has moved, roll a dice for each model that it moved over (including models it moved over when it pivoted); if the roll is equal to or greater than the model’s Save characteristic, that model’s unit suffers 1 mortal wound.</characteristic>
           </characteristics>
         </profile>
+        <profile id="cf72-82f3-c1a2-d784" name="Predatory" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Shyish Reaper is a predatory endless spell. It can move up to 8&quot; and can fly.</characteristic>
+          </characteristics>
+        </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="0282-1553-1bf0-eec7" name="PREDATORY (Nighthaunt)" hidden="false" targetId="bc8c-ff0f-e8ee-f66c" type="profile"/>
         <infoLink id="8ce0-7eec-aff0-c56e" name="Fly" hidden="false" targetId="8e0c-cbe4-27be-8a30" type="profile"/>
       </infoLinks>
       <categoryLinks>
@@ -14055,6 +14079,9 @@ The slain models you return to a unit can only be set up withi 3&quot; of an ene
       </costs>
     </selectionEntry>
     <selectionEntry id="67ba-f5bf-62b6-08e6" name="Endless Spell: Vault of Souls" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="e38c-1634-dc5b-3b71" type="max"/>
+      </constraints>
       <profiles>
         <profile id="1a30-4b26-6471-e0f3" name="Summon Vault of Souls" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
           <characteristics>
@@ -14062,7 +14089,7 @@ The slain models you return to a unit can only be set up withi 3&quot; of an ene
             <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">Only Nagash, Supreme Lord of the Undead and Nighthaunt Wizards can attempt to cast Summon Vault of Souls. [...] If successfully cast, set up a Vault of Souls model wholly within 18&quot; of the caster.</characteristic>
           </characteristics>
         </profile>
-        <profile id="fd4a-2405-b6a8-3747" name="Empowered by Shyish (Vault)" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+        <profile id="fd4a-2405-b6a8-3747" name="Empowered by Shyish" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If your battle is being fought in the Realm of Shyish, the range of this model’s Soul Siphon ability is 9&quot; instead of 6&quot;.</characteristic>
           </characteristics>
@@ -14077,9 +14104,13 @@ The slain models you return to a unit can only be set up withi 3&quot; of an ene
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Keep track of the number of mortal wounds inflicted by this model. If the total is 20 or more at the end of any phase, all units within 6&quot; of this model suffer D6 mortal wounds, and then this model is dispelled.</characteristic>
           </characteristics>
         </profile>
+        <profile id="84e0-a0e0-79f9-0a19" name="Predatory" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Vault of Souls is a predatory endless spell. It can move 8&quot; and can fly.</characteristic>
+          </characteristics>
+        </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="8427-2d42-108b-e167" name="PREDATORY (Nighthaunt)" hidden="false" targetId="bc8c-ff0f-e8ee-f66c" type="profile"/>
         <infoLink id="ea5a-950f-49d4-fc71" name="Fly" hidden="false" targetId="8e0c-cbe4-27be-8a30" type="profile"/>
       </infoLinks>
       <categoryLinks>
@@ -14308,17 +14339,6 @@ The slain models you return to a unit can only be set up withi 3&quot; of an ene
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="280.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="ca4b-1187-5120-b780" name="Endless Spells: Nighthaunt" hidden="false" collective="false" type="upgrade">
-      <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="669b-73fe-4ff5-99a4" type="max"/>
-      </constraints>
-      <entryLinks>
-        <entryLink id="ffdc-8935-1534-4f97" name="Endless Spells: Nighthaunt" hidden="false" collective="false" targetId="7614-f2ea-1e82-2e5d" type="selectionEntryGroup"/>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="afc8-8d6f-3a5e-ccea" name="3. Balefire Blade" hidden="false" collective="false" type="upgrade">
@@ -16852,11 +16872,6 @@ The slain models you return to a unit can only be set up withi 3&quot; of an ene
       </modifiers>
       <characteristics>
         <characteristic name="Command Ability Details" typeId="1b71-4c83-4e8c-093f">You can use this command ability at the end of your movement phase. If you do so, pick a gravesite that is within 9&quot; of your general, and then pick a friendly Summonable unit that has been destroyed. Set up that unit wholly within 9&quot; of that gravesite and more than 9&quot; from any enemy units. *ERRATA Jun&apos;18*</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="bc8c-ff0f-e8ee-f66c" name="PREDATORY (Nighthaunt)" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-      <characteristics>
-        <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">This Endless Spell is a predatory endless spell. It can move 8&quot; and can fly.</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/Destruction - Gloomspite Gitz.cat
+++ b/Destruction - Gloomspite Gitz.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="750c-157c-3186-61d3" name="Destruction - Gloomspite Gitz" revision="10" battleScribeVersion="2.02" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="46" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="750c-157c-3186-61d3" name="Destruction - Gloomspite Gitz" revision="11" battleScribeVersion="2.02" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="46" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profileTypes>
     <profileType id="2a8e-0fcd-1727-325b" name="Wound Track Manglers">
       <characteristicTypes>
@@ -540,11 +540,6 @@
         <categoryLink id="2689-0192-38b9-879b" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="c71f-303a-e0dc-0510" name="Endless Spells: Gloomspite Gitz" hidden="false" collective="false" targetId="49e2-be8a-2608-24dc" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="1701-d3af-af82-827a" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
-      </categoryLinks>
-    </entryLink>
     <entryLink id="0502-548a-3a9e-c2d3" name="Battalion: Gobbapalooza" hidden="false" collective="false" targetId="5a8d-7791-d79a-356a" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="58b4-29a1-09e9-82ec" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
@@ -624,6 +619,54 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="7cba-9737-e190-b35c" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="08f9-69ab-7992-76ec" name="Endless Spell: Malevolent Moon" hidden="false" collective="false" targetId="bf4d-5916-7df5-d8f0" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f8e3-641a-7a46-2f84" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="0bb1-0112-6d50-67c0" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="2617-3056-0e75-4109" name="Endless Spell: Mork&apos;s Mighty Mushroom" hidden="false" collective="false" targetId="caea-d9a3-d607-40de" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f8e3-641a-7a46-2f84" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="5338-4778-fcff-2c02" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="7d7c-9492-b438-955b" name="Endless Spell: Scrapskuttle&apos;s Arachnacauldron" hidden="false" collective="false" targetId="4714-06e3-b290-89b0" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f8e3-641a-7a46-2f84" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="4e70-f346-b37d-6ec6" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="a9f9-2782-213d-39d4" name="Endless Spell: Scuttletide" hidden="false" collective="false" targetId="3449-0bfa-dbb9-e457" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f8e3-641a-7a46-2f84" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="581c-9291-0a10-123b" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -4123,6 +4166,9 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="3449-0bfa-dbb9-e457" name="Endless Spell: Scuttletide" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="ba51-3f86-b2fb-6a74" type="max"/>
+      </constraints>
       <profiles>
         <profile id="9d5d-7be4-a143-4f1e" name="Summon Scuttletide" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
           <characteristics>
@@ -4140,12 +4186,20 @@
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">SPIDERFANG units are not affected by the Scuttling Horde ability. In addition, SPIDERFANG models can move across this model in the same manner as a model that can fly.</characteristic>
           </characteristics>
         </profile>
+        <profile id="1100-d6c1-55ba-ee9e" name="Predatory" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">A Scuttletide is a predatory endless spell. A Scuttletide can move up to 6&quot;.</characteristic>
+          </characteristics>
+        </profile>
       </profiles>
       <costs>
         <cost name="pts" typeId="points" value="30.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4714-06e3-b290-89b0" name="Endless Spell: Scrapskuttle&apos;s Arachnacauldron" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="b9d1-a4ea-1d49-1ef7" type="max"/>
+      </constraints>
       <profiles>
         <profile id="db2a-facf-62a3-8a48" name="Summon Scrapskuttle’s Arachnacauldron" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
           <characteristics>
@@ -4169,6 +4223,9 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="caea-d9a3-d607-40de" name="Endless Spell: Mork&apos;s Mighty Mushroom" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="c272-dac9-af06-17f1" type="max"/>
+      </constraints>
       <profiles>
         <profile id="3e91-d7dc-30e1-34de" name="Summon Mork&apos;s Mighty Mushroom" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
           <characteristics>
@@ -4187,10 +4244,13 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="bf4d-5916-7df5-d8f0" name="Endless Spell: Malevolent Moon" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="d5f1-75f2-d149-d674" type="max"/>
+      </constraints>
       <profiles>
-        <profile id="77bb-0b5b-8926-9ca8" name="PREDATORY (Gloomspite)" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+        <profile id="77bb-0b5b-8926-9ca8" name="Preditory" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">This Endless Spell is a predatory endless spell. It can move 12&quot; and can fly.</characteristic>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">A Malevolent Moon is a predatory endless spell. A Malevolent Moon can move up to 12&quot; and can fly.</characteristic>
           </characteristics>
         </profile>
         <profile id="3c70-e92e-da76-e434" name="Summon Malevolent Moon" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
@@ -5828,14 +5888,6 @@
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
-      <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="49e2-be8a-2608-24dc" name="Endless Spells: Gloomspite Gitz" hidden="false" collective="false" type="unit">
-      <entryLinks>
-        <entryLink id="0666-c83f-869e-13c6" name="Endless Spells: Gloomspite Gitz" hidden="false" collective="false" targetId="3f3a-9a9f-e3ad-f7de" type="selectionEntryGroup"/>
-      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>

--- a/Order - Fyreslayers.cat
+++ b/Order - Fyreslayers.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="e67a-06d2-888c-b9be" name="Order - Fyreslayers" revision="26" battleScribeVersion="2.02" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="e67a-06d2-888c-b9be" name="Order - Fyreslayers" revision="27" battleScribeVersion="2.02" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="e67a-06d2-pubN65537" name="Order Battletome: Fyreslayers"/>
     <publication id="e67a-06d2-pubN69594" name="Battletome: Fyreslayers Errata, July 2018"/>
@@ -243,9 +243,40 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="bdae-4f74-d004-f0da" name="Magmic Battleforge" hidden="false" collective="false" targetId="9a34-4e73-b5a5-7b71" type="selectionEntry"/>
-    <entryLink id="70da-3231-d20b-81c6" name="Magmic Invocations" hidden="false" collective="false" targetId="3139-10d9-f99b-dd61" type="selectionEntry">
+    <entryLink id="7eb8-af59-a3fd-f189" name="Magmic Invocation: Zharrgron Flame Splitter" hidden="false" collective="false" targetId="09c6-5753-f3b3-c56c" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="94c9-6cd1-da31-5c7e" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
-        <categoryLink id="7e3b-be23-a28b-cd16" name="Malign Sorcery" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+        <categoryLink id="31d8-db07-5f45-f5ca" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="296d-cee1-11a3-c859" name="Magmic Invocation: Molten Infernoth" hidden="false" collective="false" targetId="a210-d353-df95-85b8" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="94c9-6cd1-da31-5c7e" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="b00a-4c63-446e-67c2" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="2be4-d4a1-14c0-64a2" name="Magmic Invocation: Runic Fyrewall" hidden="false" collective="false" targetId="4383-0748-eb3c-ba75" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="94c9-6cd1-da31-5c7e" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="95a8-93fa-41f7-5c76" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -2636,15 +2667,10 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="3139-10d9-f99b-dd61" name="Magmic Invocations" hidden="false" collective="false" type="upgrade">
-      <entryLinks>
-        <entryLink id="3a3c-fb93-129c-74d5" name="Magmic Invocations" hidden="false" collective="false" targetId="644d-534f-4afd-af72" type="selectionEntryGroup"/>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="a210-d353-df95-85b8" name="Molten Infernoth" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="a210-d353-df95-85b8" name="Magmic Invocation: Molten Infernoth" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="1074-4626-a9f5-09ca" type="max"/>
+      </constraints>
       <profiles>
         <profile id="03b0-ce84-c197-d5e1" name="Summon Molten Infernoth" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
           <characteristics>
@@ -2676,7 +2702,10 @@
         <cost name="pts" typeId="points" value="50.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="4383-0748-eb3c-ba75" name="Runic Fyrewall" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="4383-0748-eb3c-ba75" name="Magmic Invocation: Runic Fyrewall" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="967e-c30c-0931-a17b" type="max"/>
+      </constraints>
       <profiles>
         <profile id="bf7b-0e30-b3b0-305e" name="Summon Runic Fyrewall" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
           <characteristics>
@@ -2708,7 +2737,10 @@
         <cost name="pts" typeId="points" value="40.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="09c6-5753-f3b3-c56c" name="Zharrgron Flame Splitter" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="09c6-5753-f3b3-c56c" name="Magmic Invocation: Zharrgron Flame Splitter" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="2039-bff7-fc94-d116" type="max"/>
+      </constraints>
       <profiles>
         <profile id="eaf0-2cee-671b-b41e" name="Summon Zharrgron Flame Splitter" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
           <characteristics>
@@ -2810,28 +2842,6 @@
         <entryLink id="f60f-df18-f4fb-c2c3" name="Heirlooms of the Lodge" hidden="false" collective="false" targetId="7808-85bb-e6f6-2f0e" type="selectionEntryGroup"/>
         <entryLink id="a8db-7a6d-25c3-ac0d" name="Icons of Grimnir" hidden="false" collective="false" targetId="8a89-6828-bd55-ee17" type="selectionEntryGroup"/>
         <entryLink id="caad-f1ed-0478-7632" name="Lodge Artefacts" hidden="false" collective="false" targetId="f006-6a05-a287-1aa1" type="selectionEntryGroup"/>
-      </entryLinks>
-    </selectionEntryGroup>
-    <selectionEntryGroup id="644d-534f-4afd-af72" name="Magmic Invocations" hidden="false" collective="false">
-      <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1bcc-4c0b-f51c-85ad" type="min"/>
-      </constraints>
-      <entryLinks>
-        <entryLink id="cafb-a853-a4bd-2df1" name="Molten Infernoth" hidden="false" collective="false" targetId="a210-d353-df95-85b8" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26f9-fc77-3649-0993" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="9a98-2997-14b9-a383" name="Runic Fyrewall" hidden="false" collective="false" targetId="4383-0748-eb3c-ba75" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa12-8315-e1ea-bba8" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="48f0-6711-19d6-95e9" name="Zharrgron Flame Splitter" hidden="false" collective="false" targetId="09c6-5753-f3b3-c56c" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="16e0-5142-1f73-e2db" type="max"/>
-          </constraints>
-        </entryLink>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="3886-2846-4e7d-dd6a" name="Magmadroth Traits" hidden="false" collective="false">

--- a/Order - Stormcast Eternals.cat
+++ b/Order - Stormcast Eternals.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="ed04-877b-c5d3-ce41" name="Order - Stormcast Eternals" revision="41" battleScribeVersion="2.02" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="ed04-877b-c5d3-ce41" name="Order - Stormcast Eternals" revision="42" battleScribeVersion="2.02" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="ed04-877b-pubN65537" name="Order Battletome: Stormcast Eternals (2nd Edition)"/>
     <publication id="ed04-877b-pubN71576" name="Battletome: Stormcast Eternals (2nd Edition)"/>
@@ -784,11 +784,6 @@
         <categoryLink id="b311-6f68-f2cc-8286" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="e5bc-138c-7386-b4b0" name="Endless Spells: Stormcast Eternals" hidden="false" collective="false" targetId="7f52-04dc-0d95-db96" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="1ff3-651e-71fb-a058" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
-      </categoryLinks>
-    </entryLink>
     <entryLink id="9187-0e96-e44b-8120" name="Knight-Zephyros" hidden="false" collective="false" targetId="40dd-3878-4b37-f96e" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="c33a-7160-1e21-d6b5" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
@@ -873,6 +868,42 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="353f-7339-c732-67c3" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="87f6-05e8-2a23-af87" name="Endless Spell: Celestian Vortex" hidden="false" collective="false" targetId="37f9-5999-6ae6-0ded" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="81f4-ef16-b80c-6926" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="7dd0-d740-0ba6-e754" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="2f06-7d8d-af8e-eaa3" name="Endless Spell: Dais Arcanum" hidden="false" collective="false" targetId="39fa-f5f9-1707-1d8d" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="81f4-ef16-b80c-6926" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1272-bd66-1b67-ef4c" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="73fd-25a0-6d3d-35dc" name="Endless Spell: Everblaze Comet" hidden="false" collective="false" targetId="4f2e-b7f4-470b-4ef8" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="81f4-ef16-b80c-6926" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a123-2e46-ec91-cda1" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -9669,6 +9700,9 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="37f9-5999-6ae6-0ded" name="Endless Spell: Celestian Vortex" publicationId="ed04-877b-pubN71576" page="189" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="3a0b-4ab8-8747-5651" type="max"/>
+      </constraints>
       <profiles>
         <profile id="831d-1ac0-fe83-9d1b" name="Predatory" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
@@ -9710,6 +9744,9 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="39fa-f5f9-1707-1d8d" name="Endless Spell: Dais Arcanum" publicationId="ed04-877b-pubN71576" page="190" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="765d-18c8-bb67-e94b" type="max"/>
+      </constraints>
       <profiles>
         <profile id="192d-afc9-494c-e8a1" name="Summon Dais Arcanum" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
           <characteristics>
@@ -9741,6 +9778,9 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="4f2e-b7f4-470b-4ef8" name="Endless Spell: Everblaze Comet" publicationId="ed04-877b-pubN71576" page="190" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="0430-5254-0069-4e52" type="max"/>
+      </constraints>
       <profiles>
         <profile id="b624-5d0a-30c7-0dd5" name="Summon Everblaze Comet" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
           <characteristics>
@@ -9766,17 +9806,6 @@
       </categoryLinks>
       <costs>
         <cost name="pts" typeId="points" value="100.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="7f52-04dc-0d95-db96" name="Endless Spells: Stormcast Eternals" hidden="false" collective="false" type="upgrade">
-      <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="5a00-59dd-feaa-9b17" type="max"/>
-      </constraints>
-      <entryLinks>
-        <entryLink id="f657-d0a9-4a0f-d52c" name="Endless Spells: Stormcast Eternals" hidden="false" collective="false" targetId="292c-f171-1e38-e270" type="selectionEntryGroup"/>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="aff4-016f-04b6-cf66" name="Averon Stormsire" page="" hidden="false" collective="false" type="unit">
@@ -12117,35 +12146,6 @@
           </costs>
         </selectionEntry>
       </selectionEntries>
-    </selectionEntryGroup>
-    <selectionEntryGroup id="292c-f171-1e38-e270" name="Endless Spells: Stormcast Eternals" publicationId="ed04-877b-pubN65537" hidden="false" collective="false">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="81f4-ef16-b80c-6926" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6177-96f8-6509-f349" type="min"/>
-      </constraints>
-      <entryLinks>
-        <entryLink id="b78c-08e1-16c3-b880" name="Endless Spell: Celestian Vortex" hidden="false" collective="false" targetId="37f9-5999-6ae6-0ded" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="66a5-aa9b-134d-0e9a" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="08c0-40aa-3cc5-ad37" name="Endless Spell: Dais Arcanum" hidden="false" collective="false" targetId="39fa-f5f9-1707-1d8d" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e62-0d01-44d2-4928" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="1b8b-35ac-06d4-9790" name="Endless Spell: Everblaze Comet" hidden="false" collective="false" targetId="4f2e-b7f4-470b-4ef8" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="792b-4d55-a4b3-950c" type="max"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="3d4c-b3f0-8c0f-1fb2" name="Traits of the Noble Beast" publicationId="ed04-877b-pubN65537" page="124" hidden="false" collective="false">
       <modifiers>


### PR DESCRIPTION
Treat all endless spells, judgements and invocations as units to improve formatting when viewing rosters.