### PR TITLE
fix type of model selectionEntries, other small normalizations

### DIFF
--- a/Chaos - Beasts of Chaos - Data.cat
+++ b/Chaos - Beasts of Chaos - Data.cat
@@ -603,7 +603,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a29e-068b-4ee5-5813" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="7325-b534-6cfb-f6f2" name="2 Gor Blades" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="7325-b534-6cfb-f6f2" name="2 Gor Blades" hidden="false" collective="false" import="true" type="model">
               <profiles>
                 <profile id="9ebf-c260-eb70-f39f" name="Rend and Tear" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
                   <characteristics>
@@ -1438,7 +1438,7 @@
         <categoryLink id="bdbc-244c-5921-0899" name="MONSTERS OF CHAOS" hidden="false" targetId="4d26-d95f-9bcd-aeff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="2ed9-881b-645a-dd6f" name="10 Chaos Warhounds" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="2ed9-881b-645a-dd6f" name="10 Chaos Warhounds" hidden="false" collective="false" import="true" type="model">
           <modifiers>
             <modifier type="decrement" field="points" value="10">
               <conditions>
@@ -2131,7 +2131,7 @@
         <categoryLink id="4ff7-67c8-cc70-c644" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="6758-ff60-1d3a-308c" name="3 Bullgors" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="6758-ff60-1d3a-308c" name="3 Bullgors" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7eca-5c76-005c-42ba" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b3b8-df03-a98f-c476" type="max"/>
@@ -2452,7 +2452,7 @@
         <categoryLink id="2d7d-0de1-0539-988b" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="0ef5-cd0e-298b-c141" name="3 Dragon Ogors" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="0ef5-cd0e-298b-c141" name="3 Dragon Ogors" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0027-ea36-b777-0028" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9cd6-4be4-5df8-d324" type="max"/>

--- a/Chaos - Daemons of Chaos.cat
+++ b/Chaos - Daemons of Chaos.cat
@@ -332,7 +332,7 @@
         <categoryLink id="4637-2924-a7b1-7f7c" name="New CategoryLink" hidden="false" targetId="84c9-64c0-ec5a-64cb" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="86bf-5743-f4ff-4a82" name="5 Furies" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="86bf-5743-f4ff-4a82" name="5 Furies" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0ea7-c141-acdb-46d5" type="min"/>
             <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3e4f-4441-9fdd-dc96" type="max"/>

--- a/Chaos - Everchosen.cat
+++ b/Chaos - Everchosen.cat
@@ -412,7 +412,7 @@
         <categoryLink id="0c12-42e7-3a48-e202" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="66b9-3778-f9a7-69cb" name="3 Varanguard" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="66b9-3778-f9a7-69cb" name="3 Varanguard" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="17d3-1ed1-b904-af65" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0c7d-e405-3378-7d57" type="max"/>

--- a/Chaos - Khorne.cat
+++ b/Chaos - Khorne.cat
@@ -5553,7 +5553,7 @@
         <categoryLink id="1036-6be3-b109-f565" name="New CategoryLink" hidden="false" targetId="affc-db83-f2d2-9b44" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="ecba-0394-14ef-ecf4" name="5 Wrathmongers" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="ecba-0394-14ef-ecf4" name="5 Wrathmongers" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="66a0-abc7-19a3-45f3" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="faf6-16df-4a72-c5e0" type="max"/>

--- a/Chaos - Monsters of Chaos.cat
+++ b/Chaos - Monsters of Chaos.cat
@@ -370,7 +370,7 @@
         <categoryLink id="0634-4d12-d3b4-34dd" name="New CategoryLink" hidden="false" targetId="7743-05c4-e313-c0ff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="0ebf-c6aa-5536-0fae" name="10 Chaos Warhounds" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="0ebf-c6aa-5536-0fae" name="10 Chaos Warhounds" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9860-3111-8795-702a" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2278-b6cf-7237-3b9a" type="max"/>
