### PR TITLE
SCE Battalion, Warclans artefact validations

### DIFF
--- a/Death - Legions of Nagash and Nighthaunt Data.cat
+++ b/Death - Legions of Nagash and Nighthaunt Data.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="e37a-2f18-f168-6ed3" name="Death: LoN and Nighthaunt Data" revision="6" battleScribeVersion="2.03" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="true" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="7" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="e37a-2f18-f168-6ed3" name="Death: LoN and Nighthaunt Data" revision="9" battleScribeVersion="2.03" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="true" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="7" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="e320-d5ec-pubN65537" name="Battletome: Legions of Nagash and Battletome: Nighthaunt"/>
     <publication id="e320-d5ec-pubN65555" name="Battletome: Nighthaunt"/>
@@ -5723,7 +5723,7 @@
         <entryLink id="b87a-78c3-64a1-0fb2" name="Artefacts" hidden="false" collective="false" import="true" targetId="a2c1-3fba-5acb-d560" type="selectionEntryGroup"/>
         <entryLink id="33e6-cddc-e5af-f028" name="Command Traits" hidden="false" collective="false" import="true" targetId="eda1-7945-4fea-a145" type="selectionEntryGroup"/>
         <entryLink id="088b-a113-47d5-029e" name="General" hidden="false" collective="false" import="true" targetId="88d2-d540-0573-3402" type="selectionEntry"/>
-        <entryLink id="61cc-f5be-523c-bb69" name="Lore of the Underworld" hidden="false" collective="false" import="true" targetId="1d74-9116-3b63-3ea2" type="selectionEntryGroup"/>
+        <entryLink id="7688-7cf8-e66b-6b4e" name="Lores of the Dead" hidden="false" collective="false" import="true" targetId="8417-93fc-9562-a748" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="140.0"/>
@@ -6727,7 +6727,6 @@
       <entryLinks>
         <entryLink id="0f56-d492-ae1e-d5a7" name="General" hidden="false" collective="false" import="true" targetId="88d2-d540-0573-3402" type="selectionEntry"/>
         <entryLink id="05cf-4fa7-92d5-04c6" name="Lores of the Dead" hidden="false" collective="false" import="true" targetId="8417-93fc-9562-a748" type="selectionEntryGroup"/>
-        <entryLink id="a1f0-e8fb-210d-07be" name="Lore of the Underworld" hidden="false" collective="false" import="true" targetId="1d74-9116-3b63-3ea2" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="170.0"/>
@@ -7203,7 +7202,7 @@
         <cost name="pts" typeId="points" value="100.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="4766-64b7-70de-195d" name="Battalion: Nighthaunt Procession" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="4766-64b7-70de-195d" name="Super-Battalion: Nighthaunt Procession" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="c6a7-dc2d-ddb9-a324" name="Bound Beneath Indomitable Will" hidden="false" typeId="bdc6-78da-3796-60a3" typeName="Battalion Abilities">
           <characteristics>
@@ -7216,7 +7215,7 @@
         <categoryLink id="dbb6-14f6-fd79-7fa7" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="05ea-3b3f-fdde-6df4" name="1 Shroudguard" hidden="false" collective="false" import="true" defaultSelectionEntryId="6670-af66-729b-c3e6">
+        <selectionEntryGroup id="05ea-3b3f-fdde-6df4" name="1) Shroudguard" hidden="false" collective="false" import="true" defaultSelectionEntryId="6670-af66-729b-c3e6">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c3b-0551-5db4-ef5a" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2f4-fd77-50d7-0e42" type="max"/>
@@ -7229,7 +7228,7 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="ef81-826d-1ae4-6419" name="6 warscroll battalions chosen in any combination from the following:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="ef81-826d-1ae4-6419" name="2) 6 warscroll battalions chosen in any combination from the following:" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fad1-29f2-ed84-6f72" type="min"/>
             <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ed9-a000-9020-b2eb" type="max"/>
@@ -8071,7 +8070,7 @@
         <entryLink id="7f03-4782-562d-e03f" name="Artefacts" hidden="false" collective="false" import="true" targetId="a2c1-3fba-5acb-d560" type="selectionEntryGroup"/>
         <entryLink id="39a4-42bf-2ec4-ce42" name="Command Traits" hidden="false" collective="false" import="true" targetId="eda1-7945-4fea-a145" type="selectionEntryGroup"/>
         <entryLink id="1470-3254-18b8-918c" name="General" hidden="false" collective="false" import="true" targetId="88d2-d540-0573-3402" type="selectionEntry"/>
-        <entryLink id="365d-93a1-fc4f-9130" name="Lore of the Underworld" hidden="false" collective="false" import="true" targetId="1d74-9116-3b63-3ea2" type="selectionEntryGroup"/>
+        <entryLink id="a845-ee36-12e5-494d" name="Lores of the Dead" hidden="false" collective="false" import="true" targetId="8417-93fc-9562-a748" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="140.0"/>
@@ -8380,6 +8379,109 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3662-07ad-18be-cd52" name="Battalion: The Dolorous Guard" page="WD 12/19" hidden="false" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="960b-4a8c-f2f7-62bb" name="Knights of Regret" hidden="false" typeId="bdc6-78da-3796-60a3" typeName="Battalion Abilities">
+          <characteristics>
+            <characteristic name="Battalion Ability Details" typeId="08e0-9ead-1dbe-c801">Add 1 to the Attacks characteristic of melee weapons used by units from this battalion that have made a charge move in the same turn. 
+In addition, roll a dice before you allocate a wound or mortal wound to your general if your general is within 3&quot; of any friendly units with this ability. On a 2+, you must allocate that wound or mortal wound to a friendly unit with that ability that is within 3&quot; of your general, instead of your general.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="30aa-a446-ebad-167a" name="1) 2-4 Hexwraith units" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f1f-a9ec-b7ba-b102" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a560-f8a1-5595-aa55" type="min"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="6d6a-cc71-811d-294f" name="Hexwraiths" hidden="false" collective="false" import="true" targetId="5801-7f4f-cd22-b629" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="120.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cedd-3fe1-36be-9ed0" name="Super-Battalion: The Emerald Host" page="WD 12/19" hidden="false" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="4fcd-10aa-097f-40c7" name="The Emerald Curse" hidden="false" typeId="bdc6-78da-3796-60a3" typeName="Battalion Abilities">
+          <characteristics>
+            <characteristic name="Battalion Ability Details" typeId="08e0-9ead-1dbe-c801">After armies are set up, but before the first battle round begins, you can pick 1 enemy HERO. Subtract 1 from save rolls for attacks that target that HERO.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="7854-7e64-28aa-9120" name="1) The Forgotten Scions" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96b1-163e-0699-33d7" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ec4-a520-125b-de2a" type="min"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="3845-f073-064f-4edd" name="Battalion: The Forgotten Scions" hidden="false" collective="false" import="true" targetId="c326-d34a-12a4-8cbd" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="fda5-295c-ccc1-b60b" name="2) 1+ The Dolorous Guard" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e006-07ed-e3ab-111f" type="min"/>
+            <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f731-d7c4-11f7-a08f" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="199b-d6c9-ef3d-e985" name="Battalion: The Dolorous Guard" hidden="false" collective="false" import="true" targetId="3662-07ad-18be-cd52" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6930-4a8b-36e2-2ac8" name="3) Any number of warscroll battalions chosen in any combination from the following list:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1575-6385-3f8d-f56f" type="min"/>
+            <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="60e9-4818-25b8-4f97" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="dc64-a2c5-b9d7-57dc" name="Battalion: The Condemned" hidden="false" collective="false" import="true" targetId="b4c4-64ab-2174-1733" type="selectionEntry"/>
+            <entryLink id="ade2-076e-edb0-887e" name="Battalion: Death Stalkers" hidden="false" collective="false" import="true" targetId="9ea5-e537-5e8a-f8c0" type="selectionEntry"/>
+            <entryLink id="bf64-2d2e-66b1-04f7" name="Battalion: Chainguard" hidden="false" collective="false" import="true" targetId="1d08-f04f-5e53-c4f8" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="80.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c326-d34a-12a4-8cbd" name="Battalion: The Forgotten Scions" page="WD 12/19" hidden="false" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="3cb4-41c4-83f5-3b49" name="Gharest Malcor, The Traitor Knight" page="" hidden="false" typeId="bdc6-78da-3796-60a3" typeName="Battalion Abilities">
+          <characteristics>
+            <characteristic name="Battalion Ability Details" typeId="08e0-9ead-1dbe-c801">Add 1 to the Attacks characteristic of Malcor&apos;s Sword of Stolen Hours. In addition, once per battle round, you can use the command ability on Malcor&apos;s warscroll without a command point being spent.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="df39-f559-1f1f-5e9a" name="2) 2 Dreadblade Harrow units" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7ac7-d7f1-bc98-b25b" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3234-3a78-91b0-f107" type="min"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="3dce-437a-e064-7788" name="Dreadblade Harrow" hidden="false" collective="false" import="true" targetId="48f2-1bf2-7fbe-167d" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="2973-1bb7-51e8-f379" name="1) 1 Knight of Shrouds on Ethereal Steed (Malcor)" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4b4d-83c6-b2c3-10e5" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8284-82e6-5fb7-1948" type="min"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="a7a4-0ec9-b789-9822" name="Knight of Shrouds on Ethereal Steed" hidden="false" collective="false" import="true" targetId="ca11-74a3-801d-4734" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="name" value="Gharest Malcor"/>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="140.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -8967,10 +9069,15 @@
     </selectionEntryGroup>
     <selectionEntryGroup id="8417-93fc-9562-a748" name="Spell Lores" hidden="false" collective="false" import="true">
       <modifiers>
-        <modifier type="increment" field="0de4-62df-c1e8-cd50" value="2.0">
-          <conditions>
-            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a30c-a3cc-8d16-7290" type="instanceOf"/>
-          </conditions>
+        <modifier type="set" field="0de4-62df-c1e8-cd50" value="3.0">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0c-91b9-f052-24af" type="instanceOf"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0758-0294-87aa-6054" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -8982,10 +9089,10 @@
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0de4-62df-c1e8-cd50" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="2e8c-080c-3933-568f" name="Lore of the Vampires" hidden="false" collective="false" import="true" targetId="25a7-5ed4-85ee-938e" type="selectionEntryGroup"/>
         <entryLink id="8284-552d-f751-e23c" name="Lore of the Underworld" hidden="false" collective="false" import="true" targetId="1d74-9116-3b63-3ea2" type="selectionEntryGroup"/>
-        <entryLink id="e8b4-bf31-fc34-d895" name="Lore of the Deathmages" hidden="false" collective="false" import="true" targetId="17ec-0f53-8531-15b5" type="selectionEntryGroup"/>
         <entryLink id="f73e-bb01-738a-a680" name="Lore of Sorrows" hidden="false" collective="false" import="true" targetId="75b2-7567-deab-a948" type="selectionEntryGroup"/>
+        <entryLink id="5e7c-ea70-5f5d-dfa6" name="Lore of the Deathmages" hidden="false" collective="false" import="true" targetId="17ec-0f53-8531-15b5" type="selectionEntryGroup"/>
+        <entryLink id="791c-c6f7-aef6-76cd" name="Lore of the Vampires" hidden="false" collective="false" import="true" targetId="25a7-5ed4-85ee-938e" type="selectionEntryGroup"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="21e2-bff5-c2ea-755f" name="Artefacts: Soulblight" hidden="false" collective="false" import="true">
@@ -10302,6 +10409,16 @@
             </conditionGroup>
           </conditionGroups>
         </modifier>
+        <modifier type="set" field="83a4-6b62-91f2-2ce0" value="3.0">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0c-91b9-f052-24af" type="instanceOf"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0758-0294-87aa-6054" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
       </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="83a4-6b62-91f2-2ce0" type="max"/>
@@ -10414,6 +10531,16 @@
                 <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d1e1-d80a-c667-b587" type="notInstanceOf"/>
                 <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a3df-7eeb-bcac-ac90" type="notInstanceOf"/>
                 <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b17-8770-65a5-e27f" type="notInstanceOf"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set" field="4dfa-6569-dae1-e760" value="3.0">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7c0c-91b9-f052-24af" type="instanceOf"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0758-0294-87aa-6054" type="greaterThan"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -10653,10 +10780,13 @@
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5ab-f60e-c534-427f" type="equalTo"/>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5ab-f60e-c534-427f" type="lessThan"/>
           </conditions>
         </modifier>
       </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4f63-ec77-65fd-7b4e" type="max"/>
+      </constraints>
       <selectionEntries>
         <selectionEntry id="c847-9563-92f0-fc04" name="1. Dread Withering" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -10762,7 +10892,7 @@
     </profile>
     <profile id="154c-e7e7-3d05-a781" name="Gravesite: Invigorating Aura" hidden="false" typeId="c137-4d1f-9d1a-524d" typeName="Battle Trait">
       <characteristics>
-        <characteristic name="Battle Trait Details" typeId="9fdd-b4b1-5f7a-0970">At the start of your hero phase, pick a friendly SUMMONABLE unit within 9&quot; of this gravesite. You can either heal D3 wounds that have been allocated to it or, if no wounds are currently allocated to the unit, you may return a number of slain models to it that have a combined Wounds characteristic equal to or less than the roll of a D3.</characteristic>
+        <characteristic name="Battle Trait Details" typeId="9fdd-b4b1-5f7a-0970">At the start of your hero phase, pick a friendly SUMMONABLE unit within 9&quot; of a gravesite. You can either heal D3 wounds that have been allocated to it or, if no wounds are currently allocated to the unit, you may return a number of slain models to it that have a combined Wounds characteristic equal to or less than the roll of a D3.</characteristic>
       </characteristics>
     </profile>
     <profile id="3998-f3e4-90e7-348a" name="Deathless Minions" hidden="false" typeId="c137-4d1f-9d1a-524d" typeName="Battle Trait">

--- a/Death - Nighthaunt.cat
+++ b/Death - Nighthaunt.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="2a46-0cf8-0cf4-e8b2" name="Death - Nighthaunt" revision="3" battleScribeVersion="2.03" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="54" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="2a46-0cf8-0cf4-e8b2" name="Death - Nighthaunt" revision="5" battleScribeVersion="2.03" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="54" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="d1ad-bba8-08e5-42da" name="Guardian of Souls with Nightmare Lantern" hidden="false" collective="false" import="true" targetId="b792-d5a1-d285-84b9" type="selectionEntry"/>
     <entryLink id="a061-b05c-7d73-58b4" name="Lady Olynder, Mortarch of Grief" hidden="false" collective="false" import="true" targetId="8ff7-4d68-6b6b-4bcc" type="selectionEntry"/>
@@ -36,6 +36,9 @@
     <entryLink id="f4b8-f559-589b-9791" name="The Briar Queen" hidden="false" collective="false" import="true" targetId="858e-ff08-a895-01e0" type="selectionEntry"/>
     <entryLink id="b215-7919-d239-66a4" name="Thorns of the Briar Queen" hidden="false" collective="false" import="true" targetId="0c14-be3f-7172-f030" type="selectionEntry"/>
     <entryLink id="6b24-f027-5ed5-07f2" name="Black Coach" hidden="false" collective="false" import="true" targetId="12bd-c09c-822e-1e5e" type="selectionEntry"/>
+    <entryLink id="18f2-b4b5-623e-e881" name="*Battalion: The Dolorous Guard" hidden="false" collective="false" import="true" targetId="3662-07ad-18be-cd52" type="selectionEntry"/>
+    <entryLink id="185d-3295-3cb6-ad60" name="*Battalion: The Emerald Host" hidden="false" collective="false" import="true" targetId="cedd-3fe1-36be-9ed0" type="selectionEntry"/>
+    <entryLink id="9464-9484-f241-d394" name="*Battalion: The Forgotten Scions" hidden="false" collective="false" import="true" targetId="c326-d34a-12a4-8cbd" type="selectionEntry"/>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="a352-6c12-37a7-8b19" name="Alliegiance" hidden="false" collective="false" import="true" type="upgrade">

--- a/Destruction - Gloomspite Gitz.cat
+++ b/Destruction - Gloomspite Gitz.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="750c-157c-3186-61d3" name="Destruction - Gloomspite Gitz" revision="18" battleScribeVersion="2.03" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="46" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="750c-157c-3186-61d3" name="Destruction - Gloomspite Gitz" revision="19" battleScribeVersion="2.03" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="46" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="3323-8984-c803-feb5" name="Gloomspite Errata/Points, July 2019"/>
   </publications>
@@ -79,7 +79,7 @@
     <entryLink id="d894-1877-e48a-d85d" name="Madcap Shaman" hidden="false" collective="false" import="true" targetId="4456-155d-685b-bd18" type="selectionEntry"/>
     <entryLink id="7c8d-2f3d-67f0-7e04" name="Loonsmasha Fanatics" hidden="false" collective="false" import="true" targetId="b1a7-92f3-64d3-91f1" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a9ee-3db2-1dd0-cb18" name="Other" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
+        <categoryLink id="a9ee-3db2-1dd0-cb18" name="Other" hidden="false" targetId="065e-fda7-fd27-1f40" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6340-167b-938c-5062" name="Battalion: Troggherd" hidden="false" collective="false" import="true" targetId="cfa0-bc57-427f-dac8" type="selectionEntry">
@@ -91,12 +91,12 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="539e-da6f-2491-3685" name="Battalion" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
+        <categoryLink id="539e-da6f-2491-3685" name="Battalion" hidden="false" targetId="be17-6bbd-b857-3f43" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b583-cda5-78cc-82b3" name="Boingrot Bounders" hidden="false" collective="false" import="true" targetId="ff2e-4400-dbde-d4c4" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="9031-2978-a3f5-2005" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
+        <categoryLink id="9031-2978-a3f5-2005" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="403d-f219-0811-551b" name="Zarbag&apos;s Gitz" hidden="false" collective="false" import="true" targetId="2653-d92c-7afc-5bf6" type="selectionEntry">
@@ -108,7 +108,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f78e-757a-032d-63f6" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
+        <categoryLink id="f78e-757a-032d-63f6" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2fa8-e4d0-5fd3-fd08" name="Zarbag" hidden="false" collective="false" import="true" targetId="db84-4cbf-0008-9a63" type="selectionEntry">
@@ -121,7 +121,7 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="80d9-404a-38d1-e227" name="HERO" hidden="false" targetId="4e0e-664d-51ea-0929" primary="false"/>
-        <categoryLink id="23ee-da9f-89e8-e7a8" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
+        <categoryLink id="23ee-da9f-89e8-e7a8" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="false"/>
         <categoryLink id="2375-b3a1-55f0-a470" name="DESTRUCTION" hidden="false" targetId="d963-a5fb-c348-2371" primary="false"/>
         <categoryLink id="1479-7967-f332-11fc" name="GROT" hidden="false" targetId="ef9c-701b-aad2-4e19" primary="false"/>
         <categoryLink id="7560-e9c1-eea4-cf6b" name="GLOOMSPITE GITZ" hidden="false" targetId="19e1-59e0-e5c6-2e94" primary="false"/>
@@ -129,99 +129,14 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="4e28-9e45-8827-ceed" name="Stabbas" hidden="false" collective="false" import="true" targetId="f468-427a-bd3b-4e91" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
-        <categoryLink id="b126-0214-d456-0bb2" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true"/>
+        <categoryLink id="b126-0214-d456-0bb2" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="eac4-d409-c319-5504" name="Shootas" hidden="false" collective="false" import="true" targetId="8599-239f-ebc7-8fcc" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="notInstanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="notInstanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="notInstanceOf"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="c0fd-3a7f-c459-2c54" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="ea88-0fff-67ed-ad6f" name="Fellwater Troggoths" hidden="false" collective="false" import="true" targetId="1532-280f-10d7-576e" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e404-398e-c044-e29a" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="edba-4107-8dd7-8613" type="greaterThan"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="8521-9527-3c3b-9740" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="483c-c369-9c07-ed26" name="Fellwater Troggoths" hidden="false" collective="false" import="true" targetId="1532-280f-10d7-576e" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e404-398e-c044-e29a" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="edba-4107-8dd7-8613" type="greaterThan"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="16c8-3c67-2546-4e88" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true"/>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="aff7-5abe-42dd-6b6e" name="Dankhold Troggboss" hidden="false" collective="false" import="true" targetId="5a11-19e5-ab10-9fd6" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="edba-4107-8dd7-8613" type="greaterThan"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="0df9-0eea-b4bd-29a2" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
-        <categoryLink id="1fb9-a22a-fa8f-d1f3" name="MONSTER" hidden="false" targetId="1959-9f6a-3056-913a" primary="false"/>
-        <categoryLink id="61e2-e154-2a00-2cf2" name="TROGGBOSS" hidden="false" targetId="b98e-fa5a-4d20-1b47" primary="false"/>
-        <categoryLink id="e9a6-f40f-f266-ea01" name="TROGGOTH" hidden="false" targetId="be2b-5e91-b381-5671" primary="false"/>
-      </categoryLinks>
-    </entryLink>
+    <entryLink id="ea88-0fff-67ed-ad6f" name="Fellwater Troggoths" hidden="false" collective="false" import="true" targetId="1532-280f-10d7-576e" type="selectionEntry"/>
     <entryLink id="90c2-6206-9d63-9e26" name="Loonboss on Giant Cave Squig" hidden="false" collective="false" import="true" targetId="8616-ec44-afd5-57d3" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="e702-5ef9-18e7-d84e" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
+        <categoryLink id="e702-5ef9-18e7-d84e" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="false"/>
         <categoryLink id="91ca-323c-c732-b47a" name="SQUIG" hidden="false" targetId="647a-69d4-fe9c-2491" primary="false"/>
         <categoryLink id="fc91-6529-65b5-8a0e" name="LOONBOSS" hidden="false" targetId="4df8-b60f-f24f-8cf1" primary="false"/>
         <categoryLink id="8953-e648-948d-7c4c" name="DESTRUCTION" hidden="false" targetId="d963-a5fb-c348-2371" primary="false"/>
@@ -229,123 +144,23 @@
         <categoryLink id="30ad-5bf9-fcbd-cc52" name="HERO" hidden="false" targetId="4e0e-664d-51ea-0929" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="c4e0-7559-06ad-0d86" name="Rockgut Troggoths" hidden="false" collective="false" import="true" targetId="3aaf-796a-28a6-fcce" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e404-398e-c044-e29a" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="edba-4107-8dd7-8613" type="greaterThan"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="e957-6bb6-0737-fd59" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true"/>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="15e7-d1be-abcc-a204" name="Rockgut Troggoths" hidden="false" collective="false" import="true" targetId="3aaf-796a-28a6-fcce" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e404-398e-c044-e29a" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="edba-4107-8dd7-8613" type="greaterThan"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="178b-77b9-7983-f33e" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