@@ -422,7 +422,7 @@
         <categoryLink id="41ef-fbd9-ad99-c088" name="New CategoryLink" hidden="false" targetId="6ab3-6403-41ed-ca06" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="8c5a-dfdd-d1e1-840e" name="5 Harpies" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="8c5a-dfdd-d1e1-840e" name="5 Harpies" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4791-042c-362f-6e53" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="120a-8111-8d31-7b6e" type="max"/>
@@ -1444,7 +1444,7 @@
         <categoryLink id="1999-b46a-74e0-6824" name="New CategoryLink" hidden="false" targetId="f1f9-41fb-b64b-9530" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="aafa-f47a-720c-df5b" name="3 Skin Wolves" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="aafa-f47a-720c-df5b" name="3 Skin Wolves" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c7c0-dd27-8356-71a1" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0bd7-2795-a841-fdc3" type="max"/>

--- a/Chaos - Nurgle.cat
+++ b/Chaos - Nurgle.cat
@@ -4140,7 +4140,7 @@
             <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">14&quot;</characteristic>
             <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">1</characteristic>
             <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">4+</characteristic>
-            <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+_</characteristic>
+            <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
             <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-</characteristic>
             <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
           </characteristics>
@@ -5322,7 +5322,7 @@
         <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">3</characteristic>
         <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">3+</characteristic>
         <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
-        <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707"/>
+        <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-</characteristic>
         <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
       </characteristics>
     </profile>

--- a/Chaos - Skaven - Data.cat
+++ b/Chaos - Skaven - Data.cat
@@ -608,7 +608,7 @@
         <categoryLink id="dac4-8455-2b75-7a23" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="6748-9377-38f3-2237" name="20 Clanrats" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="6748-9377-38f3-2237" name="20 Clanrats" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2b56-7a46-5f0f-1904" type="min"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7be6-b636-738c-63a6" type="max"/>
@@ -960,7 +960,7 @@
         <categoryLink id="cc6b-955b-117b-3e35" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="f3fc-e3bd-95bd-f5f7" name="10 Giant Rats" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="f3fc-e3bd-95bd-f5f7" name="10 Giant Rats" hidden="false" collective="false" import="true" type="model">
           <modifiers>
             <modifier type="decrement" field="points" value="10">
               <conditions>
@@ -1350,11 +1350,11 @@
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                 <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
-                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0"/>
-                <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269"/>
-                <characteristic name="To Wound" typeId="8842-17f1-9794-4efc"/>
-                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707"/>
-                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70"/>
+                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">*</characteristic>
+                <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">*</characteristic>
+                <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">*</characteristic>
+                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">*</characteristic>
+                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">*</characteristic>
               </characteristics>
             </profile>
             <profile id="314b-4e91-80ae-44f2" name="Avalanche of Flesh" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
@@ -1704,7 +1704,7 @@
         <categoryLink id="f4fe-ef3d-3e06-4c2b" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="2406-bc83-6b87-3101" name="10 Night Runners" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="2406-bc83-6b87-3101" name="10 Night Runners" hidden="false" collective="false" import="true" type="model">
           <modifiers>
             <modifier type="decrement" field="points" value="10">
               <conditions>
@@ -1839,7 +1839,7 @@
         <categoryLink id="eedb-8156-6220-f3a5" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="665a-b1b0-7940-2f64" name="5 Plague Censer Bearers" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="665a-b1b0-7940-2f64" name="5 Plague Censer Bearers" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="be3c-87c0-56fa-ded1" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cac8-9842-391c-a558" type="max"/>
@@ -2596,7 +2596,7 @@
         <categoryLink id="d4de-0793-cca4-2d9b" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="ca82-45e9-5486-4dff" name="2 Rat Ogors" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="ca82-45e9-5486-4dff" name="2 Rat Ogors" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b956-27d8-2715-8575" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1438-f972-2400-ab2a" type="max"/>
@@ -2685,7 +2685,7 @@
         <categoryLink id="0648-17fc-9b0a-2f38" name="SKAVENTIDE" hidden="false" targetId="5ed5-bfa0-f1f7-8b61" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="eea4-b539-65e0-aede" name="2 Rat Swarms" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="eea4-b539-65e0-aede" name="2 Rat Swarms" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="eb37-4c64-4c58-b481" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e842-b322-bf09-8e72" type="max"/>