-        <categoryLink id="eb64-8957-2013-50a1" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="false"/>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="c294-2a11-af9c-7cc8" name="Spider Riders" hidden="false" collective="false" import="true" targetId="f71c-25f7-10fd-9f8e" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5598-b0b7-b976-5d72" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="aab0-250c-6880-5d97" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="false"/>
-        <categoryLink id="52f8-ee37-5d1d-df89" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true"/>
-      </categoryLinks>
-    </entryLink>
+    <entryLink id="15e7-d1be-abcc-a204" name="Rockgut Troggoths" hidden="false" collective="false" import="true" targetId="3aaf-796a-28a6-fcce" type="selectionEntry"/>
     <entryLink id="aaea-fa97-38a2-2db1" name="Spider Riders" hidden="false" collective="false" import="true" targetId="f71c-25f7-10fd-9f8e" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5598-b0b7-b976-5d72" type="greaterThan"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
-        <categoryLink id="572b-80ce-cf11-e5e2" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
+        <categoryLink id="572b-80ce-cf11-e5e2" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4094-9df8-1e66-bbb3" name="Loonboss" hidden="false" collective="false" import="true" targetId="d7de-3092-1abc-b208" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="90c4-04a9-99ca-89a6" name="LOONBOSS" hidden="false" targetId="4df8-b60f-f24f-8cf1" primary="false"/>
-        <categoryLink id="5db3-0a49-8989-aa4f" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
+        <categoryLink id="5db3-0a49-8989-aa4f" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="false"/>
         <categoryLink id="9aec-c65f-75db-5e26" name="HERO" hidden="false" targetId="4e0e-664d-51ea-0929" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="d173-adaa-6567-2a7d" name="Squig Herd" hidden="false" collective="false" import="true" targetId="016c-28fe-0300-5a7b" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5598-b0b7-b976-5d72" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e404-398e-c044-e29a" type="greaterThan"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="e520-bb7c-e164-d09c" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true"/>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="8d20-a798-f03a-d4a6" name="Squig Herd" hidden="false" collective="false" import="true" targetId="016c-28fe-0300-5a7b" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5598-b0b7-b976-5d72" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e404-398e-c044-e29a" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="c0e3-ec98-cbfb-82d7" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
-      </categoryLinks>
-    </entryLink>
+    <entryLink id="8d20-a798-f03a-d4a6" name="Squig Herd" hidden="false" collective="false" import="true" targetId="d7f2-6558-9c0f-89bc" type="selectionEntry"/>
     <entryLink id="508e-ba2b-6530-65db" name="Aleguzzler Gargant" hidden="false" collective="false" import="true" targetId="9353-2c1a-a365-7fcd" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="5c24-6d9d-af12-e9dd" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="true"/>
+        <categoryLink id="5c24-6d9d-af12-e9dd" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2e34-4297-2fc7-b0fd" name="Allegiance" hidden="false" collective="false" import="true" targetId="b612-c701-be32-d00d" type="selectionEntry">
@@ -359,18 +174,18 @@
     </entryLink>
     <entryLink id="e3d8-8996-c8eb-2f52" name="Arachnarok Spider with Flinger" hidden="false" collective="false" import="true" targetId="aa89-7439-46a3-15cf" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3285-1818-d697-e5f7" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="true"/>
+        <categoryLink id="3285-1818-d697-e5f7" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b4b1-6c46-18ca-e7d2" name="Arachnarok Spider with Spiderfang Warparty" hidden="false" collective="false" import="true" targetId="5733-02d6-236b-4cbf" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b440-a494-37ad-9c2c" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="true"/>
+        <categoryLink id="b440-a494-37ad-9c2c" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5add-83c4-3432-4c3f" name="Bad Moon Loonshrine" hidden="false" collective="false" import="true" targetId="923f-6761-574a-0688" type="selectionEntry"/>
     <entryLink id="9c0b-0d90-35a3-b122" name="Colossal Squig" hidden="false" collective="false" import="true" targetId="48cd-dd8f-5a2d-5e99" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="cef2-e3fb-619d-f63d" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="true"/>
+        <categoryLink id="cef2-e3fb-619d-f63d" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d7bf-e990-4964-f25f" name="Dankhold Troggoth" hidden="false" collective="false" import="true" targetId="a3ed-975b-819f-65c9" type="selectionEntry">
@@ -381,19 +196,16 @@
           </conditions>
         </modifier>
       </modifiers>
-      <categoryLinks>
-        <categoryLink id="fe62-f596-636a-b781" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
-      </categoryLinks>
     </entryLink>
     <entryLink id="04ca-f4e4-7e08-496a" name="Fungoid Cave-Shaman" hidden="false" collective="false" import="true" targetId="6d41-0a01-8e38-6094" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="1777-6028-0bdf-110e" name="HERO" hidden="false" targetId="4e0e-664d-51ea-0929" primary="false"/>
-        <categoryLink id="2820-e7ec-5b44-0e19" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
+        <categoryLink id="2820-e7ec-5b44-0e19" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7bd4-e7f4-817b-98f5" name="Gobbapalooza" hidden="false" collective="false" import="true" targetId="649e-bb80-2cdb-9589" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="cb4c-7209-6cf7-7af0" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
+        <categoryLink id="cb4c-7209-6cf7-7af0" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f5ba-3dd8-de2e-78fa" name="Loonboss on Mangler Squigs" hidden="false" collective="false" import="true" targetId="6a0d-90f0-a499-dfbb" type="selectionEntry">
@@ -401,7 +213,7 @@
         <categoryLink id="edf3-fbef-ef9f-2ba0" name="DESTRUCTION" hidden="false" targetId="d963-a5fb-c348-2371" primary="false"/>
         <categoryLink id="9ea9-31d7-4b4f-d0ef" name="GLOOMSPITE GITZ" hidden="false" targetId="19e1-59e0-e5c6-2e94" primary="false"/>
         <categoryLink id="021b-735a-094b-2702" name="HERO" hidden="false" targetId="4e0e-664d-51ea-0929" primary="false"/>
-        <categoryLink id="77e4-ab33-eb63-4280" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
+        <categoryLink id="77e4-ab33-eb63-4280" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="false"/>
         <categoryLink id="7cfc-32ae-eb13-d60f" name="LOONBOSS" hidden="false" targetId="4df8-b60f-f24f-8cf1" primary="false"/>
         <categoryLink id="adf1-1fde-33cf-2888" name="Behemoth" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false"/>
       </categoryLinks>
@@ -412,12 +224,12 @@
         <categoryLink id="dc4f-38c9-3de7-a391" name="GLOOMSPITE GITZ" hidden="false" targetId="19e1-59e0-e5c6-2e94" primary="false"/>
         <categoryLink id="87fb-cdf8-4898-5eaf" name="HERO" hidden="false" targetId="4e0e-664d-51ea-0929" primary="false"/>
         <categoryLink id="a688-4e78-6058-66a1" name="LOONBOSS" hidden="false" targetId="4df8-b60f-f24f-8cf1" primary="false"/>
-        <categoryLink id="279b-2887-4f61-cf17" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
+        <categoryLink id="279b-2887-4f61-cf17" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8f64-1108-617d-49f0" name="Mangler Squigs" hidden="false" collective="false" import="true" targetId="ebf9-d4df-0661-726d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="def8-cc6b-7855-7dd0" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="true"/>
+        <categoryLink id="def8-cc6b-7855-7dd0" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="55db-cd60-7a7a-a163" name="Mollog" hidden="false" collective="false" import="true" targetId="857e-08ce-74a7-043f" type="selectionEntry">
@@ -430,19 +242,18 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="923a-f632-0c3d-a950" name="HERO" hidden="false" targetId="4e0e-664d-51ea-0929" primary="false"/>
-        <categoryLink id="8539-0252-21ed-5a60" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
+        <categoryLink id="8539-0252-21ed-5a60" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="521b-671b-be27-575b" name="Scuttleboss on Gigantic Spider" hidden="false" collective="false" import="true" targetId="acdd-a781-ffe2-69b1" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="c5ce-7f95-fb62-d703" name="SPIDERFANG" hidden="false" targetId="0039-839c-c04f-5451" primary="false"/>
-        <categoryLink id="9491-d28c-8af5-1440" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2325-cbc8-d512-0e11" name="Skitterstrand Arachnarok" hidden="false" collective="false" import="true" targetId="3e7f-35df-5a5d-0b38" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="3ea1-a273-bb77-a48f" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="false"/>
-        <categoryLink id="9e68-e181-4007-f260" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="true"/>
+        <categoryLink id="9e68-e181-4007-f260" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="769c-213a-a559-9692" name="Skragrott, the Loonking" hidden="false" collective="false" import="true" targetId="a2bb-637e-6b79-4ea3" type="selectionEntry">
@@ -458,54 +269,28 @@
         <categoryLink id="39be-620b-904a-87cf" name="GLOOMSPITE GITZ" hidden="false" targetId="19e1-59e0-e5c6-2e94" primary="false"/>
         <categoryLink id="cd6b-bcc2-19c5-24ad" name="GROT" hidden="false" targetId="ef9c-701b-aad2-4e19" primary="false"/>
         <categoryLink id="7401-2175-aabc-1efd" name="HERO" hidden="false" targetId="4e0e-664d-51ea-0929" primary="false"/>
-        <categoryLink id="a328-7c31-99d6-8b10" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
+        <categoryLink id="a328-7c31-99d6-8b10" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="false"/>
         <categoryLink id="2f51-1bd7-0cc6-c3e7" name="WIZARD" hidden="false" targetId="4f53-8230-2f02-9639" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b067-d8cd-64cb-2ce1" name="Sneaky Shufflers" hidden="false" collective="false" import="true" targetId="7f2d-e883-6fb0-ef8b" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="f102-df40-f15b-62d5" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
+        <categoryLink id="f102-df40-f15b-62d5" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="db10-bc42-a04c-45f1" name="Sporesplatta Fanatics" hidden="false" collective="false" import="true" targetId="3469-bad7-6b85-14b7" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="bcd5-c4fd-18a4-e9a4" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
+        <categoryLink id="bcd5-c4fd-18a4-e9a4" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4b2b-d7af-642b-85c5" name="Squig Gobba" hidden="false" collective="false" import="true" targetId="4a2d-0812-1be1-cc52" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7a95-8694-7ff6-1468" name="New CategoryLink" hidden="false" targetId="1d26-07fc-6a66-d73e" primary="true"/>
+        <categoryLink id="7a95-8694-7ff6-1468" name="New CategoryLink" hidden="false" targetId="1d26-07fc-6a66-d73e" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="19c7-4f2e-b279-e1d4" name="Squig Hoppers" hidden="false" collective="false" import="true" targetId="73c2-8a55-9faa-bb56" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f0a0-7340-338a-fdd2" type="greaterThan"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
-        <categoryLink id="ef25-1fbc-ec27-9215" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="f6aa-029d-1c30-ccb2" name="Squig Hoppers" hidden="false" collective="false" import="true" targetId="73c2-8a55-9faa-bb56" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f0a0-7340-338a-fdd2" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="0bd0-397b-2542-143e" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true"/>
+        <categoryLink id="ef25-1fbc-ec27-9215" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2e83-387c-3c8e-a77f" name="Troggoth Hag" hidden="false" collective="false" import="true" targetId="39db-30e2-d877-afce" type="selectionEntry">
@@ -517,7 +302,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0a1a-19fb-cf00-4f3c" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
+        <categoryLink id="0a1a-19fb-cf00-4f3c" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="false"/>
         <categoryLink id="0dee-94e8-9fc3-7fcf" name="HERO" hidden="false" targetId="4e0e-664d-51ea-0929" primary="false"/>
         <categoryLink id="845b-6768-7c41-a93d" name="MONSTER" hidden="false" targetId="1959-9f6a-3056-913a" primary="false"/>
         <categoryLink id="9d55-337b-636d-acfe" name="TROGGOTH" hidden="false" targetId="be2b-5e91-b381-5671" primary="false"/>
@@ -526,101 +311,70 @@
     </entryLink>
     <entryLink id="2242-65ba-9312-d2b3" name="Webspinner Shaman" hidden="false" collective="false" import="true" targetId="61af-737d-a504-8955" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b230-f1c0-9249-b0e7" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
+        <categoryLink id="b230-f1c0-9249-b0e7" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="false"/>
         <categoryLink id="76c1-3315-8d99-541b" name="SPIDERFANG" hidden="false" targetId="0039-839c-c04f-5451" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="e0f1-dc7e-f637-04b3" name="Webspinner Shaman on Arachnarok Spider" hidden="false" collective="false" import="true" targetId="27a1-4c07-2d2a-0b46" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="5cd8-96a9-fbbe-aaa2" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
+        <categoryLink id="5cd8-96a9-fbbe-aaa2" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="false"/>
         <categoryLink id="2913-fbc9-f3c3-8c8f" name="SPIDERFANG" hidden="false" targetId="0039-839c-c04f-5451" primary="false"/>
         <categoryLink id="5400-7df6-d9d2-9aa3" name="Behemoth" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8ebb-8b7b-e71c-85d2" name="Bonegrinder Gargant" hidden="false" collective="false" import="true" targetId="bab8-af7f-af7e-ed87" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2689-0192-38b9-879b" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="true"/>
+        <categoryLink id="2689-0192-38b9-879b" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="0502-548a-3a9e-c2d3" name="Battalion: Gobbapalooza" hidden="false" collective="false" import="true" targetId="5a8d-7791-d79a-356a" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="58b4-29a1-09e9-82ec" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
+        <categoryLink id="58b4-29a1-09e9-82ec" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b2de-282c-53ff-2e0d" name="Battalion: Skulkmob Horde" hidden="false" collective="false" import="true" targetId="4e4d-0bc4-c7d6-6eaf" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a1a4-1516-7e6b-8fe5" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
+        <categoryLink id="a1a4-1516-7e6b-8fe5" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="98bc-f2f3-e8bd-81f5" name="Super Battalion: Squigalanche" hidden="false" collective="false" import="true" targetId="9928-67fe-9864-84ad" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="cf60-2aae-7657-0c96" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
+        <categoryLink id="cf60-2aae-7657-0c96" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="cf42-f225-338b-0d73" name="Battalion: Squig Rider Stampede" hidden="false" collective="false" import="true" targetId="18ec-b6d7-94d1-d444" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b52b-001d-ab67-14cf" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
+        <categoryLink id="b52b-001d-ab67-14cf" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a7ef-da50-0c7b-18f6" name="Battalion: Arachnarok Spider Cluster" hidden="false" collective="false" import="true" targetId="27da-db86-26ff-eb50" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="798e-9701-e450-f77f" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
+        <categoryLink id="798e-9701-e450-f77f" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4b32-2d0e-8754-1b23" name="Super Battalion: Moonclan Skrap" hidden="false" collective="false" import="true" targetId="5cb6-36e9-af0e-4dce" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a988-39b1-9beb-69c4" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
+        <categoryLink id="a988-39b1-9beb-69c4" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a557-f316-7329-da5e" name="Battalion: Spider Rider Skitterswarm" hidden="false" collective="false" import="true" targetId="9cd2-feda-dc7f-2af9" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3f96-b6b3-fe92-b0f3" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
+        <categoryLink id="3f96-b6b3-fe92-b0f3" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="281d-2999-10f4-5ff1" name="Super Battalion: Spiderfang Stalktribe" hidden="false" collective="false" import="true" targetId="f39e-acf2-fa09-4b31" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ddd2-e1b3-9459-f9eb" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
+        <categoryLink id="ddd2-e1b3-9459-f9eb" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5171-e127-fddb-ef49" name="Battalion: Skitterstrand Nest" hidden="false" collective="false" import="true" targetId="306e-05ca-7807-93f2" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="d0c4-8479-578d-b607" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
+        <categoryLink id="d0c4-8479-578d-b607" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="fdcf-0d49-1d7b-3f1c" name="Shootas" hidden="false" collective="false" import="true" targetId="8599-239f-ebc7-8fcc" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
-        <categoryLink id="0f24-0111-ae82-9a54" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true"/>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="a6c2-eda7-fb41-9816" name="Stabbas" hidden="false" collective="false" import="true" targetId="f468-427a-bd3b-4e91" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="notInstanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="notInstanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="notInstanceOf"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="7cba-9737-e190-b35c" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
+        <categoryLink id="0f24-0111-ae82-9a54" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="08f9-69ab-7992-76ec" name="Endless Spell: Malevolent Moon" hidden="false" collective="false" import="true" targetId="bf4d-5916-7df5-d8f0" type="selectionEntry">
@@ -632,7 +386,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="0bb1-0112-6d50-67c0" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+        <categoryLink id="0bb1-0112-6d50-67c0" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2617-3056-0e75-4109" name="Endless Spell: Mork&apos;s Mighty Mushroom" hidden="false" collective="false" import="true" targetId="caea-d9a3-d607-40de" type="selectionEntry">
@@ -644,7 +398,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="5338-4778-fcff-2c02" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+        <categoryLink id="5338-4778-fcff-2c02" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7d7c-9492-b438-955b" name="Endless Spell: Scrapskuttle&apos;s Arachnacauldron" hidden="false" collective="false" import="true" targetId="4714-06e3-b290-89b0" type="selectionEntry">
@@ -656,7 +410,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4e70-f346-b37d-6ec6" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+        <categoryLink id="4e70-f346-b37d-6ec6" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a9f9-2782-213d-39d4" name="Endless Spell: Scuttletide" hidden="false" collective="false" import="true" targetId="3449-0bfa-dbb9-e457" type="selectionEntry">
@@ -668,102 +422,23 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="581c-9291-0a10-123b" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+        <categoryLink id="581c-9291-0a10-123b" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="51d1-2000-a124-4349" name="Dankhold Troggboss" hidden="false" collective="false" import="true" targetId="5a11-19e5-ab10-9fd6" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="edba-4107-8dd7-8613" type="greaterThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="d172-7e1b-8cd6-088e" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="false"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
-    <selectionEntry id="016c-28fe-0300-5a7b" name="Squig Herd" hidden="false" collective="false" import="true" type="unit">
-      <profiles>
-        <profile id="3d58-fa79-e6e7-8974" name="Squig Herd" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
-          <characteristics>
-            <characteristic name="Move" typeId="8655-6213-2824-1752">5&quot;</characteristic>
-            <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">2</characteristic>
-            <characteristic name="Bravery" typeId="0c85-bf79-836b-759e">3</characteristic>
-            <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">6+</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="d446-9840-05a9-99e5" name="Go Dat Way!" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-          <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">You can re-roll run and charge rolls for this unit while it includes any Squig Herders. </characteristic>
-          </characteristics>
-        </profile>
-        <profile id="ef60-e8dc-7916-a05e" name="Squigs Go Wild" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-          <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Roll a dice each time a Cave Squig model from this unit flees, before the model is removed from play. On a 4+, the nearest other unit within 6&quot; of the fleeing model suffers 1 mortal wound. If two or more of such units are equally close, you can pick which suffers the mortal wound.</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="6116-4d95-305b-ea76" name="Squig Herder" hidden="false" typeId="8b8c-5816-cbdb-9763" typeName="Unit Leader">
-          <characteristics>
-            <characteristic name="Leader Ability" typeId="afb5-0652-767a-6769">1 in every 6 models in this unit must be a Squig Herder model instead of a Cave Squig model. A Squig Herder is armed with a Squig Prodder instead of a Fang-filled Gob.</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <categoryLinks>
-        <categoryLink id="b4a0-0c77-5fc7-5b4b" name="DESTRUCTION" hidden="false" targetId="d963-a5fb-c348-2371" primary="false"/>
-        <categoryLink id="b771-a723-bae8-44bf" name="GLOOMSPITE GITZ" hidden="false" targetId="19e1-59e0-e5c6-2e94" primary="false"/>
-        <categoryLink id="12f1-6a17-5ee9-8049" name="MOONCLAN" hidden="false" targetId="2736-9589-d74d-1c51" primary="false"/>
-        <categoryLink id="e2e9-04ef-d250-e92a" name="SQUIG" hidden="false" targetId="6f5e-2209-6f2b-8f48" primary="false"/>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="38dd-5a78-4f5f-73ca" name="5 Squigs &amp; Squig Herder" hidden="false" collective="false" import="true" type="model">
-          <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="92c8-9318-3495-eb39" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a19e-edd0-6f0b-927e" type="min"/>
-          </constraints>
-          <costs>
-            <cost name="pts" typeId="points" value="70.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="76ea-b92b-0149-9f0e" name="Squig Prodder" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0524-32e8-963c-7d00" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d6a3-dbc7-a8a5-0e3d" type="min"/>
-          </constraints>
-          <profiles>
-            <profile id="22cc-5327-de5c-17e6" name="Squig Prodder" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
-              <characteristics>
-                <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
-                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
-                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">2</characteristic>
-                <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">5+</characteristic>
-                <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">5+</characteristic>
-                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-</characteristic>
-                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="93b5-8a92-fb79-6aa3" name="Fang-filled Gob" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="25a1-72ce-5906-a99e" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7949-6ad5-2135-b195" type="min"/>
-          </constraints>
-          <profiles>
-            <profile id="641e-a5bb-6c04-c581" name="Fang-filled Gob" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
-              <characteristics>
-                <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
-                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
-                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">2</characteristic>
-                <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">4+</characteristic>
-                <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
-                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-1</characteristic>
-                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="73c2-8a55-9faa-bb56" name="Squig Hoppers" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set-primary" field="category" value="e9f2-765a-b7b8-ce8e">
@@ -871,9 +546,9 @@
             <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">4+</characteristic>
           </characteristics>
         </profile>
-        <profile id="f336-19ec-5dbe-ff29" name="Boing! Smash!" hidden="false" typeId="f71f-b0a4-730e-ced3" typeName="Command Abilities">
+        <profile id="f336-19ec-5dbe-ff29" name="Boing! Smash!" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Command Ability Details" typeId="1b71-4c83-4e8c-093f">After this unit has made a charge move, pick 1 enemy unit within 1&quot; of this unit and roll a dice for each model in this unit. For each 4+, that enemy unit suffers 1 mortal wound.</characteristic>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">After this unit has made a charge move, pick 1 enemy unit within 1&quot; of this unit and roll a dice for each model in this unit. For each 4+, that enemy unit suffers 1 mortal wound.</characteristic>
           </characteristics>
         </profile>
         <profile id="c221-7612-f848-cf94" name="Lances of the Bounderz" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