@@ -4894,7 +4894,7 @@
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="0a8a-2e49-415f-1e9a" name="3 Packmasters" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="0a8a-2e49-415f-1e9a" name="3 Packmasters" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a95-853d-8bcf-d596" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e4e9-779f-1ce2-f09b" type="max"/>
@@ -6351,7 +6351,7 @@
         <categoryLink id="9f4d-a123-fe04-c131" name="SKAVENTIDE" hidden="false" targetId="5ed5-bfa0-f1f7-8b61" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="bdeb-153e-d7cb-3223" name="5 Wolf Rats" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="bdeb-153e-d7cb-3223" name="5 Wolf Rats" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cf83-31df-c397-651b" type="min"/>
             <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="861e-61fe-3df9-ff22" type="max"/>
@@ -6475,7 +6475,7 @@
         <categoryLink id="85d4-d8b2-3cf9-bfa8" name="New CategoryLink" hidden="false" targetId="0ffa-61ef-fa8e-6f3d" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="3557-69dc-d347-695b" name="20 Skavenslaves" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="3557-69dc-d347-695b" name="20 Skavenslaves" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1c13-29b7-a925-358c" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="650f-9251-d4b9-7688" type="max"/>

--- a/Chaos - Slaanesh.cat
+++ b/Chaos - Slaanesh.cat
@@ -1273,7 +1273,7 @@
         <categoryLink id="746d-2129-e80d-a35f" name="New CategoryLink" hidden="false" targetId="3963-2e99-aa63-c65e" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="1192-9c56-707f-3691" name="5 Seekers" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="1192-9c56-707f-3691" name="5 Seekers" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7336-8c7d-0dbc-2d3a" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="997c-1064-4895-7cc3" type="max"/>
@@ -2752,7 +2752,7 @@ If that HERO has an artefact of power, they can sacrifice that instead of suffer
         <categoryLink id="0fb0-3faf-20bb-4cef" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="b158-9ba1-3142-ea05" name="5 Hellstriders" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="b158-9ba1-3142-ea05" name="5 Hellstriders" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bf01-cd87-494e-8eb8" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3043-ba8e-fe58-8bf6" type="max"/>
@@ -2906,7 +2906,7 @@ If that HERO has an artefact of power, they can sacrifice that instead of suffer
         <categoryLink id="d60a-dd87-1b60-7eb0" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="89e4-51e9-48c0-0861" name="5 Hellstriders" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="89e4-51e9-48c0-0861" name="5 Hellstriders" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d2e6-846f-4bf8-24f8" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bf7b-0435-8bfe-a429" type="max"/>

--- a/Chaos - Slaves to Darkness - Data.cat
+++ b/Chaos - Slaves to Darkness - Data.cat
@@ -1210,7 +1210,7 @@
         <categoryLink id="1e9c-5394-c083-00b2" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="82ff-c2bb-471f-4610" name="5 Chaos Marauder Horsemen" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="82ff-c2bb-471f-4610" name="5 Chaos Marauder Horsemen" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9ef5-30b6-396e-fc11" type="min"/>
             <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="be74-29b4-5d55-793d" type="max"/>
@@ -1418,7 +1418,7 @@
         <categoryLink id="9ba1-52f8-aa5d-6c51" name="Battleline" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="2e0a-c703-22d1-0f26" name="20 Chaos Marauders" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="2e0a-c703-22d1-0f26" name="20 Chaos Marauders" hidden="false" collective="false" import="true" type="model">
           <modifiers>
             <modifier type="set" field="points" value="100.0">
               <conditions>

--- a/Chaos - Warriors of Chaos.cat
+++ b/Chaos - Warriors of Chaos.cat
@@ -800,7 +800,7 @@
         <categoryLink id="9bc2-641c-90e9-fbe7" name="New CategoryLink" hidden="false" targetId="a934-6d15-9932-b7ea" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="0cbc-1e6b-67c9-66fe" name="10 Forsaken" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="0cbc-1e6b-67c9-66fe" name="10 Forsaken" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e8c1-c948-3b23-3a54" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c3a7-e760-e158-61a4" type="max"/>
@@ -860,7 +860,7 @@
         <categoryLink id="e3ff-5587-3aaf-62e9" name="New CategoryLink" hidden="false" targetId="2acd-6a89-6575-46db" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="f046-9f84-08cc-65e7" name="3 Chaos Ogors" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="f046-9f84-08cc-65e7" name="3 Chaos Ogors" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c162-dfec-acd4-43c3" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="25f5-9709-1338-8c7b" type="max"/>
@@ -949,7 +949,7 @@
         <categoryLink id="5586-963d-cad8-5ca4" name="New CategoryLink" hidden="false" targetId="1497-6574-5cc9-b0a8" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="d1d1-234d-f2e4-428d" name="2 Chaos Familiars" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="d1d1-234d-f2e4-428d" name="2 Chaos Familiars" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d5e6-41e8-220a-448f" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3388-0f46-361a-5f0a" type="max"/>

--- a/Death - Legions of Nagash and Nighthaunt.cat
+++ b/Death - Legions of Nagash and Nighthaunt.cat
@@ -11079,7 +11079,7 @@ The slain models you return to a unit can only be set up withi 3&quot; of an ene
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="3e8e-bcb4-0021-f708" name="3 Petitioners" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="3e8e-bcb4-0021-f708" name="3 Petitioners" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="624e-a821-43e4-32b6" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8099-f7b0-32b0-1cb8" type="max"/>

--- a/Death - Tomb Kings.cat
+++ b/Death - Tomb Kings.cat
@@ -2664,7 +2664,7 @@
         <infoLink id="da44-0e91-5c71-0966" name="HORNBLOWER" hidden="false" targetId="441f-bd49-e0b1-3709" type="profile"/>
       </infoLinks>
       <selectionEntries>
-        <selectionEntry id="2d8f-16dc-56cf-9eee" name="3 Necropolis Knights" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="2d8f-16dc-56cf-9eee" name="3 Necropolis Knights" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -3473,7 +3473,7 @@
         <categoryLink id="ef98-3b6d-ae4f-4a32" name="New CategoryLink" hidden="false" targetId="f9c2-7bc0-118b-6dd3" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="0813-0d3d-7686-ea33" name="3 Sepulchral Stalkers" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="0813-0d3d-7686-ea33" name="3 Sepulchral Stalkers" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -3931,7 +3931,7 @@
         <categoryLink id="75bf-19ba-d4e0-e80d" name="New CategoryLink" hidden="false" targetId="ae5b-8b2e-3696-0b67" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="4ec1-98e0-870b-9be1" name="5 Skeleton Horse Archers" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="4ec1-98e0-870b-9be1" name="5 Skeleton Horse Archers" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -4070,7 +4070,7 @@
         <categoryLink id="9106-43e8-3553-fa41" name="New CategoryLink" hidden="false" targetId="d8ea-fdc4-d65d-96ce" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="0e59-f589-b149-e2f3" name="5 Skeleton Horsemen" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="0e59-f589-b149-e2f3" name="5 Skeleton Horsemen" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
           </constraints>
@@ -4678,7 +4678,7 @@
         <categoryLink id="ce9e-3306-d176-8ee3" name="New CategoryLink" hidden="false" targetId="4211-02e0-5e08-a64f" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="3f69-af79-54ff-ec4b" name="2 Tomb Swarms" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="3f69-af79-54ff-ec4b" name="2 Tomb Swarms" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -4754,7 +4754,7 @@
         <categoryLink id="5276-75cb-5737-af7a" name="New CategoryLink" hidden="false" targetId="e7fb-b135-7b81-7f1f" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="c071-3b3e-a94c-b3f7" name="3 Ushabti" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="c071-3b3e-a94c-b3f7" name="3 Ushabti" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -4899,7 +4899,7 @@
         <categoryLink id="fc91-15dd-dbda-0152" name="New CategoryLink" hidden="false" targetId="004b-e0d4-fd87-57e1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="a00f-4ed6-bb0f-5c43" name="10 Skeletal Legionnaires" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="a00f-4ed6-bb0f-5c43" name="10 Skeletal Legionnaires" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="959b-7628-792f-239b" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5de4-48b8-af8d-1479" type="max"/>