@@ -895,6 +570,7 @@
         <categoryLink id="f68e-1a59-7fcb-2684" name="GLOOMSPITE GITZ" hidden="false" targetId="19e1-59e0-e5c6-2e94" primary="false"/>
         <categoryLink id="a3d8-a047-8672-d0a6" name="MOONCLAN" hidden="false" targetId="2736-9589-d74d-1c51" primary="false"/>
         <categoryLink id="9db1-f85a-4c29-b074" name="SQUIG" hidden="false" targetId="6f5e-2209-6f2b-8f48" primary="false"/>
+        <categoryLink id="db16-825e-3c3e-37d1" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="03de-94a7-ba65-6208" name="5 Boingrot Bounderz" hidden="false" collective="false" import="true" type="unit">
@@ -985,6 +661,7 @@
         <categoryLink id="b308-b7a0-f0bc-74af" name="DESTRUCTION" hidden="false" targetId="d963-a5fb-c348-2371" primary="false"/>
         <categoryLink id="1f49-a564-9ed6-2ab8" name="GLOOMSPITE GITZ" hidden="false" targetId="19e1-59e0-e5c6-2e94" primary="false"/>
         <categoryLink id="d32e-1460-dcf0-3a48" name="MOONCLAN" hidden="false" targetId="2736-9589-d74d-1c51" primary="false"/>
+        <categoryLink id="d84e-6628-608d-4b62" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="a4e8-77ef-5e8c-a949" name="5 Loonsmasha Fanatics" hidden="false" collective="false" import="true" type="unit">
@@ -1147,10 +824,13 @@
       <profiles>
         <profile id="4930-b5ef-31a9-f253" name="Eat on the Move" hidden="false" typeId="bdc6-78da-3796-60a3" typeName="Battalion Abilities">
           <characteristics>
-            <characteristic name="Battalion Ability Details" typeId="08e0-9ead-1dbe-c801">If the unmodified wound roll for an attack made with a melee weapon used by a model from this battalion is 6m add 1 to the damage characteristic for that attack.</characteristic>
+            <characteristic name="Battalion Ability Details" typeId="08e0-9ead-1dbe-c801">If the unmodified wound roll for an attack made with a melee weapon used by a model from this battalion is 6, add 1 to the damage characteristic for that attack.</characteristic>
           </characteristics>
         </profile>
       </profiles>
+      <categoryLinks>
+        <categoryLink id="2488-2f48-2a77-d542" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
+      </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="f652-9d6f-90b5-a997" name="2. Troggoths (3-9)" hidden="false" collective="false" import="true">
           <constraints>
@@ -1158,28 +838,18 @@
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4766-e348-7f08-3266" type="min"/>
           </constraints>
           <entryLinks>
-            <entryLink id="50f2-2d68-c5b4-887d" name="Dankhold Troggoth" hidden="false" collective="false" import="true" targetId="a3ed-975b-819f-65c9" type="selectionEntry">
-              <categoryLinks>
-                <categoryLink id="d5de-78e8-921b-6b90" name="Other" hidden="false" targetId="065e-fda7-fd27-1f40" primary="false"/>
-              </categoryLinks>
-            </entryLink>
-            <entryLink id="80c2-93e2-7a2f-8188" name="Fellwater Troggoths" hidden="false" collective="false" import="true" targetId="1532-280f-10d7-576e" type="selectionEntry"/>
-            <entryLink id="e55b-2654-ddda-3de5" name="Rockgut Troggoths" hidden="false" collective="false" import="true" targetId="3aaf-796a-28a6-fcce" type="selectionEntry"/>
+            <entryLink id="35ff-7064-8177-663b" name="Dankhold Troggoth" hidden="false" collective="false" import="true" targetId="a3ed-975b-819f-65c9" type="selectionEntry"/>
+            <entryLink id="fabb-bc44-a2cf-77bd" name="Fellwater Troggoths" hidden="false" collective="false" import="true" targetId="1532-280f-10d7-576e" type="selectionEntry"/>
+            <entryLink id="a369-0183-b9b8-4e7c" name="Rockgut Troggoths" hidden="false" collective="false" import="true" targetId="3aaf-796a-28a6-fcce" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="4c35-0de5-ccc5-de26" name="1. Dankhold Troggboss" hidden="false" collective="false" import="true" defaultSelectionEntryId="35d5-08a1-f0d6-2174">
-          <categoryLinks>
-            <categoryLink id="7cd1-9f9d-3ad0-3ff1" name="Leader" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="false"/>
-          </categoryLinks>
           <entryLinks>
             <entryLink id="35d5-08a1-f0d6-2174" name="Dankhold Troggboss" hidden="false" collective="false" import="true" targetId="5a11-19e5-ab10-9fd6" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82ef-3917-6308-006a" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8aec-9152-bf58-ce87" type="min"/>
               </constraints>
-              <categoryLinks>
-                <categoryLink id="f32b-96e8-8c64-c4c6" name="Leader" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="false"/>
-              </categoryLinks>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
@@ -1188,11 +858,7 @@
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c7fb-ec57-05c4-dd16" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="c70b-332f-92e5-6d52" name="Aleguzzler Gargant" hidden="false" collective="false" import="true" targetId="9353-2c1a-a365-7fcd" type="selectionEntry">
-              <categoryLinks>
-                <categoryLink id="6de3-9022-34ea-6dc6" name="Behemoth" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false"/>
-              </categoryLinks>
-            </entryLink>
+            <entryLink id="c70b-332f-92e5-6d52" name="Aleguzzler Gargant" hidden="false" collective="false" import="true" targetId="9353-2c1a-a365-7fcd" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -1254,6 +920,7 @@
         <categoryLink id="5c1d-fb15-3752-7819" name="DESTRUCTION" hidden="false" targetId="d963-a5fb-c348-2371" primary="false"/>
         <categoryLink id="f453-e929-21a5-c904" name="GLOOMSPITE GITZ" hidden="false" targetId="19e1-59e0-e5c6-2e94" primary="false"/>
         <categoryLink id="b6c6-1c14-d40b-898c" name="HERO" hidden="false" targetId="4e0e-664d-51ea-0929" primary="false"/>
+        <categoryLink id="4449-2c81-40c1-33f8" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="12f5-376c-c40b-acb9" name="Crushing Grip" hidden="false" collective="false" import="true" type="upgrade">
@@ -1341,6 +1008,7 @@
         <categoryLink id="4211-b892-ad21-4452" name="GLOOMSPITE GITZ" hidden="false" targetId="19e1-59e0-e5c6-2e94" primary="false"/>
         <categoryLink id="182b-d13a-31b2-fef5" name="MONSTER" hidden="false" targetId="1959-9f6a-3056-913a" primary="false"/>
         <categoryLink id="10b3-188e-1958-5bc2" name="ALEGUZZLER" hidden="false" targetId="93bb-0e9a-301c-169c" primary="false"/>
+        <categoryLink id="316c-e5f0-f83a-f048" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="32ab-085b-e7bd-8c2d" name="Wounds Suffered" hidden="false" collective="false" import="true" type="upgrade">
@@ -1500,6 +1168,7 @@
         <categoryLink id="e646-f0f0-aad7-5d34" name="DESTRUCTION" hidden="false" targetId="d963-a5fb-c348-2371" primary="false"/>
         <categoryLink id="4003-c31d-98bc-5462" name="GLOOMSPITE GITZ" hidden="false" targetId="19e1-59e0-e5c6-2e94" primary="false"/>
         <categoryLink id="c855-a162-546a-76f8" name="TROGGOTH" hidden="false" targetId="be2b-5e91-b381-5671" primary="false"/>
+        <categoryLink id="1282-6ba8-6420-fea9" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="c748-4975-da53-61e3" name="1 Dankhold Troggoth" publicationId="3323-8984-c803-feb5" hidden="false" collective="false" import="true" type="model">
@@ -1564,7 +1233,7 @@
       <modifiers>
         <modifier type="set-primary" field="category" value="e9f2-765a-b7b8-ce8e">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e404-398e-c044-e29a" type="equalTo"/>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e404-398e-c044-e29a" type="equalTo"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -1640,7 +1309,7 @@
       <modifiers>
         <modifier type="set-primary" field="category" value="e9f2-765a-b7b8-ce8e">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e404-398e-c044-e29a" type="equalTo"/>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e404-398e-c044-e29a" type="equalTo"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -1852,6 +1521,7 @@
         <categoryLink id="9f79-9e77-d9bc-9656" name="GROT" hidden="false" targetId="ef9c-701b-aad2-4e19" primary="false"/>
         <categoryLink id="b39c-ead2-321a-a7f1" name="HERO" hidden="false" targetId="4e0e-664d-51ea-0929" primary="false"/>
         <categoryLink id="af4e-46b5-990f-979b" name="MOONCLAN" hidden="false" targetId="2736-9589-d74d-1c51" primary="false"/>
+        <categoryLink id="5ce1-9f2e-adc9-2237" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8ac2-567f-61aa-d877" name="Moon-slicer" hidden="false" collective="false" import="true" type="upgrade">
@@ -1938,6 +1608,7 @@
         <categoryLink id="03f0-a3ac-5da7-5adb" name="MOONCLAN" hidden="false" targetId="2736-9589-d74d-1c51" primary="false"/>
         <categoryLink id="e218-0501-07a4-8139" name="SQUIG" hidden="false" targetId="6f5e-2209-6f2b-8f48" primary="false"/>
         <categoryLink id="0f60-30a5-be01-1abe" name="MONSTER" hidden="false" targetId="1959-9f6a-3056-913a" primary="false"/>
+        <categoryLink id="eff9-eff6-f136-770c" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8ebe-d026-7639-5ca6" name="Wound Suffered" hidden="false" collective="false" import="true" type="upgrade">
@@ -2120,6 +1791,7 @@
         <categoryLink id="4507-000b-a2bf-972d" name="GROT" hidden="false" targetId="ef9c-701b-aad2-4e19" primary="false"/>
         <categoryLink id="bdf0-c195-345d-a790" name="HERO" hidden="false" targetId="4e0e-664d-51ea-0929" primary="false"/>
         <categoryLink id="68a3-755b-c98e-4e22" name="MOONCLAN" hidden="false" targetId="2736-9589-d74d-1c51" primary="false"/>
+        <categoryLink id="6695-878c-9d27-b372" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="75c2-e6ec-5b6f-d39f" name="Moon-prodder (Missile)" hidden="false" collective="false" import="true" type="upgrade">
@@ -2239,6 +1911,7 @@
         <categoryLink id="3c15-98dc-74ac-8a33" name="MOONCLAN" hidden="false" targetId="2736-9589-d74d-1c51" primary="false"/>
         <categoryLink id="3a5d-52f2-310f-db22" name="SQUIG" hidden="false" targetId="6f5e-2209-6f2b-8f48" primary="false"/>
         <categoryLink id="a65b-1960-8b78-0b1c" name="HERO" hidden="false" targetId="4e0e-664d-51ea-0929" primary="false"/>
+        <categoryLink id="c5c6-504b-4f9f-7b6f" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="1cfd-18f0-1366-ec81" name="General - Squig-rider (TROOP)" hidden="true" collective="false" import="true" type="upgrade">
@@ -2368,7 +2041,7 @@
       </profiles>
       <categoryLinks>
         <categoryLink id="f280-0c15-f164-122c" name="WIZARD" hidden="false" targetId="4f53-8230-2f02-9639" primary="false"/>
-        <categoryLink id="f65a-bc5e-e037-2843" name="Leader" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="false"/>
+        <categoryLink id="f65a-bc5e-e037-2843" name="Leader" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
         <categoryLink id="9684-2efe-aeba-85a3" name="HERO" hidden="false" targetId="4e0e-664d-51ea-0929" primary="false"/>
         <categoryLink id="dac9-4fc8-df4a-ae36" name="DESTRUCTION" hidden="false" targetId="d963-a5fb-c348-2371" primary="false"/>
         <categoryLink id="46b6-5990-25f1-c082" name="GROT" hidden="false" targetId="ef9c-701b-aad2-4e19" primary="false"/>
@@ -2533,6 +2206,7 @@
         <categoryLink id="e67e-bd2f-12dd-1872" name="HERO" hidden="false" targetId="4e0e-664d-51ea-0929" primary="false"/>
         <categoryLink id="26da-6ad5-bb72-78b4" name="TROGGOTH" hidden="false" targetId="be2b-5e91-b381-5671" primary="false"/>
         <categoryLink id="2689-03a6-42d2-f0cc" name="DESTRUCTION" hidden="false" targetId="d963-a5fb-c348-2371" primary="false"/>
+        <categoryLink id="6c29-f675-fe97-bf3b" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="3933-2b1f-eb5f-ed08" name="Puff-fungus Club" hidden="false" collective="false" import="true" type="upgrade">
@@ -2626,6 +2300,7 @@
         <categoryLink id="f1bc-5306-05f4-3a95" name="DESTRUCTION" hidden="false" targetId="d963-a5fb-c348-2371" primary="false"/>
         <categoryLink id="4997-467e-fa75-a327" name="GROT" hidden="false" targetId="ef9c-701b-aad2-4e19" primary="false"/>
         <categoryLink id="eed6-4892-b6a7-833f" name="GLOOMSPITE GITZ" hidden="false" targetId="19e1-59e0-e5c6-2e94" primary="false"/>
+        <categoryLink id="c1cd-3e9d-745a-5ebc" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="93c8-6e8d-e657-885b" name="Gigantic Fangs" hidden="false" collective="false" import="true" type="upgrade">
@@ -2727,6 +2402,7 @@
         <categoryLink id="54ec-e4a0-b1fd-dfd6" name="GROT" hidden="false" targetId="ef9c-701b-aad2-4e19" primary="false"/>
         <categoryLink id="06c0-4a16-9331-9abf" name="GLOOMSPITE GITZ" hidden="false" targetId="19e1-59e0-e5c6-2e94" primary="false"/>
         <categoryLink id="32e7-d0e9-7e96-cc72" name="MOONCLAN" hidden="false" targetId="2736-9589-d74d-1c51" primary="false"/>
+        <categoryLink id="f8c9-629d-ff95-66eb" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="bf58-4778-2935-152b" name="Da Moon Onna Stikk (Missile)" hidden="false" collective="false" import="true" type="upgrade">
@@ -2876,6 +2552,7 @@
         <categoryLink id="7be7-c282-f3b2-3565" name="GROT" hidden="false" targetId="ef9c-701b-aad2-4e19" primary="false"/>
         <categoryLink id="4d57-b554-98b0-8dc2" name="GLOOMSPITE GITZ" hidden="false" targetId="19e1-59e0-e5c6-2e94" primary="false"/>
         <categoryLink id="b993-b63b-2232-c9eb" name="MOONCLAN" hidden="false" targetId="2736-9589-d74d-1c51" primary="false"/>
+        <categoryLink id="1095-f56f-1c09-40f6" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="da64-8419-eecb-5169" name="Massive Gob Full of Teeth" hidden="false" collective="false" import="true" type="upgrade">
@@ -3007,7 +2684,7 @@
       </profiles>
       <categoryLinks>
         <categoryLink id="7b55-278a-f291-f1f4" name="DESTRUCTION" hidden="false" targetId="d963-a5fb-c348-2371" primary="false"/>
-        <categoryLink id="ebb7-3601-7466-471a" name="Leader" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="false"/>
+        <categoryLink id="ebb7-3601-7466-471a" name="Leader" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
         <categoryLink id="06f0-10a8-a7ec-0b3c" name="MOONCLAN" hidden="false" targetId="2736-9589-d74d-1c51" primary="false"/>
         <categoryLink id="e3ba-e696-9912-6cdd" name="WIZARD" hidden="false" targetId="4f53-8230-2f02-9639" primary="false"/>
         <categoryLink id="ed34-389f-ab51-093c" name="GROT" hidden="false" targetId="ef9c-701b-aad2-4e19" primary="false"/>
@@ -3134,7 +2811,7 @@
       </profiles>
       <categoryLinks>
         <categoryLink id="8434-b323-a27f-b993" name="SPIDERFANG" hidden="false" targetId="0039-839c-c04f-5451" primary="false"/>
-        <categoryLink id="528e-a55f-e2d5-451d" name="Leader" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="false"/>
+        <categoryLink id="528e-a55f-e2d5-451d" name="Leader" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
         <categoryLink id="f11b-c14e-240b-0c8a" name="DESTRUCTION" hidden="false" targetId="d963-a5fb-c348-2371" primary="false"/>
         <categoryLink id="f9e5-5a81-50ff-554a" name="GLOOMSPITE GITZ" hidden="false" targetId="19e1-59e0-e5c6-2e94" primary="false"/>
         <categoryLink id="bc4d-6b80-99f8-ab86" name="HERO" hidden="false" targetId="4e0e-664d-51ea-0929" primary="false"/>
@@ -3380,6 +3057,7 @@
         <categoryLink id="8a6b-73a4-2880-ea17" name="GLOOMSPITE GITZ" hidden="false" targetId="19e1-59e0-e5c6-2e94" primary="false"/>
         <categoryLink id="1b2c-1a67-7315-d7ac" name="MONSTER" hidden="false" targetId="1959-9f6a-3056-913a" primary="false"/>
         <categoryLink id="4556-b0f9-5cc8-fd54" name="SPIDERFANG" hidden="false" targetId="0039-839c-c04f-5451" primary="false"/>
+        <categoryLink id="b9cf-930f-614a-eade" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="83a7-d365-d50e-e8c7" name="Wounds Suffered" hidden="false" collective="false" import="true" type="upgrade">
@@ -3575,6 +3253,7 @@
         <categoryLink id="38fa-d9f0-d6d9-689e" name="MOONCLAN" hidden="false" targetId="2736-9589-d74d-1c51" primary="false"/>
         <categoryLink id="e7b2-1e22-6dd2-0b13" name="MONSTER" hidden="false" targetId="1959-9f6a-3056-913a" primary="false"/>
         <categoryLink id="a804-2aee-da0f-8590" name="SQUIG" hidden="false" targetId="6f5e-2209-6f2b-8f48" primary="false"/>
+        <categoryLink id="11dd-afb4-0f69-18ef" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="a3d6-2cfb-0373-3638" name="Wound Suffered" hidden="false" collective="false" import="true" type="upgrade">
@@ -3725,6 +3404,7 @@
         <categoryLink id="cd51-7497-9bbe-bf60" name="GLOOMSPITE GITZ" hidden="false" targetId="19e1-59e0-e5c6-2e94" primary="false"/>
         <categoryLink id="67b0-5749-a658-70a8" name="MONSTER" hidden="false" targetId="1959-9f6a-3056-913a" primary="false"/>
         <categoryLink id="6eda-4632-5a5b-2879" name="SPIDERFANG" hidden="false" targetId="0039-839c-c04f-5451" primary="false"/>
+        <categoryLink id="b21f-b544-f260-5e21" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e24a-cf81-b954-b59c" name="Wounds Suffered" hidden="false" collective="false" import="true" type="upgrade">
@@ -3828,6 +3508,7 @@
         <categoryLink id="b1de-0c04-6faa-f718" name="GLOOMSPITE GITZ" hidden="false" targetId="19e1-59e0-e5c6-2e94" primary="false"/>
         <categoryLink id="50a4-ac96-8f54-2a38" name="GROT" hidden="false" targetId="ef9c-701b-aad2-4e19" primary="false"/>
         <categoryLink id="0d7f-649e-b413-9b5b" name="MOONCLAN" hidden="false" targetId="2736-9589-d74d-1c51" primary="false"/>
+        <categoryLink id="781a-d097-b91c-9a7c" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ff7c-9706-0cda-c372" name="Shroomancer" hidden="false" collective="false" import="true" type="model">
@@ -4172,6 +3853,9 @@
           </characteristics>
         </profile>
       </profiles>
+      <categoryLinks>
+        <categoryLink id="825f-dedc-f9a1-9858" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
       <costs>
         <cost name="pts" typeId="points" value="30.0"/>
       </costs>
@@ -4198,6 +3882,9 @@
           </characteristics>
         </profile>
       </profiles>
+      <categoryLinks>
+        <categoryLink id="2bd7-bd44-ea76-712d" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
       <costs>
         <cost name="pts" typeId="points" value="40.0"/>
       </costs>
@@ -4219,6 +3906,9 @@
           </characteristics>
         </profile>
       </profiles>
+      <categoryLinks>
+        <categoryLink id="38ac-502b-6d07-b420" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
       <costs>
         <cost name="pts" typeId="points" value="90.0"/>
       </costs>
@@ -4255,6 +3945,9 @@
           </characteristics>
         </profile>
       </profiles>
+      <categoryLinks>
+        <categoryLink id="a525-8c20-ed7f-c898" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
+      </categoryLinks>
       <costs>
         <cost name="pts" typeId="points" value="40.0"/>
       </costs>
@@ -4280,6 +3973,7 @@
         <categoryLink id="bb2a-5fb9-ce3d-aba3" name="GROT" hidden="false" targetId="ef9c-701b-aad2-4e19" primary="false"/>
         <categoryLink id="4b08-dd9c-0596-7b04" name="GLOOMSPITE GITZ" hidden="false" targetId="19e1-59e0-e5c6-2e94" primary="false"/>
         <categoryLink id="2720-0649-a453-abec" name="MOONCLAN" hidden="false" targetId="2736-9589-d74d-1c51" primary="false"/>
+        <categoryLink id="d07c-ccab-dd39-307d" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="3db2-3139-3b64-49d5" name="6 Sneaky Snufflers" hidden="false" collective="false" import="true" type="unit">
@@ -4344,7 +4038,7 @@
       <modifiers>
         <modifier type="set-primary" field="category" value="e9f2-765a-b7b8-ce8e">
           <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5598-b0b7-b976-5d72" type="equalTo"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5598-b0b7-b976-5d72" type="greaterThan"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -4575,6 +4269,7 @@
         <categoryLink id="7940-9e69-6202-4f5a" name="GLOOMSPITE GITZ" hidden="false" targetId="19e1-59e0-e5c6-2e94" primary="false"/>
         <categoryLink id="d9f4-4b65-aad7-2e80" name="GROT" hidden="false" targetId="ef9c-701b-aad2-4e19" primary="false"/>
         <categoryLink id="58db-6cdc-c3d1-5f4e" name="MOONCLAN" hidden="false" targetId="2736-9589-d74d-1c51" primary="false"/>