--- a/Destruction - Beastclaw Raiders.cat
+++ b/Destruction - Beastclaw Raiders.cat
@@ -1131,7 +1131,7 @@
         <categoryLink id="83a0-ae88-75d2-d994" name="New CategoryLink" hidden="false" targetId="2fe3-f56d-11c0-c6eb" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="ca89-c87f-a1ba-9ea5" name="2 Frost Sabres" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="ca89-c87f-a1ba-9ea5" name="2 Frost Sabres" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -2130,7 +2130,7 @@
         <categoryLink id="7edb-7f2e-5672-6cf9" name="New CategoryLink" hidden="false" targetId="fe70-1803-6e87-6f23" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="44d2-1ab5-4cd7-129a" name="3 Icefall Yhetees" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="44d2-1ab5-4cd7-129a" name="3 Icefall Yhetees" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -2204,7 +2204,7 @@
         <categoryLink id="a14f-dd1e-3d7e-7845" name="New CategoryLink" hidden="false" targetId="124c-c37d-8a51-1cde" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="c2ff-da0b-4858-526c" name="2 Mournfang Pack" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="c2ff-da0b-4858-526c" name="2 Mournfang Pack" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -2837,7 +2837,7 @@
         </rule>
       </rules>
       <selectionEntries>
-        <selectionEntry id="73e7-d3ab-e9b3-d53b" name="3 Gore-Gruntas" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="73e7-d3ab-e9b3-d53b" name="3 Gore-Gruntas" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1ce2-0b48-1f0f-3803" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b09b-68dd-eb98-d9a5" type="max"/>

--- a/Destruction - Bonesplitterz.cat
+++ b/Destruction - Bonesplitterz.cat
@@ -1467,7 +1467,7 @@
         <categoryLink id="6a5c-5e69-7646-0865" name="New CategoryLink" hidden="false" targetId="a584-86fb-2025-dece" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="e2e7-4755-0488-3e39" name="2 Savage Big Stabbas" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="e2e7-4755-0488-3e39" name="2 Savage Big Stabbas" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -1534,7 +1534,7 @@
         <categoryLink id="d605-8181-a1fb-480c" name="New CategoryLink" hidden="false" targetId="3b76-a074-088f-f62a" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="65c5-a317-4e7d-595a" name="5 Savage Boarboy Maniaks" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="65c5-a317-4e7d-595a" name="5 Savage Boarboy Maniaks" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -1655,7 +1655,7 @@
         <categoryLink id="94e1-59af-7a67-0157" name="New CategoryLink" hidden="false" targetId="88c1-684d-58df-c938" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="72f1-324d-410a-0560" name="5 Savage Boarboys" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="72f1-324d-410a-0560" name="5 Savage Boarboys" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -1881,7 +1881,7 @@
         <categoryLink id="f980-1e67-fc4b-0ff2" name="New CategoryLink" hidden="false" targetId="17bd-1fed-fa72-3040" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="123b-17cb-f474-facd" name="10 Savage Orruks Arrowboys" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="123b-17cb-f474-facd" name="10 Savage Orruks Arrowboys" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>

--- a/Destruction - Gitmob Grots.cat
+++ b/Destruction - Gitmob Grots.cat
@@ -890,7 +890,7 @@
         <categoryLink id="9ef8-3fe9-583d-ec9b" name="New CategoryLink" hidden="false" targetId="b7aa-d42a-ccb9-6fc9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="4829-451e-26d3-a6a6" name="20 Grots" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="4829-451e-26d3-a6a6" name="20 Grots" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -1032,7 +1032,7 @@
         <categoryLink id="f133-95c7-d3b7-3c09" name="New CategoryLink" hidden="false" targetId="1218-e110-161e-bfec" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="a5a0-4d48-73bc-677e" name="3 Nasty Skulkers" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="a5a0-4d48-73bc-677e" name="3 Nasty Skulkers" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -1179,7 +1179,7 @@
         <categoryLink id="ff5d-b8e4-24ab-8a8c" name="New CategoryLink" hidden="false" targetId="e76d-af5b-dc10-eb4c" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="4074-a0e9-450b-fe38" name="2 Snotlings" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="4074-a0e9-450b-fe38" name="2 Snotlings" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>

--- a/Destruction - Gloomspite Gitz.cat
+++ b/Destruction - Gloomspite Gitz.cat
@@ -4600,7 +4600,7 @@
         <categoryLink id="58db-6cdc-c3d1-5f4e" name="MOONCLAN" hidden="false" targetId="2736-9589-d74d-1c51" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="9379-5c13-bfd0-98f8" name="20 Stabbas" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="9379-5c13-bfd0-98f8" name="20 Stabbas" hidden="false" collective="false" type="model">
           <modifiers>
             <modifier type="decrement" field="points" value="10">
               <conditions>

--- a/Destruction - Gutbusters.cat
+++ b/Destruction - Gutbusters.cat
@@ -571,7 +571,7 @@
         </profile>
       </profiles>
       <selectionEntries>
-        <selectionEntry id="4829-451e-26d3-a6a6" name="20 Grots" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="4829-451e-26d3-a6a6" name="20 Grots" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -790,7 +790,7 @@
         <categoryLink id="49c3-4ddc-e947-89d7" name="New CategoryLink" hidden="false" targetId="76b2-2cf9-f2e8-d9c9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="9dfa-2734-f9ec-cfee" name="3 Iron guts" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="9dfa-2734-f9ec-cfee" name="3 Iron guts" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -884,7 +884,7 @@
         <categoryLink id="fbe7-e35b-8b39-a8e7" name="New CategoryLink" hidden="false" targetId="6261-97a8-d9d9-ba30" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="c046-54ba-8cf4-69ba" name="3 Leadbelchers" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="c046-54ba-8cf4-69ba" name="3 Leadbelchers" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -1003,7 +1003,7 @@
         <categoryLink id="f42c-74e3-1929-cd2e" name="New CategoryLink" hidden="false" targetId="41cf-bc14-e54b-f1b2" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="32e1-cfd2-ea58-959c" name="3 Ogors" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="32e1-cfd2-ea58-959c" name="3 Ogors" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>

--- a/Destruction - Ironjawz.cat
+++ b/Destruction - Ironjawz.cat
@@ -1355,7 +1355,7 @@
         <categoryLink id="90bd-b798-8af8-ac08" name="New CategoryLink" hidden="false" targetId="03eb-456f-dd6c-7024" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="d05a-773e-1d60-9d53" name="10 Ardboys" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="d05a-773e-1d60-9d53" name="10 Ardboys" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -1525,7 +1525,7 @@
         <categoryLink id="23c2-731d-ad9d-a474" name="New CategoryLink" hidden="false" targetId="8078-2d2a-5057-2725" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="0873-dbd9-0f07-71aa" name="5 Brutes" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="0873-dbd9-0f07-71aa" name="5 Brutes" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -1726,7 +1726,7 @@
         <categoryLink id="7727-8825-dc98-0690" name="New CategoryLink" hidden="false" targetId="cf17-dd69-1f56-c2d5" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="32a4-72ca-15cd-fd08" name="3 Gore-Gruntas" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="32a4-72ca-15cd-fd08" name="3 Gore-Gruntas" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>

--- a/Destruction - Maneaters.cat
+++ b/Destruction - Maneaters.cat
@@ -113,7 +113,7 @@
         <categoryLink id="513c-101b-c9ce-6b71" name="OGOR" hidden="false" targetId="1422-e165-b7d0-b2d9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="556a-314d-1fdf-fb7a" name="3 Maneaters" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="556a-314d-1fdf-fb7a" name="3 Maneaters" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>