+        <categoryLink id="855f-5b07-6a82-3c13" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="9379-5c13-bfd0-98f8" name="20 Stabbas" hidden="false" collective="false" import="true" type="upgrade">
@@ -4761,6 +4456,7 @@
         <categoryLink id="b125-dddb-9a25-a2f9" name="GLOOMSPITE GITZ" hidden="false" targetId="19e1-59e0-e5c6-2e94" primary="false"/>
         <categoryLink id="2fcb-2b12-0339-fbb2" name="GROT" hidden="false" targetId="ef9c-701b-aad2-4e19" primary="false"/>
         <categoryLink id="247b-7fff-f11b-5c09" name="MOONCLAN" hidden="false" targetId="2736-9589-d74d-1c51" primary="false"/>
+        <categoryLink id="a105-c86c-d51a-ea2e" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="11ba-3041-0d9a-e4c1" name="20 Shootas" publicationId="3323-8984-c803-feb5" hidden="false" collective="false" import="true" type="model">
@@ -4939,7 +4635,7 @@
       </profiles>
       <categoryLinks>
         <categoryLink id="32e0-0d30-99e5-af0b" name="SPIDERFANG" hidden="false" targetId="0039-839c-c04f-5451" primary="false"/>
-        <categoryLink id="827a-a4f6-8c38-ddac" name="Leader" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="false"/>
+        <categoryLink id="827a-a4f6-8c38-ddac" name="Leader" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
         <categoryLink id="9bd3-9f4c-6eca-5357" name="DESTRUCTION" hidden="false" targetId="d963-a5fb-c348-2371" primary="false"/>
         <categoryLink id="3402-83b9-6b43-a57c" name="GLOOMSPITE GITZ" hidden="false" targetId="19e1-59e0-e5c6-2e94" primary="false"/>
         <categoryLink id="4251-56d3-bd27-40d9" name="GROT" hidden="false" targetId="ef9c-701b-aad2-4e19" primary="false"/>
@@ -5059,6 +4755,7 @@
         <categoryLink id="1c64-3f23-5d65-aef9" name="MONSTER" hidden="false" targetId="1959-9f6a-3056-913a" primary="false"/>
         <categoryLink id="858c-1ae2-bcf9-547a" name="TROGGOTH" hidden="false" targetId="be2b-5e91-b381-5671" primary="false"/>
         <categoryLink id="9943-c1b1-2472-868d" name="WIZARD" hidden="false" targetId="4f53-8230-2f02-9639" primary="false"/>
+        <categoryLink id="1a93-1f35-0d2e-d90b" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="61c9-012e-dd47-25b6" name="Wounds Suffered" hidden="false" collective="false" import="true" type="upgrade">
@@ -5234,6 +4931,7 @@
         <categoryLink id="e22e-008b-04b6-2596" name="DESTRUCTION" hidden="false" targetId="d963-a5fb-c348-2371" primary="false"/>
         <categoryLink id="5a82-7449-7ee9-fe67" name="GLOOMSPITE GITZ" hidden="false" targetId="19e1-59e0-e5c6-2e94" primary="false"/>
         <categoryLink id="e7f0-f270-8772-52b3" name="MOONCLAN" hidden="false" targetId="2736-9589-d74d-1c51" primary="false"/>
+        <categoryLink id="28ac-f9da-e2b3-12d7" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="75b7-5446-a598-66e6" name="5 Sporesplatta Fanatics" hidden="false" collective="false" import="true" type="unit">
@@ -5308,6 +5006,7 @@
         <categoryLink id="0687-e5da-c0af-6679" name="GLOOMSPITE GITZ" hidden="false" targetId="19e1-59e0-e5c6-2e94" primary="false"/>
         <categoryLink id="2e15-5f11-6221-bdc7" name="MONSTER" hidden="false" targetId="1959-9f6a-3056-913a" primary="false"/>
         <categoryLink id="fd37-effe-e116-c45d" name="ALEGUZZLER" hidden="false" targetId="93bb-0e9a-301c-169c" primary="false"/>
+        <categoryLink id="d269-6aba-c6c3-4416" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="9233-1bb1-5dde-ae7c" name="Wounds Suffered" hidden="false" collective="false" import="true" type="upgrade">
@@ -5460,6 +5159,7 @@
         <categoryLink id="45d6-f414-c756-4165" name="MONSTER" hidden="false" targetId="1959-9f6a-3056-913a" primary="false"/>
         <categoryLink id="2e42-da17-30b4-c8ba" name="MOONCLAN" hidden="false" targetId="2736-9589-d74d-1c51" primary="false"/>
         <categoryLink id="c745-fc04-a300-d1b2" name="SQUIG" hidden="false" targetId="6f5e-2209-6f2b-8f48" primary="false"/>
+        <categoryLink id="630d-7d42-f8b8-16d1" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="3a48-f3f4-7c7a-ef8e" name="Wounds Suffered" hidden="false" collective="false" import="true" type="upgrade">
@@ -5601,6 +5301,7 @@
         <categoryLink id="8a9a-24ad-817b-45ec" name="MONSTER" hidden="false" targetId="1959-9f6a-3056-913a" primary="false"/>
         <categoryLink id="fea3-1dae-fd35-efc5" name="MOONCLAN" hidden="false" targetId="2736-9589-d74d-1c51" primary="false"/>
         <categoryLink id="47eb-ab66-8566-2669" name="SQUIG" hidden="false" targetId="6f5e-2209-6f2b-8f48" primary="false"/>
+        <categoryLink id="4663-fa96-2f39-fc1a" name="New CategoryLink" hidden="false" targetId="1d26-07fc-6a66-d73e" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="b739-483a-693c-5f80" name="Spit-squigs" hidden="false" collective="false" import="true" type="upgrade">
@@ -5888,6 +5589,9 @@
           </characteristics>
         </profile>
       </profiles>
+      <categoryLinks>
+        <categoryLink id="e73c-8fc9-9f9b-35fe" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
+      </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="f84c-02c4-1193-7217" name="1. Head Loonboss" hidden="false" collective="false" import="true">
           <constraints>
@@ -5928,37 +5632,7 @@
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b4a-8c86-b755-0409" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="ac93-062f-2b91-3d49" name="Squig Herd" hidden="false" collective="false" import="true" targetId="016c-28fe-0300-5a7b" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditionGroups>
-                    <conditionGroup type="or">
-                      <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5598-b0b7-b976-5d72" type="greaterThan"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e404-398e-c044-e29a" type="greaterThan"/>
-                      </conditions>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-              </modifiers>
-              <categoryLinks>
-                <categoryLink id="8726-2365-d352-0aa3" name="Battleline" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="false"/>
-              </categoryLinks>
-            </entryLink>
-            <entryLink id="5c96-3046-3934-d7f1" name="Squig Herd" hidden="false" collective="false" import="true" targetId="016c-28fe-0300-5a7b" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditionGroups>
-                    <conditionGroup type="and">
-                      <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5598-b0b7-b976-5d72" type="equalTo"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e404-398e-c044-e29a" type="equalTo"/>
-                      </conditions>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-              </modifiers>
-            </entryLink>
+            <entryLink id="2cae-2c46-b7a6-97ed" name="Squig Herd" hidden="false" collective="false" import="true" targetId="d7f2-6558-9c0f-89bc" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="e334-cb4c-d676-3e5b" name="3. Squig Rider Stampedes (1+)" hidden="false" collective="false" import="true">
@@ -5984,7 +5658,7 @@
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="7c14-ee59-5315-658e" name="Battalion" hidden="false" targetId="be17-6bbd-b857-3f43" primary="false"/>
+        <categoryLink id="7c14-ee59-5315-658e" name="Battalion" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="d22b-27ec-5598-a079" name="Gobbapalooza" hidden="false" collective="false" import="true" targetId="649e-bb80-2cdb-9589" type="selectionEntry">
@@ -6007,7 +5681,7 @@
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="1333-da70-3517-0bd5" name="Battalion" hidden="false" targetId="be17-6bbd-b857-3f43" primary="false"/>
+        <categoryLink id="1333-da70-3517-0bd5" name="Battalion" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="1d43-e5e2-2900-9380" name="1. Grots (3+)" hidden="false" collective="false" import="true">
@@ -6051,7 +5725,7 @@
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="bdb8-f5aa-93d5-5c66" name="Battalion" hidden="false" targetId="be17-6bbd-b857-3f43" primary="false"/>
+        <categoryLink id="bdb8-f5aa-93d5-5c66" name="Battalion" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="bdef-8c21-6f88-692d" name="2. Mangler Squigs" hidden="false" collective="false" import="true">
@@ -6085,6 +5759,9 @@
           </characteristics>
         </profile>
       </profiles>
+      <categoryLinks>
+        <categoryLink id="7b89-9ddc-210b-cf44" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
+      </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="d381-c748-839f-7fd9" name="1. Loonbosses (1 to 3)" hidden="false" collective="false" import="true">
           <constraints>
@@ -6180,37 +5857,7 @@
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a49d-320d-f066-ca01" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="4652-f4ed-1ed0-a8bd" name="Squig Herd" hidden="false" collective="false" import="true" targetId="016c-28fe-0300-5a7b" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditionGroups>
-                    <conditionGroup type="or">
-                      <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5598-b0b7-b976-5d72" type="greaterThan"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e404-398e-c044-e29a" type="greaterThan"/>
-                      </conditions>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-              </modifiers>
-              <categoryLinks>
-                <categoryLink id="5fdc-14de-d047-8566" name="Battleline" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="false"/>
-              </categoryLinks>
-            </entryLink>
-            <entryLink id="0d89-266e-628c-1fd4" name="Squig Herd" hidden="false" collective="false" import="true" targetId="016c-28fe-0300-5a7b" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditionGroups>
-                    <conditionGroup type="and">
-                      <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5598-b0b7-b976-5d72" type="equalTo"/>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e404-398e-c044-e29a" type="equalTo"/>
-                      </conditions>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-              </modifiers>
-            </entryLink>
+            <entryLink id="4652-f4ed-1ed0-a8bd" name="Squig Herd" hidden="false" collective="false" import="true" targetId="d7f2-6558-9c0f-89bc" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -6227,7 +5874,7 @@
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="18d3-9fd0-dbe3-0cfa" name="Battalion" hidden="false" targetId="be17-6bbd-b857-3f43" primary="false"/>
+        <categoryLink id="18d3-9fd0-dbe3-0cfa" name="Battalion" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="8381-e2ad-6a86-988d" name="2. Skitterstrand Arachnarok" hidden="false" collective="false" import="true" defaultSelectionEntryId="8db2-1232-f2ed-9363">
@@ -6262,7 +5909,7 @@
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="86f0-4dc9-9826-0054" name="Battalion" hidden="false" targetId="be17-6bbd-b857-3f43" primary="false"/>
+        <categoryLink id="86f0-4dc9-9826-0054" name="Battalion" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="167a-319f-e429-ad2f" name="1. Scuttleboss" hidden="false" collective="false" import="true" defaultSelectionEntryId="2482-20ba-9ae8-1a0f">
@@ -6298,7 +5945,7 @@
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="aeaf-d8b6-4864-c7f8" name="Battalion" hidden="false" targetId="be17-6bbd-b857-3f43" primary="false"/>
+        <categoryLink id="aeaf-d8b6-4864-c7f8" name="Battalion" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="7305-defd-e857-6f36" name="1. Skitterstrand Arachnaroks (2 to 3)" hidden="false" collective="false" import="true" defaultSelectionEntryId="6883-1ade-1745-b6ff">
@@ -6324,6 +5971,9 @@
           </characteristics>
         </profile>
       </profiles>
+      <categoryLinks>
+        <categoryLink id="b54c-933f-372c-ee87" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
+      </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="8dca-b943-c3bf-3bfe" name="1. Head Webspinner Shaman" hidden="false" collective="false" import="true">
           <constraints>
@@ -6420,6 +6070,7 @@
         <categoryLink id="bcd0-baa6-1087-4f63" name="DESTRUCTION" hidden="false" targetId="d963-a5fb-c348-2371" primary="false"/>
         <categoryLink id="a94f-e5dc-e1ca-197e" name="GLOOMSPITE GITZ" hidden="false" targetId="19e1-59e0-e5c6-2e94" primary="false"/>
         <categoryLink id="6c91-4e78-b143-307c" name="MONSTER" hidden="false" targetId="1959-9f6a-3056-913a" primary="false"/>
+        <categoryLink id="1d89-5350-3e0e-7aa1" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="eb2b-ad7b-c2a7-37ff" name="Wounds Suffered" hidden="false" collective="false" import="true" type="upgrade">
@@ -6559,6 +6210,111 @@
       </selectionEntries>
       <costs>
         <cost name="pts" typeId="points" value="230.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d7f2-6558-9c0f-89bc" name="Squig Herd" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set-primary" field="category" value="e9f2-765a-b7b8-ce8e">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f0a0-7340-338a-fdd2" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd67-add1-9a8b-a9eb" type="greaterThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="38b2-2b4a-8644-b7ba" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <profiles>
+        <profile id="316e-4472-7656-59ac" name="Squig Herd" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
+          <characteristics>
+            <characteristic name="Move" typeId="8655-6213-2824-1752">5&quot;</characteristic>
+            <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">2</characteristic>
+            <characteristic name="Bravery" typeId="0c85-bf79-836b-759e">3</characteristic>
+            <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">6+</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="3c57-bbf7-7445-034c" name="Go Dat Way!" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">You can re-roll run and charge rolls for this unit while it includes any Squig Herders. </characteristic>
+          </characteristics>
+        </profile>
+        <profile id="8ca2-5071-5816-8456" name="Squigs Go Wild" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Roll a dice each time a Cave Squig model from this unit flees, before the model is removed from play. On a 4+, the nearest other unit within 6&quot; of the fleeing model suffers 1 mortal wound. If two or more of such units are equally close, you can pick which suffers the mortal wound.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="23bd-5296-d248-38e7" name="Squig Herder" hidden="false" typeId="8b8c-5816-cbdb-9763" typeName="Unit Leader">
+          <characteristics>
+            <characteristic name="Leader Ability" typeId="afb5-0652-767a-6769">1 in every 6 models in this unit must be a Squig Herder model instead of a Cave Squig model. A Squig Herder is armed with a Squig Prodder instead of a Fang-filled Gob.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink id="8bea-1cc7-43f7-ee36" name="DESTRUCTION" hidden="false" targetId="d963-a5fb-c348-2371" primary="false"/>
+        <categoryLink id="1a9a-63f5-c93a-6af2" name="GLOOMSPITE GITZ" hidden="false" targetId="19e1-59e0-e5c6-2e94" primary="false"/>
+        <categoryLink id="3472-d798-92db-85c6" name="MOONCLAN" hidden="false" targetId="2736-9589-d74d-1c51" primary="false"/>
+        <categoryLink id="f534-b763-f8b9-89b1" name="SQUIG" hidden="false" targetId="6f5e-2209-6f2b-8f48" primary="false"/>
+        <categoryLink id="e2f3-ad6e-eaa7-280e" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="4cd8-36a2-0d7b-eed9" name="5 Squigs &amp; Squig Herder" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e38-e605-f953-4293" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bfc0-83db-d089-65df" type="min"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="points" value="70.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="856f-da16-0be8-ba3d" name="Squig Prodder" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f47-12f5-c1c7-3a2f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f63-d786-0973-929f" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="436e-93f9-57cf-f6c3" name="Squig Prodder" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
+                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
+                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">2</characteristic>
+                <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">5+</characteristic>
+                <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">5+</characteristic>
+                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-</characteristic>
+                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5d62-bbd8-97e1-431d" name="Fang-filled Gob" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2db4-ce63-8449-becc" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6040-d930-8c9c-3962" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="00d6-6788-094c-ab5a" name="Fang-filled Gob" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
+                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
+                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">2</characteristic>
+                <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">4+</characteristic>
+                <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
+                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-1</characteristic>
+                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Destruction - Orruk Warclans.cat
+++ b/Destruction - Orruk Warclans.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="5419-b58f-5a39-0bfe" name="Destruction - Orruk Warclans" revision="6" battleScribeVersion="2.03" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="6" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="5419-b58f-5a39-0bfe" name="Destruction - Orruk Warclans" revision="7" battleScribeVersion="2.03" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="6" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="7e25-33bb-pubN65537" name="Destruction Battletome: Bonesplitterz"/>
     <publication id="7e25-33bb-pubN82863" name="Age of Sigmar: The Rules"/>
@@ -56,6 +56,7 @@
     <categoryEntry id="2187-d5fb-d16f-646c" name="Brute" hidden="false"/>
     <categoryEntry id="ef1e-4f71-6a42-d189" name="GORDRAKK" hidden="false"/>
     <categoryEntry id="043f-174a-6b6a-bbb1" name="Gore Gruntas" hidden="false"/>
+    <categoryEntry id="94d9-92a8-fced-0685" name="BONESPLITTERZ WIZARD" hidden="false"/>
   </categoryEntries>
   <entryLinks>
     <entryLink id="fc4d-9292-0908-041e" name="Allegiance" hidden="false" collective="false" import="true" targetId="9dbb-2d1a-12d8-7faf" type="selectionEntry">
@@ -826,6 +827,19 @@ At the end of any phase in which you use this command ability, you must roll a d
       </costs>
     </selectionEntry>
     <selectionEntry id="2d80-c52b-1ec8-3c5d" name="Maniak Weirdnob" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c55-3eee-a90a-ac07" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33cb-28e3-cf3d-7f21" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ad47-29fe-1799-53ed" type="lessThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile id="c76f-fe1c-85f6-909e" name="Maniak Weirdnob" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
@@ -864,7 +878,16 @@ At the end of any phase in which you use this command ability, you must roll a d
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="18c0-ed54-52bc-0de2" type="equalTo"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="115b-bd71-6506-80ec" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="fd38-9674-ac69-00ad" name="Fireball" hidden="true" targetId="b40c-04ea-2ffb-0c01" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="115b-bd71-6506-80ec" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -878,6 +901,7 @@ At the end of any phase in which you use this command ability, you must roll a d
         <categoryLink id="cf17-bb3d-999c-6cf5" name="New CategoryLink" hidden="false" targetId="4e0e-664d-51ea-0929" primary="false"/>
         <categoryLink id="e739-a9d0-6011-74d0" name="New CategoryLink" hidden="false" targetId="02c4-b631-39dd-c932" primary="false"/>
         <categoryLink id="43a3-e222-b944-6b47" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
+        <categoryLink id="2338-02d8-feb0-940c" name="BONESPLITTERZ WIZARD" hidden="false" targetId="94d9-92a8-fced-0685" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="0e36-4d67-0203-b4fa" name="Bonebeast Staff" hidden="false" collective="false" import="true" type="upgrade">
@@ -936,6 +960,19 @@ At the end of any phase in which you use this command ability, you must roll a d
       </costs>
     </selectionEntry>
     <selectionEntry id="5e7e-f978-4c37-4666" name="Savage Big Boss" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c55-3eee-a90a-ac07" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33cb-28e3-cf3d-7f21" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ad47-29fe-1799-53ed" type="lessThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile id="3134-f673-d485-9b7a" name="Let Me At â€™Em" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
@@ -998,6 +1035,19 @@ At the end of any phase in which you use this command ability, you must roll a d
       </costs>
     </selectionEntry>
     <selectionEntry id="e930-136b-3f26-a52c" name="Savage Big Stabbas" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c55-3eee-a90a-ac07" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33cb-28e3-cf3d-7f21" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ad47-29fe-1799-53ed" type="lessThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile id="90c3-68f4-8dea-23d5" name="Savage Big Stabbas" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
@@ -1074,6 +1124,17 @@ At the end of any phase in which you use this command ability, you must roll a d
             <conditionGroup type="or">
               <conditions>
                 <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="33cb-28e3-cf3d-7f21" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c55-3eee-a90a-ac07" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33cb-28e3-cf3d-7f21" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ad47-29fe-1799-53ed" type="lessThan"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -1208,6 +1269,17 @@ At the end of any phase in which you use this command ability, you must roll a d
               <conditions>
                 <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ad47-29fe-1799-53ed" type="equalTo"/>
                 <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="33cb-28e3-cf3d-7f21" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c55-3eee-a90a-ac07" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33cb-28e3-cf3d-7f21" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ad47-29fe-1799-53ed" type="lessThan"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -1370,6 +1442,19 @@ At the end of any phase in which you use this command ability, you must roll a d
       </costs>
     </selectionEntry>
     <selectionEntry id="bfed-dba3-ebd5-04b1" name="Savage Orruks" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c55-3eee-a90a-ac07" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33cb-28e3-cf3d-7f21" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ad47-29fe-1799-53ed" type="lessThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile id="f6fd-c038-942d-8691" name="Savage Orruks" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
@@ -1494,6 +1579,17 @@ At the end of any phase in which you use this command ability, you must roll a d
               <conditions>
                 <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ad47-29fe-1799-53ed" type="equalTo"/>
                 <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="33cb-28e3-cf3d-7f21" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c55-3eee-a90a-ac07" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33cb-28e3-cf3d-7f21" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ad47-29fe-1799-53ed" type="lessThan"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -1645,6 +1741,17 @@ At the end of any phase in which you use this command ability, you must roll a d
             </conditionGroup>
           </conditionGroups>
         </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c55-3eee-a90a-ac07" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33cb-28e3-cf3d-7f21" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ad47-29fe-1799-53ed" type="lessThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
       </modifiers>
       <profiles>
         <profile id="65e4-80c8-4f12-a03c" name="Savage Orruks Morboys" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
@@ -1753,6 +1860,19 @@ At the end of any phase in which you use this command ability, you must roll a d
       </costs>
     </selectionEntry>
     <selectionEntry id="99a1-6ae4-4f8c-bc69" name="Wardokk" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c55-3eee-a90a-ac07" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33cb-28e3-cf3d-7f21" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ad47-29fe-1799-53ed" type="lessThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile id="1be5-464d-2aac-2e0f" name="Wardokk" hidden="false" typeId="f55d-ee3a-1597-110f" typeName="Magic">
           <characteristics>
@@ -1794,7 +1914,7 @@ At the end of any phase in which you use this command ability, you must roll a d
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="18c0-ed54-52bc-0de2" type="equalTo"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="115b-bd71-6506-80ec" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -1804,7 +1924,7 @@ At the end of any phase in which you use this command ability, you must roll a d
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="18c0-ed54-52bc-0de2" type="equalTo"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="115b-bd71-6506-80ec" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -1818,6 +1938,7 @@ At the end of any phase in which you use this command ability, you must roll a d
         <categoryLink id="c034-ac20-85d7-1a6e" name="New CategoryLink" hidden="false" targetId="4f53-8230-2f02-9639" primary="false"/>
         <categoryLink id="b5c6-7bbc-848e-4dc6" name="New CategoryLink" hidden="false" targetId="2657-35fb-5dd1-22d1" primary="false"/>
         <categoryLink id="44bd-1fb2-8766-4541" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
+        <categoryLink id="60cc-7a62-0749-9a8d" name="BONESPLITTERZ WIZARD" hidden="false" targetId="94d9-92a8-fced-0685" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ec1a-565a-d09e-e757" name="Bonebeast Stikk" hidden="false" collective="false" import="true" type="upgrade">
@@ -1854,6 +1975,19 @@ At the end of any phase in which you use this command ability, you must roll a d
       </costs>
     </selectionEntry>
     <selectionEntry id="f6fa-7f5f-0836-e986" name="Wurrgog Prophet" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c55-3eee-a90a-ac07" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33cb-28e3-cf3d-7f21" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ad47-29fe-1799-53ed" type="lessThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile id="179a-6b52-b9da-8f99" name="Prophet of da Waaagh!" hidden="false" typeId="f71f-b0a4-730e-ced3" typeName="Command Abilities">
           <characteristics>
@@ -1892,7 +2026,7 @@ At the end of any phase in which you use this command ability, you must roll a d
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="18c0-ed54-52bc-0de2" type="equalTo"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="115b-bd71-6506-80ec" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -1901,7 +2035,7 @@ At the end of any phase in which you use this command ability, you must roll a d
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="18c0-ed54-52bc-0de2" type="equalTo"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="115b-bd71-6506-80ec" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -1915,6 +2049,7 @@ At the end of any phase in which you use this command ability, you must roll a d
         <categoryLink id="f938-5d6c-a93a-b956" name="New CategoryLink" hidden="false" targetId="4f53-8230-2f02-9639" primary="false"/>
         <categoryLink id="5f48-1cef-6d62-7094" name="New CategoryLink" hidden="false" targetId="d3b6-2571-40a2-8c15" primary="false"/>
         <categoryLink id="993a-e2d3-37d7-3f1e" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
+        <categoryLink id="9a9d-ae91-73aa-2b2d" name="BONESPLITTERZ WIZARD" hidden="false" targetId="94d9-92a8-fced-0685" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="44c0-fe5b-43de-cf32" name="Wurrog Staff and Bone Shiv" hidden="false" collective="false" import="true" type="upgrade">
@@ -1966,21 +2101,6 @@ At the end of any phase in which you use this command ability, you must roll a d
         <entryLink id="7bcd-cee1-56e9-089f" name="General" hidden="false" collective="false" import="true" targetId="2782-06bf-a7cc-86b6" type="selectionEntry"/>
         <entryLink id="7a32-52e2-bc9f-f5a9" name="Artefacts" hidden="false" collective="false" import="true" targetId="281b-c7b4-5e59-c155" type="selectionEntryGroup"/>
         <entryLink id="ca54-34d5-2e73-879a" name="Command Traits" hidden="false" collective="false" import="true" targetId="7919-8973-c0b9-afc5" type="selectionEntryGroup"/>
-        <entryLink id="d1da-68d7-8280-a982" name="Warclan Extras" hidden="true" collective="false" import="true" targetId="b384-5be7-036f-143c" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="false">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="688f-a281-d5d0-4f24" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="72b6-9777-df40-1149" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="de74-0645-34e8-23e4" type="instanceOf"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-        </entryLink>
         <entryLink id="c28d-be3f-8180-a459" name="Spell Lores" hidden="false" collective="false" import="true" targetId="e29e-75bb-6308-1c51" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
@@ -2013,6 +2133,19 @@ At the end of any phase in which you use this command ability, you must roll a d
       </costs>
     </selectionEntry>
     <selectionEntry id="8911-e844-4a80-59f4" name="Gordrakk, the Fist of Gork" page="109" hidden="false" collective="false" import="true" type="model">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c55-3eee-a90a-ac07" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eba0-179a-d749-6e62" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ad47-29fe-1799-53ed" type="lessThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5b79-99c3-47da-39f3" type="max"/>
       </constraints>
@@ -2065,11 +2198,6 @@ If the mortal wounds inflicted by this modelâ€™s Massively Destructive Bulk mean
           </characteristics>
         </profile>
       </profiles>
-      <rules>
-        <rule id="8f5a-6ef0-1a6e-7532" name="Gordrakk, the Fist of Gork" hidden="false">
-          <description>Gordrakk, the Fist of Gork is a single model. Gordrakk is armed with two axes, one called Smasha and the other Kunnin&apos;. He rides into battle on the back of a huge Maw-krusha called Bigteef, who batters opponents with his Mighty Fists, flatten them with his Destructive Bulk, and smashes them with his Bladed Tail. Even his Innard-bursting Bellow can kill foes!</description>
-        </rule>
-      </rules>
       <categoryLinks>
         <categoryLink id="0d74-9660-97eb-3a68" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false"/>
         <categoryLink id="6d6f-f560-3148-f94b" name="New CategoryLink" hidden="false" targetId="d963-a5fb-c348-2371" primary="false"/>
@@ -2224,6 +2352,19 @@ If the mortal wounds inflicted by this modelâ€™s Massively Destructive Bulk mean
       </costs>
     </selectionEntry>
     <selectionEntry id="cc40-ece7-eef5-d04b" name="Ironskull&apos;z Boyz" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c55-3eee-a90a-ac07" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eba0-179a-d749-6e62" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ad47-29fe-1799-53ed" type="lessThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="3a06-6183-61cc-85a1" type="max"/>
       </constraints>
@@ -2312,6 +2453,19 @@ If the mortal wounds inflicted by this modelâ€™s Massively Destructive Bulk mean
       </costs>
     </selectionEntry>
     <selectionEntry id="fd0a-af12-54bd-01f0" name="Orruk Warchanter" hidden="false" collective="false" import="true" type="model">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c55-3eee-a90a-ac07" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eba0-179a-d749-6e62" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ad47-29fe-1799-53ed" type="lessThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile id="c67e-9a66-c3e9-793f" name="Orruk Warchanter" page="113" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
@@ -2375,6 +2529,19 @@ If the mortal wounds inflicted by this modelâ€™s Massively Destructive Bulk mean
       </costs>
     </selectionEntry>
     <selectionEntry id="9e6f-9feb-1e38-bb18" name="Orruk Megaboss" hidden="false" collective="false" import="true" type="model">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c55-3eee-a90a-ac07" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eba0-179a-d749-6e62" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ad47-29fe-1799-53ed" type="lessThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile id="ad9a-11ca-7951-56df" name="Orruk Megaboss" page="112" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
@@ -2441,6 +2608,19 @@ If the mortal wounds inflicted by this modelâ€™s Massively Destructive Bulk mean
       </costs>
     </selectionEntry>
     <selectionEntry id="ae95-32b7-49ff-83d2" name="Orruk Weirdnob Shaman" hidden="false" collective="false" import="true" type="model">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c55-3eee-a90a-ac07" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eba0-179a-d749-6e62" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ad47-29fe-1799-53ed" type="lessThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile id="b080-960b-05ab-04c7" name="Orruk Weirdnob Shaman" hidden="false" typeId="f55d-ee3a-1597-110f" typeName="Magic">
           <characteristics>
@@ -2516,6 +2696,19 @@ If the mortal wounds inflicted by this modelâ€™s Massively Destructive Bulk mean
       </costs>
     </selectionEntry>
     <selectionEntry id="e864-97aa-ce42-06dc" name="Megaboss on Maw-krusha" hidden="false" collective="false" import="true" type="model">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c55-3eee-a90a-ac07" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eba0-179a-d749-6e62" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ad47-29fe-1799-53ed" type="lessThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile id="4488-5a58-f1ac-07b1" name="Fly" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
@@ -2734,6 +2927,17 @@ If the mortal wounds inflicted by this modelâ€™s Destructive Bulk mean there are
             </conditionGroup>
           </conditionGroups>
         </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c55-3eee-a90a-ac07" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eba0-179a-d749-6e62" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ad47-29fe-1799-53ed" type="lessThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
       </modifiers>
       <profiles>
         <profile id="ba99-5b6c-397e-7552" name="Orruk Brutes" page="115" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
@@ -2917,6 +3121,17 @@ If the mortal wounds inflicted by this modelâ€™s Destructive Bulk mean there are
             </conditionGroup>
           </conditionGroups>
         </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c55-3eee-a90a-ac07" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eba0-179a-d749-6e62" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ad47-29fe-1799-53ed" type="lessThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
       </modifiers>
       <profiles>
         <profile id="08b0-773e-9b7d-0068" name="Orruk Gore-Gruntas" page="116" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
@@ -3048,6 +3263,17 @@ In addition, add 1 to hit rolls and wound rolls for attacks made with this unitâ
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c55-3eee-a90a-ac07" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eba0-179a-d749-6e62" type="lessThan"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ad47-29fe-1799-53ed" type="lessThan"/>
+              </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
@@ -3509,19 +3735,7 @@ In addition, add 1 to hit rolls and wound rolls for attacks made with this unitâ
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
-    <selectionEntryGroup id="869d-7858-5b4e-c2d0" name="Artefacts: Reservoirs of Waaagh! Energy" hidden="true" collective="false" import="true">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="33cb-28e3-cf3d-7f21" type="equalTo"/>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4f53-8230-2f02-9639" type="instanceOf"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
+    <selectionEntryGroup id="869d-7858-5b4e-c2d0" name="Artefacts: Reservoirs of Waaagh! Energy" hidden="false" collective="false" import="true">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3512-8fac-1846-5761" type="max"/>
       </constraints>
@@ -3574,25 +3788,6 @@ In addition, add 1 to hit rolls and wound rolls for attacks made with this unitâ
       </selectionEntries>
     </selectionEntryGroup>
     <selectionEntryGroup id="523a-72ea-4869-2b03" name="Traits: Heralds of the Great Green God" hidden="false" collective="false" import="true">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="33cb-28e3-cf3d-7f21" type="equalTo"/>
-              </conditions>
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b8fe-45e1-5aa2-3421" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b685-28b4-a20e-2e33" type="instanceOf"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0211-6299-ea8f-f444" type="max"/>
       </constraints>
@@ -3689,122 +3884,8 @@ In addition, add 1 to hit rolls and wound rolls for attacks made with this unitâ
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
-    <selectionEntryGroup id="2596-f479-3222-4f7b" name="Artefacts: Arcane Treasure" hidden="true" collective="false" import="true">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4f53-8230-2f02-9639" type="instanceOf"/>
-          </conditions>
-        </modifier>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33cb-28e3-cf3d-7f21" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="558e-a31a-21eb-007f" type="max"/>
-      </constraints>
-      <selectionEntries>
-        <selectionEntry id="5c6e-1546-6229-8284" name="1. Ju-ju Wotnotz" page="" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d016-841d-18a0-76fb" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="1c18-4449-881d-70fb" name="1. Ju-ju Wotnotz" hidden="false" typeId="0ac4-aacb-2481-8e72" typeName="Artefact">
-              <characteristics>
-                <characteristic name="Artefact Details" typeId="0918-c47a-d84e-c0cf">Each time the bearer successfully casts a spell and the casting roll was a double, they can immediately attempt to cast another spell (this does not count towards the number of spells the wizard can attempt to cast in their hero phase).</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="c0c8-f256-f55a-9a09" name="2. Big Spirit Stikk" page="" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4448-5561-fb7e-91ea" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="60eb-3fff-0b43-36e6" name="2. Big Spirit Stikk" hidden="false" typeId="0ac4-aacb-2481-8e72" typeName="Artefact">
-              <characteristics>
-                <characteristic name="Artefact Details" typeId="0918-c47a-d84e-c0cf">Pick one of this WIZARDâ€™s melee weapons to be the Big Spirit Stikk. Add 1 to the Attacks characteristic of this weapon. Add 2 instead if the wielder directs all of its attacks against a MONSTER</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="f5a4-3d7e-8df3-8e32" name="3. Morkâ€™s Boney Bitz" page="" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f59f-9918-5174-2d58" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="e769-877a-11aa-18b1" name="3. Morkâ€™s Boney Bitz" hidden="false" typeId="0ac4-aacb-2481-8e72" typeName="Artefact">
-              <characteristics>
-                <characteristic name="Artefact Details" typeId="0918-c47a-d84e-c0cf">You can add 1 to this WIZARDâ€™s casting rolls for each enemy MONSTERwithin 24&quot; of him.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="5282-47c1-c45c-8b8d" name="4. Da Great Zappa Squig" page="" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9b3-24b8-90f2-4ffd" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="ffa4-c42a-259b-7a11" name="4. Da Great Zappa Squig" hidden="false" typeId="0ac4-aacb-2481-8e72" typeName="Artefact">
-              <characteristics>
-                <characteristic name="Artefact Details" typeId="0918-c47a-d84e-c0cf">The bearer of Da Great Zappa Squig knows one additional spell. This spell is always randomly generated by rolling a dice and consulting the Lore of the Savage Waaagh! (pg 86)</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="2ba0-a3ad-cde5-e27d" name="5. Big Wurrgog Mask" page="" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2150-d68e-a6f4-4a90" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="e1bc-6501-2640-2cc7" name="5. Big Wurrgog Mask" hidden="false" typeId="0ac4-aacb-2481-8e72" typeName="Artefact">
-              <characteristics>
-                <characteristic name="Artefact Details" typeId="0918-c47a-d84e-c0cf">Once per game, during your hero phase, the wielder of the Big Wurrgog Mask can unleash its power. When they do so, select a unit within 12&quot; that is visible to the wearer. That unit suffers D3 mortal wounds. The wearer can then continue staring at the unit; if they do, roll a dice. On a 3 or more, the unit suffers another D3 mortal wounds, but on a 1 or a 2, the wearer is immediately slain. Continue repeating this until the wearer is slain, decides to stop staring or the unit in question has been wiped out.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="3d35-6ae0-ab00-2dde" name="6. Mystic Waaagh! Paint" page="" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="064a-76e9-b60c-17d6" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="ec71-075a-1cd6-9595" name="6. Mystic Waaagh! Paint" hidden="false" typeId="0ac4-aacb-2481-8e72" typeName="Artefact">
-              <characteristics>
-                <characteristic name="Artefact Details" typeId="0918-c47a-d84e-c0cf">Add 1 to all unbinding rolls made by the WIZARD. In addition,the wearer of the Mystic Waaagh! Paint can attempt to unbind spells if they are within 36&quot; of the caster.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-    </selectionEntryGroup>
     <selectionEntryGroup id="281b-c7b4-5e59-c155" name="Artefacts" hidden="false" collective="false" import="true">
       <modifiers>
-        <modifier type="set" field="bbc4-2edc-7570-6192" value="0.0">
-          <conditions>
-            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0be7-af29-227d-5efb" type="equalTo"/>
-          </conditions>
-        </modifier>
         <modifier type="increment" field="08a4-aaa8-cdb1-db85" value="1.0">
           <repeats>
             <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="be17-6bbd-b857-3f43" repeats="1" roundUp="false"/>
@@ -3819,27 +3900,86 @@ In addition, add 1 to hit rolls and wound rolls for attacks made with this unitâ
         <categoryLink id="c21f-dec5-a1a7-f16c" name="New CategoryLink" hidden="false" targetId="3564-4c26-10b4-d953" primary="false"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="8831-b809-3129-819b" name="Arcane Treasure" hidden="false" collective="false" import="true" targetId="2596-f479-3222-4f7b" type="selectionEntryGroup"/>
-        <entryLink id="6e52-73b0-e564-20c4" name="Bonesplitterz Artefacts" hidden="false" collective="false" import="true" targetId="869d-7858-5b4e-c2d0" type="selectionEntryGroup"/>
-        <entryLink id="ecee-aeac-b921-918a" name="Artefacts of Destruction" hidden="false" collective="false" import="true" targetId="ca3c-6bfc-07f1-2953" type="selectionEntryGroup"/>
+        <entryLink id="6e52-73b0-e564-20c4" name="Bonesplitterz Artefacts" hidden="false" collective="false" import="true" targetId="869d-7858-5b4e-c2d0" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="94d9-92a8-fced-0685" type="notInstanceOf"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </entryLink>
+        <entryLink id="ecee-aeac-b921-918a" name="Artefacts of Destruction" hidden="false" collective="false" import="true" targetId="ca3c-6bfc-07f1-2953" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3c55-3eee-a90a-ac07" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
         <entryLink id="d2b9-7c77-b175-3f4c" name="Realm Artefacts of Power" hidden="false" collective="false" import="true" targetId="37b0-af21-630c-d8af" type="selectionEntryGroup"/>
-        <entryLink id="9dba-3552-1045-4e17" name="Ironjawz Artefacts" hidden="false" collective="false" import="true" targetId="4c62-d7fb-3add-f833" type="selectionEntryGroup"/>
-        <entryLink id="c862-d500-ea10-4197" name="Weird Trinkets" hidden="false" collective="false" import="true" targetId="66f8-0866-8c4e-5ac3" type="selectionEntryGroup"/>
-        <entryLink id="5562-aa53-0075-f5e1" name="Artefacts: Ironjawz Warclan" hidden="false" collective="false" import="true" targetId="3be1-bc09-3cf5-19e1" type="selectionEntryGroup"/>
-        <entryLink id="5ddc-23fe-dccc-9230" name="Artefacts: Bonesplitterz Warclan" hidden="false" collective="false" import="true" targetId="aba4-6326-986d-bfa7" type="selectionEntryGroup"/>
-        <entryLink id="c70d-b36c-8344-16f1" name="Artefacts: Boss Bones and Other Gubbinz" hidden="false" collective="false" import="true" targetId="dd9b-5136-e99d-b610" type="selectionEntryGroup"/>
+        <entryLink id="9dba-3552-1045-4e17" name="Ironjawz Artefacts" hidden="false" collective="false" import="true" targetId="4c62-d7fb-3add-f833" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fb31-0c98-2d1d-8492" type="notInstanceOf"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+        <entryLink id="c862-d500-ea10-4197" name="Weird Trinkets" hidden="false" collective="false" import="true" targetId="66f8-0866-8c4e-5ac3" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7ede-c037-02c4-b83d" type="notInstanceOf"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+        <entryLink id="5562-aa53-0075-f5e1" name="Artefacts: Ironjawz Warclan" hidden="false" collective="false" import="true" targetId="3be1-bc09-3cf5-19e1" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eba0-179a-d749-6e62" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+        <entryLink id="5ddc-23fe-dccc-9230" name="Artefacts: Bonesplitterz Warclan" hidden="false" collective="false" import="true" targetId="aba4-6326-986d-bfa7" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="33cb-28e3-cf3d-7f21" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+        <entryLink id="c70d-b36c-8344-16f1" name="Artefacts: Boss Bones and Other Gubbinz" hidden="true" collective="false" import="true" targetId="dd9b-5136-e99d-b610" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4e0e-664d-51ea-0929" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9db3-55f3-706c-01bd" type="instanceOf"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </entryLink>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="7919-8973-c0b9-afc5" name="Command Traits" hidden="false" collective="false" import="true">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b745-17c4-8fbf-8b04" type="equalTo"/>
-          </conditions>
-        </modifier>
-        <modifier type="set" field="8712-b467-8b4a-c3c4" value="0.0">
-          <conditions>
-            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f180-6d47-0fdb-d77f" type="equalTo"/>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2782-06bf-a7cc-86b6" type="lessThan"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -3847,116 +3987,75 @@ In addition, add 1 to hit rolls and wound rolls for attacks made with this unitâ
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8712-b467-8b4a-c3c4" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="c2b1-bb7a-41f4-6d17" name="Bonesplitterz Command Traits" hidden="false" collective="false" import="true" targetId="523a-72ea-4869-2b03" type="selectionEntryGroup"/>
-        <entryLink id="5d8b-1c7b-6da8-884a" name="Destruction Command Traits" hidden="false" collective="false" import="true" targetId="1319-8f5e-1ff1-08c9" type="selectionEntryGroup"/>
-        <entryLink id="14a5-becc-305b-67dd" name="Ironjawz Command Traits" hidden="false" collective="false" import="true" targetId="9858-0f3e-e91b-ed76" type="selectionEntryGroup"/>
-        <entryLink id="2038-5f26-0780-799c" name="Champions of the Weird" hidden="false" collective="false" import="true" targetId="3dfa-d1ab-31b8-b5fa" type="selectionEntryGroup"/>
-        <entryLink id="5fb3-e0fe-1cf3-55e8" name="Traits: Ironjawz Warclan" hidden="false" collective="false" import="true" targetId="c446-4553-755a-bd29" type="selectionEntryGroup"/>
+        <entryLink id="c2b1-bb7a-41f4-6d17" name="Bonesplitterz Command Traits" hidden="true" collective="false" import="true" targetId="523a-72ea-4869-2b03" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f6fa-7f5f-0836-e986" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5e7e-f978-4c37-4666" type="instanceOf"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </entryLink>
+        <entryLink id="5d8b-1c7b-6da8-884a" name="Destruction Command Traits" hidden="false" collective="false" import="true" targetId="1319-8f5e-1ff1-08c9" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3c55-3eee-a90a-ac07" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+        <entryLink id="14a5-becc-305b-67dd" name="Ironjawz Command Traits" hidden="false" collective="false" import="true" targetId="9858-0f3e-e91b-ed76" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fb31-0c98-2d1d-8492" type="notInstanceOf"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+        <entryLink id="2038-5f26-0780-799c" name="Champions of the Weird" hidden="false" collective="false" import="true" targetId="3dfa-d1ab-31b8-b5fa" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7ede-c037-02c4-b83d" type="notInstanceOf"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+        <entryLink id="5fb3-e0fe-1cf3-55e8" name="Traits: Ironjawz Warclan" hidden="false" collective="false" import="true" targetId="c446-4553-755a-bd29" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="eba0-179a-d749-6e62" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+        <entryLink id="7216-8704-eb5b-d18c" name="Traits: Shamanistic Quirks" hidden="false" collective="false" import="true" targetId="fa5a-f950-c7df-0559" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="94d9-92a8-fced-0685" type="notInstanceOf"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+        <entryLink id="2ed7-e085-007a-e4db" name="Traits: Bonesplitterz Warclan" hidden="false" collective="false" import="true" targetId="4900-2ad5-7dd9-9f73" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="33cb-28e3-cf3d-7f21" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
       </entryLinks>