--- a/Destruction - Moonclan Grots.cat
+++ b/Destruction - Moonclan Grots.cat
@@ -466,7 +466,7 @@
         </profile>
       </profiles>
       <selectionEntries>
-        <selectionEntry id="c597-ba10-c65d-da7a" name="2 Grot Squig Herders" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="c597-ba10-c65d-da7a" name="2 Grot Squig Herders" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -531,7 +531,7 @@
         </profile>
       </profiles>
       <selectionEntries>
-        <selectionEntry id="d9f3-fa66-a28e-a0eb" name="5 Grot Squig Hoppers" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="d9f3-fa66-a28e-a0eb" name="5 Grot Squig Hoppers" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -834,7 +834,7 @@
         </rule>
       </rules>
       <selectionEntries>
-        <selectionEntry id="4829-451e-26d3-a6a6" name="20 Grots" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="4829-451e-26d3-a6a6" name="20 Grots" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -1198,7 +1198,7 @@
         </profile>
       </profiles>
       <selectionEntries>
-        <selectionEntry id="8a54-2ce4-3444-d9d6" name="5 Cave Squigs" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="8a54-2ce4-3444-d9d6" name="5 Cave Squigs" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3cb7-3f81-d971-37b7" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5dbe-a5bd-f47e-74cd" type="max"/>

--- a/Destruction - Spiderfang Grots.cat
+++ b/Destruction - Spiderfang Grots.cat
@@ -326,7 +326,7 @@
         </profile>
       </profiles>
       <selectionEntries>
-        <selectionEntry id="c240-fd48-7e6c-b0bf" name="5 Grot Spider Riders" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="c240-fd48-7e6c-b0bf" name="5 Grot Spider Riders" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>

--- a/Destruction - Troggoth.cat
+++ b/Destruction - Troggoth.cat
@@ -153,7 +153,7 @@
         <categoryLink id="8b29-1fcc-bcc2-5201" name="New CategoryLink" hidden="false" targetId="fe2d-b68b-d67e-b356" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="2c11-7fe6-2311-6235" name="3 Fellwater Troggoths" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="2c11-7fe6-2311-6235" name="3 Fellwater Troggoths" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -230,7 +230,7 @@
         <categoryLink id="ebee-87a6-4d77-7338" name="New CategoryLink" hidden="false" targetId="7028-500a-7514-9de1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="0d96-ca36-4bf9-4f9a" name="3 Rockgut Troggoths" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="0d96-ca36-4bf9-4f9a" name="3 Rockgut Troggoths" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -307,7 +307,7 @@
         <categoryLink id="4071-acb6-b964-df88" name="New CategoryLink" hidden="false" targetId="d9e4-0e75-af07-f1ed" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="22e0-12c5-4928-dc32" name="3 Sourbreath Troggoths" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="22e0-12c5-4928-dc32" name="3 Sourbreath Troggoths" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>

--- a/Order - Daughters of Khaine.cat
+++ b/Order - Daughters of Khaine.cat
@@ -1551,7 +1551,7 @@
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                 <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">2&quot;</characteristic>
-                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0"/>
+                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">6</characteristic>
                 <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">3+</characteristic>
                 <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
                 <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-1</characteristic>
@@ -2629,7 +2629,7 @@
                 <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">2</characteristic>
                 <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">3+</characteristic>
                 <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">4+</characteristic>
-                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707"/>
+                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-</characteristic>
                 <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
               </characteristics>
             </profile>

--- a/Order - Empire.cat
+++ b/Order - Empire.cat
@@ -691,7 +691,7 @@
         <categoryLink id="32e5-ec33-cee2-ef87" name="New CategoryLink" hidden="false" targetId="b970-b3bf-e1a4-a6fc" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="3a16-f1f6-f8a9-4521" name="5 Knights of Order" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="3a16-f1f6-f8a9-4521" name="5 Knights of Order" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e11a-733d-3e98-afe7" type="min"/>
             <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="50ae-3416-1f42-29e9" type="max"/>