-    </selectionEntryGroup>
-    <selectionEntryGroup id="b384-5be7-036f-143c" name="Warclan Extras" hidden="false" collective="false" import="true">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="688f-a281-d5d0-4f24" type="instanceOf"/>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="72b6-9777-df40-1149" type="instanceOf"/>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="de74-0645-34e8-23e4" type="instanceOf"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <selectionEntries>
-        <selectionEntry id="f180-6d47-0fdb-d77f" name="Bring it Down, Ladz" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="688f-a281-d5d0-4f24" type="notInstanceOf"/>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b745-17c4-8fbf-8b04" type="equalTo"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fab9-7be1-1aab-aaa5" type="max"/>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87f0-4d69-0c61-232a" type="min"/>
-          </constraints>
-          <profiles>
-            <profile id="417a-85c1-867f-5af6" name="Bring it Down, Ladz" hidden="false" typeId="c749-bae4-71a8-0c36" typeName="Command Trait">
-              <characteristics>
-                <characteristic name="Command Trait Details" typeId="ee96-6f3a-e5ca-2350">Instead of rolling on the Monster Hunters table, your general and any friendly Bonegrinz unit within 12&quot; can always choose their result.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="0be7-af29-227d-5efb" name="Da Icebone Skull" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="de74-0645-34e8-23e4" type="notInstanceOf"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f224-9a8a-59fe-58b2" type="max"/>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf67-c833-2947-2368" type="min"/>
-          </constraints>
-          <profiles>
-            <profile id="677e-e9e8-cf57-03f5" name="Da Icebone Skull" hidden="false" typeId="0ac4-aacb-2481-8e72" typeName="Artefact">
-              <characteristics>
-                <characteristic name="Artefact Details" typeId="0918-c47a-d84e-c0cf">This ancient, crystallized skull bestows the bearer with the endurance of an everlasting winter. All damage suffered by the bearer is halved (rounding down). In addition, the bearer heals 1 wound in each of your hero phases.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="1a80-8e21-ab27-e02c" name="Blood Waaagh!" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="72b6-9777-df40-1149" type="notInstanceOf"/>
-                  </conditions>
-                  <conditionGroups>
-                    <conditionGroup type="and">
-                      <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f53-8230-2f02-9639" type="notInstanceOf"/>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="72b6-9777-df40-1149" type="notInstanceOf"/>
-                      </conditions>
-                    </conditionGroup>
-                  </conditionGroups>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="55e6-caa3-344d-182c" type="max"/>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9767-2f57-471e-27ac" type="min"/>
-          </constraints>
-          <profiles>
-            <profile id="8967-4856-b661-5e2d" name="Blood Waaagh!" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
-              <characteristics>
-                <characteristic name="Casting Value" typeId="2508-b604-1258-a920">8</characteristic>
-                <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, pick a BONESPLITTERZ unit within 6&quot;. That unit can immediately pile in and attack as if it were the combat phase.  Only one WIZARD can attempt to cast Blood Waaagh! in each hero phase.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
     </selectionEntryGroup>
     <selectionEntryGroup id="3135-5fd5-a577-157e" name="Additional Bonesplitterz Units" hidden="false" collective="false" import="true">
       <entryLinks>
@@ -3972,14 +4071,7 @@ In addition, add 1 to hit rolls and wound rolls for attacks made with this unitâ
         <entryLink id="64c9-0f06-bd7d-d6f5" name="Wurrgog Prophet" hidden="false" collective="false" import="true" targetId="f6fa-7f5f-0836-e986" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="c135-87e9-74a7-48b6" name="Lore of the Weird" page="102" hidden="true" collective="false" import="true">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="157e-e19c-bc6e-6d49" type="instanceOf"/>
-          </conditions>
-        </modifier>
-      </modifiers>
+    <selectionEntryGroup id="c135-87e9-74a7-48b6" name="Lore of the Weird" page="102" hidden="false" collective="false" import="true">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5497-1ed2-2ffb-5415" type="max"/>
       </constraints>
@@ -4065,18 +4157,6 @@ In addition, add 1 to hit rolls and wound rolls for attacks made with this unitâ
       </selectionEntries>
     </selectionEntryGroup>
     <selectionEntryGroup id="9858-0f3e-e91b-ed76" name="Traits: Ironclad Warlords" page="103" hidden="false" collective="false" import="true">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="157e-e19c-bc6e-6d49" type="notInstanceOf"/>
-                <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fb31-0c98-2d1d-8492" type="notInstanceOf"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8cf0-eb20-ab14-e9b5" type="max"/>
       </constraints>
@@ -4156,18 +4236,6 @@ In addition, add 1 to hit rolls and wound rolls for attacks made with this unitâ
       </selectionEntries>
     </selectionEntryGroup>
     <selectionEntryGroup id="4c62-d7fb-3add-f833" name="Artefacts: Da Boss&apos;s Hoard" page="103" hidden="false" collective="false" import="true">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="157e-e19c-bc6e-6d49" type="notInstanceOf"/>
-                <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fb31-0c98-2d1d-8492" type="notInstanceOf"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c17e-8c85-3f55-9cb4" type="max"/>
       </constraints>
@@ -4247,18 +4315,6 @@ In addition, add 1 to hit rolls and wound rolls for attacks made with this unitâ
       </selectionEntries>
     </selectionEntryGroup>
     <selectionEntryGroup id="3dfa-d1ab-31b8-b5fa" name="Traits: Champions of the Weird" page="103" hidden="false" collective="false" import="true">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="157e-e19c-bc6e-6d49" type="notInstanceOf"/>
-                <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7ede-c037-02c4-b83d" type="notInstanceOf"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="34fe-8061-edc8-3704" type="max"/>
       </constraints>
@@ -4302,18 +4358,6 @@ In addition, add 1 to hit rolls and wound rolls for attacks made with this unitâ
       </selectionEntries>
     </selectionEntryGroup>
     <selectionEntryGroup id="66f8-0866-8c4e-5ac3" name="Artefacts: Weird Trinkets" page="57" hidden="false" collective="false" import="true">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="157e-e19c-bc6e-6d49" type="notInstanceOf"/>
-                <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7ede-c037-02c4-b83d" type="notInstanceOf"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d5c6-2f4b-0b60-d44b" type="max"/>
       </constraints>
@@ -4358,15 +4402,6 @@ In addition, add 1 to hit rolls and wound rolls for attacks made with this unitâ
     </selectionEntryGroup>
     <selectionEntryGroup id="0307-2418-9dbc-7b2f" name="Ironjawz Mount Traits" page="103" hidden="false" collective="false" import="true">
       <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="157e-e19c-bc6e-6d49" type="notInstanceOf"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
         <modifier type="increment" field="324a-1d59-7092-6fbe" value="1.0">
           <repeats>
             <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="be17-6bbd-b857-3f43" repeats="1" roundUp="false"/>
@@ -4522,18 +4557,27 @@ In addition, add 1 to hit rolls and wound rolls for attacks made with this unitâ
     </selectionEntryGroup>
     <selectionEntryGroup id="e29e-75bb-6308-1c51" name="Spell Lores" hidden="false" collective="false" import="true">
       <entryLinks>
-        <entryLink id="d243-28dc-9d18-08b3" name="Lore of the Weird" hidden="false" collective="false" import="true" targetId="c135-87e9-74a7-48b6" type="selectionEntryGroup"/>
-        <entryLink id="c54e-197d-cae4-5055" name="Lore of the Savage Beast" hidden="false" collective="false" import="true" targetId="847a-d124-5e4d-1613" type="selectionEntryGroup"/>
+        <entryLink id="d243-28dc-9d18-08b3" name="Lore of the Weird" hidden="false" collective="false" import="true" targetId="c135-87e9-74a7-48b6" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="157e-e19c-bc6e-6d49" type="notInstanceOf"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+        <entryLink id="c54e-197d-cae4-5055" name="Lore of the Savage Beast" hidden="false" collective="false" import="true" targetId="847a-d124-5e4d-1613" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9db3-55f3-706c-01bd" type="notInstanceOf"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="3be1-bc09-3cf5-19e1" name="Artefacts: Ironjawz Warclan" hidden="false" collective="false" import="true">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eba0-179a-d749-6e62" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2639-25e4-d36e-1316" type="max"/>
       </constraints>
@@ -4649,13 +4693,6 @@ In addition, add 1 to hit rolls and wound rolls for attacks made with this unitâ
       </selectionEntries>
     </selectionEntryGroup>
     <selectionEntryGroup id="aba4-6326-986d-bfa7" name="Artefacts: Bonesplitterz Warclan" hidden="false" collective="false" import="true">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="33cb-28e3-cf3d-7f21" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf33-bf13-e3ed-478e" type="max"/>
       </constraints>
@@ -4756,34 +4793,23 @@ In addition, add 1 to hit rolls and wound rolls for attacks made with this unitâ
       </selectionEntries>
     </selectionEntryGroup>
     <selectionEntryGroup id="c446-4553-755a-bd29" name="Traits: Ironjawz Warclan" hidden="false" collective="false" import="true">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="eba0-179a-d749-6e62" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f3a-15d5-d9fb-1ac8" type="max"/>
       </constraints>
       <selectionEntries>
-        <selectionEntry id="aae9-2f8d-8061-0299" name="0. Right Fist of Dakkbad" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="aae9-2f8d-8061-0299" name="0. Right Fist of Dakkbad" hidden="true" collective="false" import="true" type="upgrade">
           <modifiers>
-            <modifier type="set" field="6031-d981-12c6-5fca" value="1.0">
+            <modifier type="set" field="a354-7a2d-24fb-f2b6" value="1.0">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="eef6-4cd5-66a5-a5fb" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="hidden" value="false">
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="eef6-4cd5-66a5-a5fb" type="equalTo"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-            <modifier type="set" field="hidden" value="true">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="eef6-4cd5-66a5-a5fb" type="equalTo"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fb31-0c98-2d1d-8492" type="notInstanceOf"/>
+                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="eef6-4cd5-66a5-a5fb" type="greaterThan"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fb31-0c98-2d1d-8492" type="instanceOf"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -4807,13 +4833,9 @@ In addition, add 1 to hit rolls and wound rolls for attacks made with this unitâ
         <selectionEntry id="9eac-03ea-c9ec-f9f4" name="0. Checked Out" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="ee80-b852-898f-b917" value="1.0">
-              <conditionGroups>
-                <conditionGroup type="and">
-                  <conditions>
-                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="106b-3df1-006f-1b47" type="equalTo"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="106b-3df1-006f-1b47" type="equalTo"/>
+              </conditions>
             </modifier>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -4839,23 +4861,14 @@ In addition, add 1 to hit rolls and wound rolls for attacks made with this unitâ
         <selectionEntry id="ff63-7e19-b2a2-1143" name="0. Get Da Realmgate" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="0c6b-af74-6f54-b73b" value="1.0">
-              <conditionGroups>
-                <conditionGroup type="and">
-                  <conditions>
-                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="be7c-ed66-5895-6473" type="equalTo"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="088b-3a27-03f7-8249" type="notInstanceOf"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="be7c-ed66-5895-6473" type="equalTo"/>
+              </conditions>
             </modifier>
             <modifier type="set" field="hidden" value="true">
-              <conditionGroups>
-                <conditionGroup type="and">
-                  <conditions>
-                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="be7c-ed66-5895-6473" type="equalTo"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="be7c-ed66-5895-6473" type="equalTo"/>
+              </conditions>
             </modifier>
           </modifiers>
           <constraints>
@@ -4876,18 +4889,6 @@ In addition, add 1 to hit rolls and wound rolls for attacks made with this unitâ
       </selectionEntries>
     </selectionEntryGroup>
     <selectionEntryGroup id="fa5a-f950-c7df-0559" name="Traits: Shamanistic Quirks" hidden="false" collective="false" import="true">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="33cb-28e3-cf3d-7f21" type="equalTo"/>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f53-8230-2f02-9639" type="instanceOf"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1c3-6117-da55-df65" type="max"/>
       </constraints>
@@ -4939,14 +4940,7 @@ In addition, add 1 to hit rolls and wound rolls for attacks made with this unitâ
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
-    <selectionEntryGroup id="847a-d124-5e4d-1613" name="Lore of the Savage Beast" page="102" hidden="true" collective="false" import="true">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9db3-55f3-706c-01bd" type="instanceOf"/>
-          </conditions>
-        </modifier>
-      </modifiers>
+    <selectionEntryGroup id="847a-d124-5e4d-1613" name="Lore of the Savage Beast" page="102" hidden="false" collective="false" import="true">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f99-f15b-40f1-ba1a" type="max"/>
       </constraints>
@@ -5031,19 +5025,7 @@ In addition, add 1 to hit rolls and wound rolls for attacks made with this unitâ
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
-    <selectionEntryGroup id="dd9b-5136-e99d-b610" name="Artefacts: Boss Bones and Other Gubbinz" hidden="true" collective="false" import="true">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="33cb-28e3-cf3d-7f21" type="equalTo"/>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4e0e-664d-51ea-0929" type="instanceOf"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
+    <selectionEntryGroup id="dd9b-5136-e99d-b610" name="Artefacts: Boss Bones and Other Gubbinz" hidden="false" collective="false" import="true">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1472-90b7-4a8a-0b6c" type="max"/>
       </constraints>
@@ -5141,34 +5123,23 @@ In addition, add 1 to hit rolls and wound rolls for attacks made with this unitâ
       </selectionEntries>
     </selectionEntryGroup>
     <selectionEntryGroup id="4900-2ad5-7dd9-9f73" name="Traits: Bonesplitterz Warclan" hidden="false" collective="false" import="true">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="eba0-179a-d749-6e62" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8955-44eb-f9b4-64b0" type="max"/>
       </constraints>
       <selectionEntries>
-        <selectionEntry id="b50d-3224-bdd6-2c5a" name="0. A Right Monster" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="b50d-3224-bdd6-2c5a" name="0. A Right Monster" hidden="true" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="2612-a2d6-a130-2e3c" value="1.0">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="9e65-9af8-84b8-1148" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="hidden" value="false">
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
                     <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="9e65-9af8-84b8-1148" type="equalTo"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-            <modifier type="set" field="hidden" value="true">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="eef6-4cd5-66a5-a5fb" type="equalTo"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fb31-0c98-2d1d-8492" type="notInstanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c9ee-e3ba-3b83-fe1c" type="instanceOf"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -5189,22 +5160,22 @@ In addition, add 1 to hit rolls and wound rolls for attacks made with this unitâ
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="40b4-db0f-b8ed-bed3" name="0. Pure-bread War Boar" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="40b4-db0f-b8ed-bed3" name="0. Pure-bread War Boar" hidden="true" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="c102-ba7c-8f0e-718b" value="1.0">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="18c0-ed54-52bc-0de2" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="hidden" value="false">
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="106b-3df1-006f-1b47" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="18c0-ed54-52bc-0de2" type="greaterThan"/>
                     <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="02c4-b631-39dd-c932" type="instanceOf"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
-            </modifier>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="115b-bd71-6506-80ec" type="equalTo"/>
-              </conditions>
             </modifier>
           </modifiers>
           <constraints>
@@ -5225,23 +5196,14 @@ In addition, add 1 to hit rolls and wound rolls for attacks made with this unitâ
         <selectionEntry id="aa88-e3a3-a4b0-1eee" name="0. Fireball" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="1b73-1388-df2f-e1cb" value="1.0">
-              <conditionGroups>
-                <conditionGroup type="and">
-                  <conditions>
-                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="18c0-ed54-52bc-0de2" type="equalTo"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="088b-3a27-03f7-8249" type="notInstanceOf"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="115b-bd71-6506-80ec" type="equalTo"/>
+              </conditions>
             </modifier>
             <modifier type="set" field="hidden" value="true">
-              <conditionGroups>
-                <conditionGroup type="and">
-                  <conditions>
-                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="be7c-ed66-5895-6473" type="equalTo"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="115b-bd71-6506-80ec" type="equalTo"/>
+              </conditions>
             </modifier>
           </modifiers>
           <constraints>
@@ -5249,12 +5211,6 @@ In addition, add 1 to hit rolls and wound rolls for attacks made with this unitâ
             <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="1b73-1388-df2f-e1cb" type="min"/>
           </constraints>
           <profiles>
-            <profile id="3460-22b2-8585-f20a" name="Fireball" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
-              <characteristics>
-                <characteristic name="Casting Value" typeId="2508-b604-1258-a920">5</characteristic>
-                <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, pick 1 enemy unit within 18&quot; of the caster and visible to them. If that enemy unit has 1 model, it suffers 1 mortal wound; if it has 2-9 models, it suffers D3 mortal wounds; and if it has 10 or more models, it suffers D6 mortal wounds.</characteristic>
-              </characteristics>
-            </profile>
             <profile id="cdb0-0d3d-e44a-a345" name="Fireball" hidden="false" typeId="bdc6-78da-3796-60a3" typeName="Battalion Abilities">
               <characteristics>
                 <characteristic name="Battalion Ability Details" typeId="08e0-9ead-1dbe-c801">The general of a Drakkfoot army does not receive a command trait. Instead, all DRAKKFOOT WIZARDS know the Fireball spell instead of the Arcane Bolt spell</characteristic>

--- a/Order - Stormcast Eternals - Data.cat
+++ b/Order - Stormcast Eternals - Data.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="82b4-f6e1-3e37-5ea1" name="Order - Stormcast Eternals - Data" revision="46" battleScribeVersion="2.03" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="true" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="82b4-f6e1-3e37-5ea1" name="Order - Stormcast Eternals - Data" revision="47" battleScribeVersion="2.03" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="true" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="ed04-877b-pubN65537" name="Order Battletome: Stormcast Eternals (2nd Edition)"/>
     <publication id="ed04-877b-pubN71576" name="Battletome: Stormcast Eternals (2nd Edition)"/>
@@ -9358,6 +9358,53 @@
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry id="8bab-4c0b-f465-3235" name="Battalion: Blessed Star Host (OPEN PLAY)" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="92d7-7cef-e812-82ab" name="Battalion: Blessed Star Host (OPEN PLAY)" page="SC! Stormcast" hidden="false" typeId="bdc6-78da-3796-60a3" typeName="Battalion Abilities">
+          <characteristics>
+            <characteristic name="Battalion Ability Details" typeId="08e0-9ead-1dbe-c801">Blessed Host units have a Save characteristic of 3+ whilst they are within 12&quot; of their Lord-Celestant.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="0ec7-576f-857f-f2e5" name="1) 1 Lord-Celestant" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe8d-c946-62b5-b3e2" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5cc-d447-c87b-3da6" type="min"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="00b6-3248-0c82-12c9" name="Lord-Celestant" hidden="false" collective="false" import="true" targetId="425f-9d59-b2f6-b5f0" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="973d-4cfc-41fc-868c" name="3) 1 unit of Retributors" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f584-680e-e546-1461" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc6d-c887-5e2a-884b" type="min"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="21c8-5b2b-be8f-3ba9" name="Retributors" hidden="false" collective="false" import="true" targetId="20ee-5f80-e899-a31b" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="c084-6ee5-b252-dcb8" name="4) 1 unit of Prosecutors" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9502-9e09-2abe-6df0" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="978a-808b-1f54-2068" type="min"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="fc82-8b48-c5df-79b1" name="Prosecutors" hidden="false" collective="false" import="true" targetId="432b-fe7d-867c-7e7d" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="3b1c-9522-9d38-4ff2" name="2) 1 unit of Liberators" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d72-272c-ba79-3a0a" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7892-a7d9-69ac-c15a" type="min"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="a581-7b2b-63ac-3506" name="Liberators" hidden="false" collective="false" import="true" targetId="5b8e-b5ee-8df3-9f2f" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>

--- a/Order - Stormcast Eternals.cat
+++ b/Order - Stormcast Eternals.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="ed04-877b-c5d3-ce41" name="Order - Stormcast Eternals" revision="45" battleScribeVersion="2.02" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="ed04-877b-c5d3-ce41" name="Order - Stormcast Eternals" revision="46" battleScribeVersion="2.03" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profileTypes>
     <profileType id="9cb4-15df-780d-f4ee" name="Crew Table">
       <characteristicTypes>
@@ -10,7 +10,7 @@
     </profileType>
   </profileTypes>
   <entryLinks>
-    <entryLink id="7332-f387-438b-852c" name="Allegiance" hidden="false" collective="false" targetId="c6a3-2acf-1e46-3896" type="selectionEntry">
+    <entryLink id="7332-f387-438b-852c" name="Allegiance" hidden="false" collective="false" import="true" targetId="c6a3-2acf-1e46-3896" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -22,65 +22,65 @@
         <categoryLink id="f799-9cd3-6530-624e" name="New CategoryLink" hidden="false" targetId="87e8-c095-f059-5f7b" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="e779-4dc2-4d8c-8676" name="Lord-Celestant on Dracoth" hidden="false" collective="false" targetId="5232-9953-1b83-0097" type="selectionEntry">
+    <entryLink id="e779-4dc2-4d8c-8676" name="Lord-Celestant on Dracoth" hidden="false" collective="false" import="true" targetId="5232-9953-1b83-0097" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="e779-4dc2-4d8c-8676-6c6b-e787-f9b8-a510" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
         <categoryLink id="9620-6595-3e80-d5d0" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="6e8d-cdd5-337d-ef5d" name="Drakesworn Templar" hidden="false" collective="false" targetId="1090-dc26-d603-1103" type="selectionEntry">
+    <entryLink id="6e8d-cdd5-337d-ef5d" name="Drakesworn Templar" hidden="false" collective="false" import="true" targetId="1090-dc26-d603-1103" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="9976-7cf6-7328-9c78" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
         <categoryLink id="20e3-9500-7c6c-fd18" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="e7aa-2962-d6ab-8be7" name="Lord-Celestant on Stardrake" hidden="false" collective="false" targetId="19ca-60d5-c3b7-9444" type="selectionEntry">
+    <entryLink id="e7aa-2962-d6ab-8be7" name="Lord-Celestant on Stardrake" hidden="false" collective="false" import="true" targetId="19ca-60d5-c3b7-9444" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="18bc-1971-240b-40da" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false"/>
         <categoryLink id="e0f7-0c46-7886-1b91" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="3655-872d-ae10-f8a5" name="Concussors" hidden="false" collective="false" targetId="a106-3d7e-be4d-bf3b" type="selectionEntry">