--- a/Order - High Elves.cat
+++ b/Order - High Elves.cat
@@ -256,7 +256,7 @@
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="42eb-57fe-407a-a6e3" name="10 Highborn Spearmen" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="42eb-57fe-407a-a6e3" name="10 Highborn Spearmen" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4ff4-7fc2-7e29-4682" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4e9e-26d4-2eea-7cfa" type="min"/>
@@ -489,7 +489,7 @@
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="c627-5569-fb15-b6b2" name="5 Highborn Silver Helms" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="c627-5569-fb15-b6b2" name="5 Highborn Silver Helms" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a86d-d8ea-047e-7853" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a0ec-1a60-347e-51a3" type="min"/>
@@ -761,7 +761,7 @@
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="ff9f-582b-5c49-bfe0" name="10 Highborn Archers" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="ff9f-582b-5c49-bfe0" name="10 Highborn Archers" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ebf2-c5e1-8f19-e585" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4cb3-199e-4b1b-1d00" type="min"/>

--- a/Order - Kharadron Overlords - Data.cat
+++ b/Order - Kharadron Overlords - Data.cat
@@ -1468,7 +1468,7 @@
                 <categoryLink id="d806-f34e-8d86-78ab" name="New CategoryLink" hidden="false" targetId="3e42-aa53-94bc-8757" primary="false"/>
               </categoryLinks>
               <selectionEntries>
-                <selectionEntry id="6304-4a38-14dc-8c1b" name="3 Prosecutors" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="6304-4a38-14dc-8c1b" name="3 Prosecutors" hidden="false" collective="false" type="model">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="db7f-29fa-a3a2-ab77" type="min"/>
                     <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8393-73d0-192a-2c5f" type="max"/>
@@ -1644,7 +1644,7 @@
                 <categoryLink id="098b-b676-d6e8-9d21" name="New CategoryLink" hidden="false" targetId="b396-0600-80d6-cee9" primary="false"/>
               </categoryLinks>
               <selectionEntries>
-                <selectionEntry id="fc6c-cb44-b57d-34b5" name="3 Prosecutors" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="fc6c-cb44-b57d-34b5" name="3 Prosecutors" hidden="false" collective="false" type="model">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ccc8-7cc4-6b7b-5918" type="min"/>
                     <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="806b-e394-71a2-57f5" type="max"/>

--- a/Order - Seraphon.cat
+++ b/Order - Seraphon.cat
@@ -4382,7 +4382,7 @@
                 <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">*</characteristic>
                 <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">4+</characteristic>
                 <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
-                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707"/>
+                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-</characteristic>
                 <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
               </characteristics>
             </profile>

--- a/Order - Stormcast Eternals - Data.cat
+++ b/Order - Stormcast Eternals - Data.cat
@@ -2914,7 +2914,7 @@
         <categoryLink id="3410-ac2a-bf55-2271" name="New CategoryLink" hidden="false" targetId="b396-0600-80d6-cee9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="c13f-4ddc-ec60-cc37" name="5 Liberators" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="c13f-4ddc-ec60-cc37" name="5 Liberators" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="816c-3f67-d6b7-3726" type="min"/>
             <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8bdd-921d-93d1-7711" type="max"/>

--- a/Order - Switfhawk Agents.cat
+++ b/Order - Switfhawk Agents.cat
@@ -258,7 +258,7 @@
                 <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">2</characteristic>
                 <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">4+</characteristic>
                 <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">5+</characteristic>
-                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707"/>
+                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-</characteristic>
                 <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
               </characteristics>
             </profile>
@@ -766,7 +766,7 @@
                 <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">4</characteristic>
                 <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">4+</characteristic>
                 <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">5+</characteristic>
-                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707"/>
+                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-</characteristic>
                 <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
               </characteristics>
             </profile>


### PR DESCRIPTION
Many model selectionEntry elements had type attributes with the value of "upgrade." It doesn't seem to impact BattleScribe, but the correction makes for easier external parsing.