+    <entryLink id="3655-872d-ae10-f8a5" name="Concussors" hidden="false" collective="false" import="true" targetId="a106-3d7e-be4d-bf3b" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="3655-872d-ae10-f8a5-065e-fda7-fd27-1f40" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="38dc-ac4d-bb07-37a9" name="Desolators" hidden="false" collective="false" targetId="c97b-8f8b-99d4-71ed" type="selectionEntry">
+    <entryLink id="38dc-ac4d-bb07-37a9" name="Desolators" hidden="false" collective="false" import="true" targetId="c97b-8f8b-99d4-71ed" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="38dc-ac4d-bb07-37a9-065e-fda7-fd27-1f40" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="d7c3-3ecd-4fe2-3212" name="Fulminators" hidden="false" collective="false" targetId="fed1-2388-810f-3ae7" type="selectionEntry">
+    <entryLink id="d7c3-3ecd-4fe2-3212" name="Fulminators" hidden="false" collective="false" import="true" targetId="fed1-2388-810f-3ae7" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="d7c3-3ecd-4fe2-3212-065e-fda7-fd27-1f40" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="4566-0227-ca46-cab0" name="Tempestors" hidden="false" collective="false" targetId="4115-b86d-bbd9-69ab" type="selectionEntry">
+    <entryLink id="4566-0227-ca46-cab0" name="Tempestors" hidden="false" collective="false" import="true" targetId="4115-b86d-bbd9-69ab" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="4566-0227-ca46-cab0-065e-fda7-fd27-1f40" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="ecee-1c5d-f5ae-c105" name="Drakesworn Temple" hidden="false" collective="false" targetId="983e-2e66-1d7a-cfaa" type="selectionEntry">
+    <entryLink id="ecee-1c5d-f5ae-c105" name="Drakesworn Temple" hidden="false" collective="false" import="true" targetId="983e-2e66-1d7a-cfaa" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ecee-1c5d-f5ae-c105-be17-6bbd-b857-3f43" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="fc60-fa48-ec37-6e97" name="Battalion: Extremis Chamber" hidden="false" collective="false" targetId="2c05-5952-538d-8f2c" type="selectionEntry">
+    <entryLink id="fc60-fa48-ec37-6e97" name="Battalion: Extremis Chamber" hidden="false" collective="false" import="true" targetId="2c05-5952-538d-8f2c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="fc60-fa48-ec37-6e97-be17-6bbd-b857-3f43" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="b2f2-6ed0-5714-ca68" name="Lightning Echelon" hidden="false" collective="false" targetId="4afb-8202-c231-ba96" type="selectionEntry">
+    <entryLink id="b2f2-6ed0-5714-ca68" name="Lightning Echelon" hidden="false" collective="false" import="true" targetId="4afb-8202-c231-ba96" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b2f2-6ed0-5714-ca68-be17-6bbd-b857-3f43" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="e1f6-1935-8e6c-9526" name="Battalion: Thunderwave Echelon" hidden="false" collective="false" targetId="695f-edd6-db5c-bbc3" type="selectionEntry">
+    <entryLink id="e1f6-1935-8e6c-9526" name="Battalion: Thunderwave Echelon" hidden="false" collective="false" import="true" targetId="695f-edd6-db5c-bbc3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="e1f6-1935-8e6c-9526-be17-6bbd-b857-3f43" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="ea68-313d-ab64-e7d5" name="Judicators" hidden="false" collective="false" targetId="993b-d238-93ba-a4f2" type="selectionEntry">
+    <entryLink id="ea68-313d-ab64-e7d5" name="Judicators" hidden="false" collective="false" import="true" targetId="993b-d238-93ba-a4f2" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -92,112 +92,112 @@
         <categoryLink id="ea68-313d-ab64-e7d5-065e-fda7-fd27-1f40" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="6baa-75dc-373d-a127" name="Celestant-Prime, Hammer of Sigmar" hidden="false" collective="false" targetId="4827-4147-67c2-16f7" type="selectionEntry">
+    <entryLink id="6baa-75dc-373d-a127" name="Celestant-Prime, Hammer of Sigmar" hidden="false" collective="false" import="true" targetId="4827-4147-67c2-16f7" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="6baa-75dc-373d-a127-6c6b-e787-f9b8-a510" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="ec2a-ac0a-92f9-6b53" name="Knight-Azyros" hidden="false" collective="false" targetId="afac-5154-99ae-ee3c" type="selectionEntry">
+    <entryLink id="ec2a-ac0a-92f9-6b53" name="Knight-Azyros" hidden="false" collective="false" import="true" targetId="afac-5154-99ae-ee3c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ec2a-ac0a-92f9-6b53-6c6b-e787-f9b8-a510" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="caba-79b0-d660-22ac" name="Knight-Heraldor" hidden="false" collective="false" targetId="3c2d-c00c-722b-36d2" type="selectionEntry">
+    <entryLink id="caba-79b0-d660-22ac" name="Knight-Heraldor" hidden="false" collective="false" import="true" targetId="3c2d-c00c-722b-36d2" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="caba-79b0-d660-22ac-6c6b-e787-f9b8-a510" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="973a-aa28-e9de-1f2f" name="Knight-Venator" hidden="false" collective="false" targetId="aeb5-ae52-567b-5f8c" type="selectionEntry">
+    <entryLink id="973a-aa28-e9de-1f2f" name="Knight-Venator" hidden="false" collective="false" import="true" targetId="aeb5-ae52-567b-5f8c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="973a-aa28-e9de-1f2f-6c6b-e787-f9b8-a510" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="b3c6-1d6d-3af0-9d9e" name="Knight-Vexillor" hidden="false" collective="false" targetId="9320-740f-eb76-c07b" type="selectionEntry">
+    <entryLink id="b3c6-1d6d-3af0-9d9e" name="Knight-Vexillor" hidden="false" collective="false" import="true" targetId="9320-740f-eb76-c07b" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b3c6-1d6d-3af0-9d9e-6c6b-e787-f9b8-a510" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="fe7d-4037-5dde-6926" name="Lord-Castellant" hidden="false" collective="false" targetId="15e7-d7b5-5bed-3c54" type="selectionEntry">
+    <entryLink id="fe7d-4037-5dde-6926" name="Lord-Castellant" hidden="false" collective="false" import="true" targetId="15e7-d7b5-5bed-3c54" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="fe7d-4037-5dde-6926-6c6b-e787-f9b8-a510" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="0f9a-f02a-61ca-324b" name="Lord-Celestant" hidden="false" collective="false" targetId="425f-9d59-b2f6-b5f0" type="selectionEntry">
+    <entryLink id="0f9a-f02a-61ca-324b" name="Lord-Celestant" hidden="false" collective="false" import="true" targetId="425f-9d59-b2f6-b5f0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="0f9a-f02a-61ca-324b-6c6b-e787-f9b8-a510" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="5048-b161-6f3d-8c30" name="Lord-Relictor" hidden="false" collective="false" targetId="ce64-88a6-ce56-0940" type="selectionEntry">
+    <entryLink id="5048-b161-6f3d-8c30" name="Lord-Relictor" hidden="false" collective="false" import="true" targetId="ce64-88a6-ce56-0940" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5048-b161-6f3d-8c30-6c6b-e787-f9b8-a510" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="369f-4f98-a1df-728a" name="Decimators" hidden="false" collective="false" targetId="5330-8a21-c53d-7aa3" type="selectionEntry">
+    <entryLink id="369f-4f98-a1df-728a" name="Decimators" hidden="false" collective="false" import="true" targetId="5330-8a21-c53d-7aa3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="369f-4f98-a1df-728a-065e-fda7-fd27-1f40" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="29fb-a93d-9625-1332" name="Gryph-Hounds" hidden="false" collective="false" targetId="d79a-14b4-5f86-76d2" type="selectionEntry">
+    <entryLink id="29fb-a93d-9625-1332" name="Gryph-Hounds" hidden="false" collective="false" import="true" targetId="d79a-14b4-5f86-76d2" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="29fb-a93d-9625-1332-065e-fda7-fd27-1f40" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="ab34-4569-760e-6394" name="Prosecutors" hidden="false" collective="false" targetId="432b-fe7d-867c-7e7d" type="selectionEntry">
+    <entryLink id="ab34-4569-760e-6394" name="Prosecutors" hidden="false" collective="false" import="true" targetId="432b-fe7d-867c-7e7d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ab34-4569-760e-6394-065e-fda7-fd27-1f40" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="8e5e-09df-e579-13cb" name="Protectors" hidden="false" collective="false" targetId="5858-a948-c65e-b3b7" type="selectionEntry">
+    <entryLink id="8e5e-09df-e579-13cb" name="Protectors" hidden="false" collective="false" import="true" targetId="5858-a948-c65e-b3b7" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8e5e-09df-e579-13cb-065e-fda7-fd27-1f40" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="cfdb-3b6b-1a35-b615" name="Retributors" hidden="false" collective="false" targetId="20ee-5f80-e899-a31b" type="selectionEntry">
+    <entryLink id="cfdb-3b6b-1a35-b615" name="Retributors" hidden="false" collective="false" import="true" targetId="20ee-5f80-e899-a31b" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="cfdb-3b6b-1a35-b615-065e-fda7-fd27-1f40" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="8450-2122-ada7-b31b" name="Exemplar Chamber" hidden="false" collective="false" targetId="ff72-27ce-5454-ddb7" type="selectionEntry">
+    <entryLink id="8450-2122-ada7-b31b" name="Exemplar Chamber" hidden="false" collective="false" import="true" targetId="ff72-27ce-5454-ddb7" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8450-2122-ada7-b31b-be17-6bbd-b857-3f43" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="1cbb-a6d7-33ae-12cd" name="Battalion: Devastation Brotherhood" hidden="false" collective="false" targetId="ac73-fd63-1eac-3469" type="selectionEntry">
+    <entryLink id="1cbb-a6d7-33ae-12cd" name="Battalion: Devastation Brotherhood" hidden="false" collective="false" import="true" targetId="ac73-fd63-1eac-3469" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="1cbb-a6d7-33ae-12cd-be17-6bbd-b857-3f43" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="b8e7-aaa6-d516-7fff" name="Hammerstrike Force" hidden="false" collective="false" targetId="063b-7290-fde1-ba0b" type="selectionEntry">
+    <entryLink id="b8e7-aaa6-d516-7fff" name="Hammerstrike Force" hidden="false" collective="false" import="true" targetId="063b-7290-fde1-ba0b" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b8e7-aaa6-d516-7fff-be17-6bbd-b857-3f43" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="a8b9-8a1b-ce3f-0f15" name="[SE] Battalion: Harbinger Chamber" hidden="false" collective="false" targetId="a14f-bf85-c562-e1be" type="selectionEntry">
+    <entryLink id="a8b9-8a1b-ce3f-0f15" name="[SE] Battalion: Harbinger Chamber" hidden="false" collective="false" import="true" targetId="a14f-bf85-c562-e1be" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="a8b9-8a1b-ce3f-0f15-be17-6bbd-b857-3f43" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="b8f2-7398-172f-7557" name="Battalion: Lords of the Storm" hidden="false" collective="false" targetId="2952-d3ab-822e-bc2d" type="selectionEntry">
+    <entryLink id="b8f2-7398-172f-7557" name="Battalion: Lords of the Storm" hidden="false" collective="false" import="true" targetId="2952-d3ab-822e-bc2d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b8f2-7398-172f-7557-be17-6bbd-b857-3f43" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="9beb-20c3-152f-c3ff" name="[SE] Battalion: Skyborne Slayers" hidden="false" collective="false" targetId="aba7-e4f3-2224-86ab" type="selectionEntry">
+    <entryLink id="9beb-20c3-152f-c3ff" name="[SE] Battalion: Skyborne Slayers" hidden="false" collective="false" import="true" targetId="aba7-e4f3-2224-86ab" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="9beb-20c3-152f-c3ff-be17-6bbd-b857-3f43" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="a3bb-25dc-9dbe-fe3a" name="Battalion: Thunderhead Brotherhood" hidden="false" collective="false" targetId="7fb3-580c-8aca-03e0" type="selectionEntry">
+    <entryLink id="a3bb-25dc-9dbe-fe3a" name="Battalion: Thunderhead Brotherhood" hidden="false" collective="false" import="true" targetId="7fb3-580c-8aca-03e0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="a3bb-25dc-9dbe-fe3a-be17-6bbd-b857-3f43" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="7b33-884a-7f3b-b67a" name="Vanguard Wing" hidden="false" collective="false" targetId="37c1-f534-e5d8-3d4c" type="selectionEntry">
+    <entryLink id="7b33-884a-7f3b-b67a" name="Vanguard Wing" hidden="false" collective="false" import="true" targetId="37c1-f534-e5d8-3d4c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7b33-884a-7f3b-b67a-be17-6bbd-b857-3f43" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="36a1-876b-0aa7-cb42" name="Battalion: Wardens of the Realmgate (OPEN PLAY)" hidden="false" collective="false" targetId="0f00-f028-eb1c-7471" type="selectionEntry">
+    <entryLink id="36a1-876b-0aa7-cb42" name="Battalion: Wardens of the Realmgate (OPEN PLAY)" hidden="false" collective="false" import="true" targetId="0f00-f028-eb1c-7471" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -209,37 +209,37 @@
         <categoryLink id="36a1-876b-0aa7-cb42-be17-6bbd-b857-3f43" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="8aac-828e-2989-eae5" name="[SE] Battalion: Warrior Brotherhood" hidden="false" collective="false" targetId="894e-4388-ce01-827c" type="selectionEntry">
+    <entryLink id="8aac-828e-2989-eae5" name="[SE] Battalion: Warrior Brotherhood" hidden="false" collective="false" import="true" targetId="894e-4388-ce01-827c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8aac-828e-2989-eae5-be17-6bbd-b857-3f43" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="a058-0cf7-52b4-b59b" name="[SE] Battalion: Warrior Chamber" hidden="false" collective="false" targetId="e315-d3ca-f68a-2918" type="selectionEntry">
+    <entryLink id="a058-0cf7-52b4-b59b" name="[SE] Battalion: Warrior Chamber" hidden="false" collective="false" import="true" targetId="e315-d3ca-f68a-2918" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="a058-0cf7-52b4-b59b-be17-6bbd-b857-3f43" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="cd66-df81-2c79-7231" name="Knight-Questor" hidden="false" collective="false" targetId="3c95-3545-4b34-4221" type="selectionEntry">
+    <entryLink id="cd66-df81-2c79-7231" name="Knight-Questor" hidden="false" collective="false" import="true" targetId="3c95-3545-4b34-4221" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="cd66-df81-2c79-7231-6c6b-e787-f9b8-a510" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="b377-1f0c-bd84-9aa8" name="Lord-Veritant" hidden="false" collective="false" targetId="7132-5dde-398e-d8a0" type="selectionEntry">
+    <entryLink id="b377-1f0c-bd84-9aa8" name="Lord-Veritant" hidden="false" collective="false" import="true" targetId="7132-5dde-398e-d8a0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b377-1f0c-bd84-9aa8-6c6b-e787-f9b8-a510" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="376a-8389-ff8a-9558" name="Aetherwings" hidden="false" collective="false" targetId="8940-6351-56bb-6cbf" type="selectionEntry">
+    <entryLink id="376a-8389-ff8a-9558" name="Aetherwings" hidden="false" collective="false" import="true" targetId="8940-6351-56bb-6cbf" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="376a-8389-ff8a-9558-065e-fda7-fd27-1f40" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="a266-1d9d-9fc2-c054" name="Lord-Aquilor" hidden="false" collective="false" targetId="a352-bb91-9133-a58d" type="selectionEntry">
+    <entryLink id="a266-1d9d-9fc2-c054" name="Lord-Aquilor" hidden="false" collective="false" import="true" targetId="a352-bb91-9133-a58d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="a266-1d9d-9fc2-c054-6c6b-e787-f9b8-a510" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="39fb-ca45-181d-24bb" name="Vanguard-Hunters" hidden="false" collective="false" targetId="a304-f6e3-9750-fae8" type="selectionEntry">
+    <entryLink id="39fb-ca45-181d-24bb" name="Vanguard-Hunters" hidden="false" collective="false" import="true" targetId="a304-f6e3-9750-fae8" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
@@ -256,22 +256,22 @@
         <categoryLink id="39fb-ca45-181d-24bb-065e-fda7-fd27-1f40" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="9764-9c8d-87a6-abb9" name="Vanguard-Palladors" hidden="false" collective="false" targetId="495f-0703-ade1-f179" type="selectionEntry">
+    <entryLink id="9764-9c8d-87a6-abb9" name="Vanguard-Palladors" hidden="false" collective="false" import="true" targetId="495f-0703-ade1-f179" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="9764-9c8d-87a6-abb9-065e-fda7-fd27-1f40" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="88ae-4437-b276-fe0a" name="Vanguard-Raptors with Hurricane Crossbows" hidden="false" collective="false" targetId="f013-a130-757f-6fbd" type="selectionEntry">
+    <entryLink id="88ae-4437-b276-fe0a" name="Vanguard-Raptors with Hurricane Crossbows" hidden="false" collective="false" import="true" targetId="f013-a130-757f-6fbd" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="88ae-4437-b276-fe0a-065e-fda7-fd27-1f40" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="6c32-cec9-846c-c420" name="Vanguard-Raptors with Longstrike Crossbows" hidden="false" collective="false" targetId="5a5d-a64b-6f2e-0ed9" type="selectionEntry">
+    <entryLink id="6c32-cec9-846c-c420" name="Vanguard-Raptors with Longstrike Crossbows" hidden="false" collective="false" import="true" targetId="5a5d-a64b-6f2e-0ed9" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="6c32-cec9-846c-c420-065e-fda7-fd27-1f40" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="18ae-599f-8351-6eb0" name="Judicators" hidden="false" collective="false" targetId="993b-d238-93ba-a4f2" type="selectionEntry">
+    <entryLink id="18ae-599f-8351-6eb0" name="Judicators" hidden="false" collective="false" import="true" targetId="993b-d238-93ba-a4f2" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -283,7 +283,7 @@
         <categoryLink id="18ae-599f-8351-6eb0-e9f2-765a-b7b8-ce8e" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="7192-af21-9337-5a33" name="Vanguard-Hunters" hidden="false" collective="false" targetId="a304-f6e3-9750-fae8" type="selectionEntry">
+    <entryLink id="7192-af21-9337-5a33" name="Vanguard-Hunters" hidden="false" collective="false" import="true" targetId="a304-f6e3-9750-fae8" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
@@ -307,7 +307,7 @@
         <categoryLink id="7192-af21-9337-5a33-e9f2-765a-b7b8-ce8e" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="1381-fe5a-9734-3d88" name="Aetherstrike Force (OPEN PLAY)" hidden="false" collective="false" targetId="a154-4988-4a34-47cc" type="selectionEntry">
+    <entryLink id="1381-fe5a-9734-3d88" name="Aetherstrike Force (OPEN PLAY)" hidden="false" collective="false" import="true" targetId="a154-4988-4a34-47cc" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -319,7 +319,7 @@
         <categoryLink id="1381-fe5a-9734-3d88-be17-6bbd-b857-3f43" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="8cd2-9f33-bbe3-9dbb" name="Anvils of the Heldenhammer Warrior Chamber (OPEN PLAY)" hidden="false" collective="false" targetId="d3e3-7ebf-8719-faa8" type="selectionEntry">
+    <entryLink id="8cd2-9f33-bbe3-9dbb" name="Anvils of the Heldenhammer Warrior Chamber (OPEN PLAY)" hidden="false" collective="false" import="true" targetId="d3e3-7ebf-8719-faa8" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -331,7 +331,7 @@
         <categoryLink id="8cd2-9f33-bbe3-9dbb-be17-6bbd-b857-3f43" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="2f9a-e151-a5c0-ed8b" name="Astral Templars Exemplar Chamber (OPEN PLAY)" hidden="false" collective="false" targetId="5b24-120b-335d-b72a" type="selectionEntry">
+    <entryLink id="2f9a-e151-a5c0-ed8b" name="Astral Templars Exemplar Chamber (OPEN PLAY)" hidden="false" collective="false" import="true" targetId="5b24-120b-335d-b72a" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -343,7 +343,7 @@
         <categoryLink id="2f9a-e151-a5c0-ed8b-be17-6bbd-b857-3f43" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="85c2-e244-3f45-7e07" name="Celestial Hunting Pack (OPEN PLAY)" hidden="false" collective="false" targetId="0152-90f7-5d97-cbc7" type="selectionEntry">
+    <entryLink id="85c2-e244-3f45-7e07" name="Celestial Hunting Pack (OPEN PLAY)" hidden="false" collective="false" import="true" targetId="0152-90f7-5d97-cbc7" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -355,7 +355,7 @@
         <categoryLink id="85c2-e244-3f45-7e07-be17-6bbd-b857-3f43" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="8d0a-205d-514c-5ee4" name="Celestial Vindicators Warrior Chamber (OPEN PLAY)" hidden="false" collective="false" targetId="e5ff-fc8a-dd7d-8ce6" type="selectionEntry">
+    <entryLink id="8d0a-205d-514c-5ee4" name="Celestial Vindicators Warrior Chamber (OPEN PLAY)" hidden="false" collective="false" import="true" targetId="e5ff-fc8a-dd7d-8ce6" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -367,7 +367,7 @@
         <categoryLink id="8d0a-205d-514c-5ee4-be17-6bbd-b857-3f43" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="4e35-45af-800f-97ca" name="Celestial Warbringers Harbinger Chamber (OPEN PLAY)" hidden="false" collective="false" targetId="22e1-8aa5-9407-4103" type="selectionEntry">
+    <entryLink id="4e35-45af-800f-97ca" name="Celestial Warbringers Harbinger Chamber (OPEN PLAY)" hidden="false" collective="false" import="true" targetId="22e1-8aa5-9407-4103" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -379,7 +379,7 @@
         <categoryLink id="4e35-45af-800f-97ca-be17-6bbd-b857-3f43" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="8787-b794-8f5f-748c" name="Hallowed Knights Warrior Chamber (OPEN PLAY)" hidden="false" collective="false" targetId="4c73-2f8e-94c2-7533" type="selectionEntry">
+    <entryLink id="8787-b794-8f5f-748c" name="Hallowed Knights Warrior Chamber (OPEN PLAY)" hidden="false" collective="false" import="true" targetId="4c73-2f8e-94c2-7533" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -391,7 +391,7 @@
         <categoryLink id="8787-b794-8f5f-748c-be17-6bbd-b857-3f43" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="1e89-1feb-1111-ad63" name="Hammers of Sigmar Warrior Chamber (OPEN PLAY)" hidden="false" collective="false" targetId="883d-d217-a60f-29e1" type="selectionEntry">
+    <entryLink id="1e89-1feb-1111-ad63" name="Hammers of Sigmar Warrior Chamber (OPEN PLAY)" hidden="false" collective="false" import="true" targetId="883d-d217-a60f-29e1" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -403,7 +403,7 @@
         <categoryLink id="1e89-1feb-1111-ad63-be17-6bbd-b857-3f43" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="5be4-e82b-ac90-d618" name="Battalion: Knights Excelsior Exemplar Chamber (OPEN PLAY)" hidden="false" collective="false" targetId="f46c-399f-8000-3fd9" type="selectionEntry">
+    <entryLink id="5be4-e82b-ac90-d618" name="Battalion: Knights Excelsior Exemplar Chamber (OPEN PLAY)" hidden="false" collective="false" import="true" targetId="f46c-399f-8000-3fd9" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -415,7 +415,7 @@
         <categoryLink id="5be4-e82b-ac90-d618-be17-6bbd-b857-3f43" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="f358-1f20-87ca-8594" name="Storm Heralds (OPEN PLAY)" hidden="false" collective="false" targetId="89c3-ea1e-c629-4f08" type="selectionEntry">
+    <entryLink id="f358-1f20-87ca-8594" name="Storm Heralds (OPEN PLAY)" hidden="false" collective="false" import="true" targetId="89c3-ea1e-c629-4f08" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -427,7 +427,7 @@
         <categoryLink id="f358-1f20-87ca-8594-be17-6bbd-b857-3f43" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="d87f-bf9e-015d-1af0" name="Storm Vortex Garrison (OPEN PLAY)" hidden="false" collective="false" targetId="3d22-e222-7cfc-a710" type="selectionEntry">
+    <entryLink id="d87f-bf9e-015d-1af0" name="Storm Vortex Garrison (OPEN PLAY)" hidden="false" collective="false" import="true" targetId="3d22-e222-7cfc-a710" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -439,7 +439,7 @@
         <categoryLink id="d87f-bf9e-015d-1af0-be17-6bbd-b857-3f43" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="e23b-aa5e-b7bb-3200" name="Tempest Lords Harbinger Chamber (OPEN PLAY)" hidden="false" collective="false" targetId="a7aa-0f4b-58e7-35d6" type="selectionEntry">
+    <entryLink id="e23b-aa5e-b7bb-3200" name="Tempest Lords Harbinger Chamber (OPEN PLAY)" hidden="false" collective="false" import="true" targetId="a7aa-0f4b-58e7-35d6" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -451,52 +451,52 @@
         <categoryLink id="e23b-aa5e-b7bb-3200-be17-6bbd-b857-3f43" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="3a30-a5fb-b190-8f94" name="Battalion: Vanguard Angelos Conclave" hidden="false" collective="false" targetId="d008-f976-b91f-c618" type="selectionEntry">
+    <entryLink id="3a30-a5fb-b190-8f94" name="Battalion: Vanguard Angelos Conclave" hidden="false" collective="false" import="true" targetId="d008-f976-b91f-c618" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="3a30-a5fb-b190-8f94-be17-6bbd-b857-3f43" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="b5e1-481e-9ed8-2203" name="[SE] Battalion: Vanguard Auxiliary Chamber" hidden="false" collective="false" targetId="32e3-a9ff-fb72-d014" type="selectionEntry">
+    <entryLink id="b5e1-481e-9ed8-2203" name="[SE] Battalion: Vanguard Auxiliary Chamber" hidden="false" collective="false" import="true" targetId="32e3-a9ff-fb72-d014" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b5e1-481e-9ed8-2203-be17-6bbd-b857-3f43" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="1c36-182c-68b1-3c8a" name="Battalion: Vanguard Justicar Conclave" hidden="false" collective="false" targetId="eff1-e522-7ea5-8c52" type="selectionEntry">
+    <entryLink id="1c36-182c-68b1-3c8a" name="Battalion: Vanguard Justicar Conclave" hidden="false" collective="false" import="true" targetId="eff1-e522-7ea5-8c52" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="1c36-182c-68b1-3c8a-be17-6bbd-b857-3f43" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="7d2b-3d65-f016-dd26" name="Neave Blacktalon" hidden="false" collective="false" targetId="e72f-58fe-d697-6be6" type="selectionEntry">
+    <entryLink id="7d2b-3d65-f016-dd26" name="Neave Blacktalon" hidden="false" collective="false" import="true" targetId="e72f-58fe-d697-6be6" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="878d-82e9-0d1f-bd99" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="c40a-f331-f505-15bc" name="Lord-Ordinator" hidden="false" collective="false" targetId="c924-f509-4a7f-1735" type="selectionEntry">
+    <entryLink id="c40a-f331-f505-15bc" name="Lord-Ordinator" hidden="false" collective="false" import="true" targetId="c924-f509-4a7f-1735" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="376f-1c95-c369-666c" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="0e35-1edd-4065-5563" name="Vandus Hammerhand" hidden="false" collective="false" targetId="66fb-5872-a345-2ad5" type="selectionEntry">
+    <entryLink id="0e35-1edd-4065-5563" name="Vandus Hammerhand" hidden="false" collective="false" import="true" targetId="66fb-5872-a345-2ad5" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="58ec-d130-40a7-a957" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="a22f-a46a-385b-a573" name="Gavriel Sureheart" hidden="false" collective="false" targetId="722a-0a7a-212c-da4c" type="selectionEntry">
+    <entryLink id="a22f-a46a-385b-a573" name="Gavriel Sureheart" hidden="false" collective="false" import="true" targetId="722a-0a7a-212c-da4c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="1f84-e88b-9637-7569" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="4391-8ed0-6bff-1873" name="Steelheart&apos;s Champions" hidden="false" collective="false" targetId="b8d3-7d4a-8689-ab16" type="selectionEntry">
+    <entryLink id="4391-8ed0-6bff-1873" name="Steelheart&apos;s Champions" hidden="false" collective="false" import="true" targetId="b8d3-7d4a-8689-ab16" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="db9d-cce0-e6d5-7b2b" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="6c56-3ab4-c910-2153" name="Blacktalon&apos;s Shadowhammers" hidden="false" collective="false" targetId="51db-1e95-d3e5-6d81" type="selectionEntry">
+    <entryLink id="6c56-3ab4-c910-2153" name="Blacktalon&apos;s Shadowhammers" hidden="false" collective="false" import="true" targetId="51db-1e95-d3e5-6d81" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="9d2d-651a-bc3d-b5cb" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="c3d7-1905-1703-71f9" name="Liberators" hidden="false" collective="false" targetId="5b8e-b5ee-8df3-9f2f" type="selectionEntry">
+    <entryLink id="c3d7-1905-1703-71f9" name="Liberators" hidden="false" collective="false" import="true" targetId="5b8e-b5ee-8df3-9f2f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
@@ -514,17 +514,17 @@
         <categoryLink id="2f63-f6dc-4954-9c55" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="8b3c-2baa-f4d3-d24e" name="The Farstriders" hidden="false" collective="false" targetId="384d-78bf-f7a0-887d" type="selectionEntry">
+    <entryLink id="8b3c-2baa-f4d3-d24e" name="The Farstriders" hidden="false" collective="false" import="true" targetId="384d-78bf-f7a0-887d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="cc48-c68b-1b08-e579" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="f4d1-5179-c21a-a1b4" name="Castigators" hidden="false" collective="false" targetId="623f-7949-6fb7-fd62" type="selectionEntry">
+    <entryLink id="f4d1-5179-c21a-a1b4" name="Castigators" hidden="false" collective="false" import="true" targetId="623f-7949-6fb7-fd62" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="14f6-681b-356f-053c" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="18c5-dfd0-7146-0e0b" name="Sequitors" hidden="false" collective="false" targetId="29da-7c0d-155b-f63a" type="selectionEntry">
+    <entryLink id="18c5-dfd0-7146-0e0b" name="Sequitors" hidden="false" collective="false" import="true" targetId="29da-7c0d-155b-f63a" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
@@ -576,12 +576,12 @@
         <categoryLink id="e863-7685-ffb6-0f7d" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="f3ba-f7a5-03b5-3662" name="Evocators" hidden="false" collective="false" targetId="6427-4f9f-abde-dc0b" type="selectionEntry">
+    <entryLink id="f3ba-f7a5-03b5-3662" name="Evocators" hidden="false" collective="false" import="true" targetId="6427-4f9f-abde-dc0b" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="e9e3-cc75-93e6-669f" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="87b6-f5af-5630-028d" name="Sequitors" hidden="false" collective="false" targetId="29da-7c0d-155b-f63a" type="selectionEntry">
+    <entryLink id="87b6-f5af-5630-028d" name="Sequitors" hidden="false" collective="false" import="true" targetId="29da-7c0d-155b-f63a" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
@@ -636,92 +636,92 @@
         <categoryLink id="0925-48f7-b549-8bb4" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="52b2-0d9a-3028-fa25" name="Lord-Arcanum on Gryph-charger" hidden="false" collective="false" targetId="775a-c8fb-23a8-5c2a" type="selectionEntry">
+    <entryLink id="52b2-0d9a-3028-fa25" name="Lord-Arcanum on Gryph-charger" hidden="false" collective="false" import="true" targetId="775a-c8fb-23a8-5c2a" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="957e-3dc0-3ee9-0fc3" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="f772-e53a-d545-36bf" name="Knight-Incantor" hidden="false" collective="false" targetId="7a4b-b062-14f2-65db" type="selectionEntry">
+    <entryLink id="f772-e53a-d545-36bf" name="Knight-Incantor" hidden="false" collective="false" import="true" targetId="7a4b-b062-14f2-65db" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="81f4-08b8-bb19-b094" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="860b-7244-e6f9-95dd" name="Celestar Ballista" hidden="false" collective="false" targetId="70bf-9177-9d10-bc5f" type="selectionEntry">
+    <entryLink id="860b-7244-e6f9-95dd" name="Celestar Ballista" hidden="false" collective="false" import="true" targetId="70bf-9177-9d10-bc5f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b6b7-1d6e-212d-7528" name="New CategoryLink" hidden="false" targetId="1d26-07fc-6a66-d73e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="11c3-a45d-d15e-3eea" name="Errant-Questor" hidden="false" collective="false" targetId="530a-e1c9-444c-bc70" type="selectionEntry">
+    <entryLink id="11c3-a45d-d15e-3eea" name="Errant-Questor" hidden="false" collective="false" import="true" targetId="530a-e1c9-444c-bc70" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="035e-e1a2-f002-fad7" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="3209-2c3a-ad64-504b" name="Astreia Solbright" hidden="false" collective="false" targetId="0bd3-8d56-f1d3-23ea" type="selectionEntry">
+    <entryLink id="3209-2c3a-ad64-504b" name="Astreia Solbright" hidden="false" collective="false" import="true" targetId="0bd3-8d56-f1d3-23ea" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="512f-b29a-f843-d65b" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="28f9-1c1e-70b7-c180" name="Aventis Firestrike, Magister of Hammerhal" hidden="false" collective="false" targetId="c346-0cbf-16de-8230" type="selectionEntry">
+    <entryLink id="28f9-1c1e-70b7-c180" name="Aventis Firestrike, Magister of Hammerhal" hidden="false" collective="false" import="true" targetId="c346-0cbf-16de-8230" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7573-e4b8-25f7-c8cf" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="f7c8-b7e1-a7b4-5092" name="Soulstrike Brotherhood" hidden="false" collective="false" targetId="472f-6bba-2cd2-b8e2" type="selectionEntry">
+    <entryLink id="f7c8-b7e1-a7b4-5092" name="Soulstrike Brotherhood" hidden="false" collective="false" import="true" targetId="472f-6bba-2cd2-b8e2" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="1755-cb16-ceee-2167" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="3dfe-c941-44d5-52d3" name="Grand Convocation" hidden="false" collective="false" targetId="75a8-2654-1bd3-8f34" type="selectionEntry">
+    <entryLink id="3dfe-c941-44d5-52d3" name="Grand Convocation" hidden="false" collective="false" import="true" targetId="75a8-2654-1bd3-8f34" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="61f6-214e-1881-4b22" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="1bfa-953c-b9e2-c093" name="Hailstorm Battery" hidden="false" collective="false" targetId="9c9a-f9e7-169b-db81" type="selectionEntry">
+    <entryLink id="1bfa-953c-b9e2-c093" name="Hailstorm Battery" hidden="false" collective="false" import="true" targetId="9c9a-f9e7-169b-db81" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="04c2-2adc-1b8f-ac6e" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="5c08-4d56-cc4f-f201" name="Cleansing Phalanx" hidden="false" collective="false" targetId="21f3-48f7-f857-926b" type="selectionEntry">
+    <entryLink id="5c08-4d56-cc4f-f201" name="Cleansing Phalanx" hidden="false" collective="false" import="true" targetId="21f3-48f7-f857-926b" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="4c01-4356-8e76-a686" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="c2dd-da0d-e78b-00f9" name="Sacrosanct Chamber" hidden="false" collective="false" targetId="48fb-f451-6bbc-e520" type="selectionEntry">
+    <entryLink id="c2dd-da0d-e78b-00f9" name="Sacrosanct Chamber" hidden="false" collective="false" import="true" targetId="48fb-f451-6bbc-e520" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b33b-1389-db3f-6325" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="0f9d-93e9-051e-c701" name="Lord-Arcanum on Tauralon" hidden="false" collective="false" targetId="6f87-6fec-658e-d582" type="selectionEntry">
+    <entryLink id="0f9d-93e9-051e-c701" name="Lord-Arcanum on Tauralon" hidden="false" collective="false" import="true" targetId="6f87-6fec-658e-d582" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="1d95-5099-0d9b-7e86" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="490f-a876-a870-8261" name="Lord-Arcanum on Celestial Dracoline" hidden="false" collective="false" targetId="8568-5b1b-179d-e1c5" type="selectionEntry">
+    <entryLink id="490f-a876-a870-8261" name="Lord-Arcanum on Celestial Dracoline" hidden="false" collective="false" import="true" targetId="8568-5b1b-179d-e1c5" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5877-e8fd-ba9b-1479" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="3bfb-34ae-c0c1-4dff" name="Lord-Arcanum" hidden="false" collective="false" targetId="f069-8a02-0d59-83be" type="selectionEntry">
+    <entryLink id="3bfb-34ae-c0c1-4dff" name="Lord-Arcanum" hidden="false" collective="false" import="true" targetId="f069-8a02-0d59-83be" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="6b43-39fd-d7dd-e91e" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="b844-d5ca-0586-7f67" name="Lord-Exorcist" hidden="false" collective="false" targetId="b92f-b04d-3339-5cd9" type="selectionEntry">
+    <entryLink id="b844-d5ca-0586-7f67" name="Lord-Exorcist" hidden="false" collective="false" import="true" targetId="b92f-b04d-3339-5cd9" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b311-6f68-f2cc-8286" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="9187-0e96-e44b-8120" name="Knight-Zephyros" hidden="false" collective="false" targetId="40dd-3878-4b37-f96e" type="selectionEntry">
+    <entryLink id="9187-0e96-e44b-8120" name="Knight-Zephyros" hidden="false" collective="false" import="true" targetId="40dd-3878-4b37-f96e" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="c33a-7160-1e21-d6b5" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="47f0-cb47-75b8-a274" name="Evocators on Celestial Dracolines" hidden="false" collective="false" targetId="8800-4822-2349-f731" type="selectionEntry">
+    <entryLink id="47f0-cb47-75b8-a274" name="Evocators on Celestial Dracolines" hidden="false" collective="false" import="true" targetId="8800-4822-2349-f731" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="04b9-6251-3372-712e" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="7c0d-67e0-e921-b5a2" name="Liberators" hidden="false" collective="false" targetId="5b8e-b5ee-8df3-9f2f" type="selectionEntry">
+    <entryLink id="7c0d-67e0-e921-b5a2" name="Liberators" hidden="false" collective="false" import="true" targetId="5b8e-b5ee-8df3-9f2f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
@@ -739,17 +739,17 @@
         <categoryLink id="edc3-8f86-cca0-4bd6" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="cfea-25a0-2fd1-2a9b" name="Averon Stormsire" hidden="false" collective="false" targetId="aff4-016f-04b6-cf66" type="selectionEntry">
+    <entryLink id="cfea-25a0-2fd1-2a9b" name="Averon Stormsire" hidden="false" collective="false" import="true" targetId="aff4-016f-04b6-cf66" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="d34c-8c42-41a0-8e5c" name="Leader" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="8bbe-faa3-9614-40fc" name="Stormsire&apos;s Cursebreakers" hidden="false" collective="false" targetId="d804-282f-96b2-4d98" type="selectionEntry">
+    <entryLink id="8bbe-faa3-9614-40fc" name="Stormsire&apos;s Cursebreakers" hidden="false" collective="false" import="true" targetId="d804-282f-96b2-4d98" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="45b6-6b81-032b-6784" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="082c-edfa-8f7c-1020" name="Battalion: Hammerhands Lords of the Storm (OPEN PLAY)" hidden="false" collective="false" targetId="c9c0-16a8-1728-708d" type="selectionEntry">
+    <entryLink id="082c-edfa-8f7c-1020" name="Battalion: Hammerhands Lords of the Storm (OPEN PLAY)" hidden="false" collective="false" import="true" targetId="c9c0-16a8-1728-708d" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -761,7 +761,7 @@
         <categoryLink id="f044-8052-7274-1210" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="0508-f4c6-ba90-94f2" name="Battalion: Hammerhands Thunderhead Brotherhood (OPEN PLAY)" hidden="false" collective="false" targetId="9481-65d8-8d78-39c3" type="selectionEntry">
+    <entryLink id="0508-f4c6-ba90-94f2" name="Battalion: Hammerhands Thunderhead Brotherhood (OPEN PLAY)" hidden="false" collective="false" import="true" targetId="9481-65d8-8d78-39c3" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -773,7 +773,7 @@
         <categoryLink id="3768-4e63-3cc1-fb3d" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="1cc8-5cf4-981a-399e" name="Battalion: Hammerhands Hammerstrike Force (OPEN PLAY)" hidden="false" collective="false" targetId="26f7-ec28-074c-c74c" type="selectionEntry">
+    <entryLink id="1cc8-5cf4-981a-399e" name="Battalion: Hammerhands Hammerstrike Force (OPEN PLAY)" hidden="false" collective="false" import="true" targetId="26f7-ec28-074c-c74c" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -785,7 +785,7 @@
         <categoryLink id="d278-45b1-bf0d-e013" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="4eab-1d36-f4d5-bd7a" name="Battalion: Hammerhands Warrior Chamber (OPEN PLAY)" hidden="false" collective="false" targetId="e483-ff09-abf5-0b89" type="selectionEntry">
+    <entryLink id="4eab-1d36-f4d5-bd7a" name="Battalion: Hammerhands Warrior Chamber (OPEN PLAY)" hidden="false" collective="false" import="true" targetId="e483-ff09-abf5-0b89" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -797,7 +797,7 @@
         <categoryLink id="353f-7339-c732-67c3" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="87f6-05e8-2a23-af87" name="Endless Spell: Celestian Vortex" hidden="false" collective="false" targetId="37f9-5999-6ae6-0ded" type="selectionEntry">
+    <entryLink id="87f6-05e8-2a23-af87" name="Endless Spell: Celestian Vortex" hidden="false" collective="false" import="true" targetId="37f9-5999-6ae6-0ded" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -809,7 +809,7 @@
         <categoryLink id="7dd0-d740-0ba6-e754" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="2f06-7d8d-af8e-eaa3" name="Endless Spell: Dais Arcanum" hidden="false" collective="false" targetId="39fa-f5f9-1707-1d8d" type="selectionEntry">
+    <entryLink id="2f06-7d8d-af8e-eaa3" name="Endless Spell: Dais Arcanum" hidden="false" collective="false" import="true" targetId="39fa-f5f9-1707-1d8d" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -821,7 +821,7 @@
         <categoryLink id="1272-bd66-1b67-ef4c" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="73fd-25a0-6d3d-35dc" name="Endless Spell: Everblaze Comet" hidden="false" collective="false" targetId="4f2e-b7f4-470b-4ef8" type="selectionEntry">
+    <entryLink id="73fd-25a0-6d3d-35dc" name="Endless Spell: Everblaze Comet" hidden="false" collective="false" import="true" targetId="4f2e-b7f4-470b-4ef8" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -833,8 +833,17 @@
         <categoryLink id="a123-2e46-ec91-cda1" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
       </categoryLinks>
     </entryLink>
+    <entryLink id="b12a-5582-ad4f-c46e" name="Battalion: Blessed Star Host (OPEN PLAY)" hidden="false" collective="false" import="true" targetId="8bab-4c0b-f465-3235" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ca54-0d07-72c2-d26f" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </entryLink>
   </entryLinks>
   <catalogueLinks>
-    <catalogueLink id="9f47-72b8-45c8-2825" name="Order - Stormcast Eternals - Data" targetId="82b4-f6e1-3e37-5ea1" type="catalogue"/>
+    <catalogueLink id="9f47-72b8-45c8-2825" name="Order - Stormcast Eternals - Data" targetId="82b4-f6e1-3e37-5ea1" type="catalogue" importRootEntries="true"/>
   </catalogueLinks>
 </catalogue>


### PR DESCRIPTION
SCE
- Added the "Blessed Host" battalion upon very entitled request. 

Orruk Warclans
- Many changes to how traits and artefacts were treated because most were validated incorrectly; Bonesplitterz always have access to their specific artefacts and command traits, even in Big Waaagh, same with Ironjawz. Several were also just not popping up at all.
"Hidden IF NOT INSTANCE OF [MEGABOSS] AND [IRONJAWZ]" meant that it was visible for all Ironjawz heroes, etc etc

- Many Drakkfoot traits/artefacts were instead listed as Icebone, vice versa, some stuff was randomly listed as Ironjaws instead of Bonesplitters, very odd mix

- Also, no validation at all on Ironjawz/Bonesplitterz armies outside of Battalions, with each being able to take the other. Seems bizarre, so that was fixed.

- Arcane Treasures & Warclan Extras, hold-overs from BtL; Bonesplitterz, were taken out, as they no longer exist in the Battletome