### PR TITLE
Issue Fixin' & Catalog Mixin'

### DIFF
--- a/Chaos - Legion of Azgorh.cat
+++ b/Chaos - Legion of Azgorh.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="8c11-75b5-5857-1b26" name="Chaos - Legion of Azgorh" revision="11" battleScribeVersion="2.02" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="24" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="8c11-75b5-5857-1b26" name="Chaos - Legion of Azgorh" revision="12" battleScribeVersion="2.03" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="24" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="8c11-75b5-pubN65537" name="The Legion of Azgorh Warscrolls Compendium"/>
     <publication id="8c11-75b5-pubN67268" name="Warscroll: Shar’tor the Executioner"/>
@@ -29,7 +29,7 @@
     <categoryEntry id="1f86-67ce-4ee9-a13a" name="MAGMA CANNON" hidden="false"/>
     <categoryEntry id="e24d-ff4c-5eca-fbbd" name="DREADQUAKE MORTAR" hidden="false"/>
     <categoryEntry id="c69f-0887-81d5-f65f" name="SIEGE GARGANT" hidden="false"/>
-    <categoryEntry id="ac6e-c8dc-e517-c58a" name="ZHARR GOROTH" hidden="false"/>
+    <categoryEntry id="ac6e-c8dc-e517-c58a" name="DAWI ZHARR" hidden="false"/>
     <categoryEntry id="3fbf-052e-2c47-86d7" name="K&apos;DAAI" hidden="false"/>
     <categoryEntry id="bc87-8623-2da4-3e93" name="BA&apos;HAL" hidden="false"/>
     <categoryEntry id="bd49-ce5a-1c30-9366" name="SHAR’TOR THE EXECUTIONER" hidden="false"/>
@@ -37,7 +37,7 @@
     <categoryEntry id="8c5d-3e9c-82b0-8142" name="GARGANT" hidden="false"/>
   </categoryEntries>
   <entryLinks>
-    <entryLink id="b5fb-19d4-5cc6-1b16" name="Battalion: Blackshard Warhost" hidden="false" collective="false" targetId="cf30-69b6-b5bd-4cb1" type="selectionEntry">
+    <entryLink id="b5fb-19d4-5cc6-1b16" name="Battalion: Blackshard Warhost" hidden="false" collective="false" import="true" targetId="cf30-69b6-b5bd-4cb1" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
@@ -55,7 +55,7 @@
         <categoryLink id="eb26-3745-71a1-757a" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="827e-8837-934a-96e4" name="Battalion: Hashut&apos;s Wrath Artillery Train" hidden="false" collective="false" targetId="6638-1032-9e14-e0e8" type="selectionEntry">
+    <entryLink id="827e-8837-934a-96e4" name="Battalion: Hashut&apos;s Wrath Artillery Train" hidden="false" collective="false" import="true" targetId="6638-1032-9e14-e0e8" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
@@ -73,7 +73,7 @@
         <categoryLink id="1dfd-9509-122d-6358" name="New CategoryLink" hidden="false" targetId="be17-6bbd-b857-3f43" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="d38e-a2f7-93b9-b861" name="*Bull Centaur Renders" hidden="false" collective="false" targetId="5c3d-5a69-c9f0-f6b4" type="selectionEntry">
+    <entryLink id="d38e-a2f7-93b9-b861" name="*Bull Centaur Renders" hidden="false" collective="false" import="true" targetId="5c3d-5a69-c9f0-f6b4" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
@@ -90,92 +90,73 @@
         <categoryLink id="127f-d0d2-76c5-e2b3" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="9a27-8354-06e2-843b" name="*Bull Centaur Taur&apos;ruk" hidden="false" collective="false" targetId="c44c-2b12-5f83-8be9" type="selectionEntry">
+    <entryLink id="9a27-8354-06e2-843b" name="*Bull Centaur Taur&apos;ruk" hidden="false" collective="false" import="true" targetId="c44c-2b12-5f83-8be9" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b1c9-480a-e520-198d" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="f64e-fc1f-f5b9-ac31" name="Daemonsmith" hidden="false" collective="false" targetId="16e0-5e2f-bbed-429b" type="selectionEntry">
+    <entryLink id="f64e-fc1f-f5b9-ac31" name="Daemonsmith" hidden="false" collective="false" import="true" targetId="16e0-5e2f-bbed-429b" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8360-13e7-0695-b09c" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="b0fb-7500-514f-6872" name="Deathshrieker Rocket Launcher" hidden="false" collective="false" targetId="e639-c727-48a8-7070" type="selectionEntry">
+    <entryLink id="b0fb-7500-514f-6872" name="Deathshrieker Rocket Launcher" hidden="false" collective="false" import="true" targetId="e639-c727-48a8-7070" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="860d-8b07-f89a-72a3" name="New CategoryLink" hidden="false" targetId="1d26-07fc-6a66-d73e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="ed09-ae6c-14ef-52bf" name="Drazhoath the Ashen" hidden="false" collective="false" targetId="5b09-6a5b-f328-5b76" type="selectionEntry">
+    <entryLink id="ed09-ae6c-14ef-52bf" name="Drazhoath the Ashen" hidden="false" collective="false" import="true" targetId="5b09-6a5b-f328-5b76" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="fcf4-8f1a-6520-e52d" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false"/>
         <categoryLink id="c43d-7c38-bd73-46bb" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="2a89-93c8-0df5-67c5" name="Dreadquake Mortar" hidden="false" collective="false" targetId="8260-d945-aa2f-4b19" type="selectionEntry">
+    <entryLink id="2a89-93c8-0df5-67c5" name="Dreadquake Mortar" hidden="false" collective="false" import="true" targetId="8260-d945-aa2f-4b19" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="c63a-17fa-d753-7e7c" name="New CategoryLink" hidden="false" targetId="1d26-07fc-6a66-d73e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="5e23-b57c-3ab8-8585" name="Infernal Guard Battle Standard Bearer" hidden="false" collective="false" targetId="9e19-65b2-2ada-6966" type="selectionEntry">
+    <entryLink id="5e23-b57c-3ab8-8585" name="Infernal Guard Battle Standard Bearer" hidden="false" collective="false" import="true" targetId="9e19-65b2-2ada-6966" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="9889-03e8-cf4f-5a51" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="2774-afb6-99b6-fa0f" name="Infernal Guard Castellan" hidden="false" collective="false" targetId="0a2d-7e3a-3be2-00bc" type="selectionEntry">
+    <entryLink id="2774-afb6-99b6-fa0f" name="Infernal Guard Castellan" hidden="false" collective="false" import="true" targetId="0a2d-7e3a-3be2-00bc" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="485f-e3b9-aeb7-8687" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="9a85-b557-0b72-663c" name="Infernal Guard Fireglaives" hidden="false" collective="false" targetId="e4a6-dabb-cad7-b02d" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="instanceOf"/>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="instanceOf"/>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed37-3e74-a225-25ce" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
+    <entryLink id="9a85-b557-0b72-663c" name="Infernal Guard Fireglaives" hidden="false" collective="false" import="true" targetId="e4a6-dabb-cad7-b02d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ef68-8cb1-5e92-5a40" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true"/>
+        <categoryLink id="ef68-8cb1-5e92-5a40" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="fc9f-1446-b1d1-05ae" name="Infernal Guard Ironsworn" hidden="false" collective="false" targetId="2f68-7c57-f3c6-70a8" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="cc81-5f84-a3ad-aec8" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true"/>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="bba1-e911-d5dc-edb8" name="Iron Daemon War Engine" hidden="false" collective="false" targetId="c630-ea56-761c-4c04" type="selectionEntry">
+    <entryLink id="bba1-e911-d5dc-edb8" name="Iron Daemon War Engine" hidden="false" collective="false" import="true" targetId="c630-ea56-761c-4c04" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="bc21-c834-e096-4405" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="efd8-ac15-16a0-720b" name="K&apos;daai Fireborn" hidden="false" collective="false" targetId="26b1-dafe-11b2-5cc0" type="selectionEntry">
+    <entryLink id="efd8-ac15-16a0-720b" name="K&apos;daai Fireborn" hidden="false" collective="false" import="true" targetId="26b1-dafe-11b2-5cc0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="87f1-6a3b-18d4-4f97" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="7f9d-d1df-0f66-1147" name="Magma Cannon" hidden="false" collective="false" targetId="f715-f879-b9b4-b0fb" type="selectionEntry">
+    <entryLink id="7f9d-d1df-0f66-1147" name="Magma Cannon" hidden="false" collective="false" import="true" targetId="f715-f879-b9b4-b0fb" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ed39-fb52-8583-e0aa" name="New CategoryLink" hidden="false" targetId="1d26-07fc-6a66-d73e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="a19d-9de9-7b83-e234" name="Shar’tor the Executioner" hidden="false" collective="false" targetId="a6f6-09b4-da9c-a082" type="selectionEntry">
+    <entryLink id="a19d-9de9-7b83-e234" name="Shar’tor the Executioner" hidden="false" collective="false" import="true" targetId="a6f6-09b4-da9c-a082" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="80e3-44bf-bb82-d336" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="e31f-31df-3fe6-d593" name="Skullcracker War Engine" hidden="false" collective="false" targetId="12dc-3982-1d36-ddb7" type="selectionEntry">
+    <entryLink id="e31f-31df-3fe6-d593" name="Skullcracker War Engine" hidden="false" collective="false" import="true" targetId="12dc-3982-1d36-ddb7" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b0af-d877-c451-6dca" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="b6f4-0163-9921-4e09" name="*Bull Centaur Renders" hidden="false" collective="false" targetId="5c3d-5a69-c9f0-f6b4" type="selectionEntry">
+    <entryLink id="b6f4-0163-9921-4e09" name="*Bull Centaur Renders" hidden="false" collective="false" import="true" targetId="5c3d-5a69-c9f0-f6b4" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
@@ -192,19 +173,7 @@
         <categoryLink id="5c36-e9a9-ad43-a38e" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="69fb-1517-118f-b85b" name="Infernal Guard Fireglaives" hidden="false" collective="false" targetId="e4a6-dabb-cad7-b02d" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ce74-fe99-620c-0868" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="2b76-8135-5b74-1166" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="cabc-7926-10ad-fc7c" name="Allegiance" hidden="false" collective="false" targetId="904c-53b5-501f-08e0" type="selectionEntry">
+    <entryLink id="cabc-7926-10ad-fc7c" name="Allegiance" hidden="false" collective="false" import="true" targetId="904c-53b5-501f-08e0" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
@@ -222,25 +191,12 @@
         <categoryLink id="c33a-ba4f-6154-8280" name="New CategoryLink" hidden="false" targetId="87e8-c095-f059-5f7b" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="982d-a93f-ca62-31d4" name="Infernal Guard Ironsworn" hidden="false" collective="false" targetId="2f68-7c57-f3c6-70a8" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62e4-370f-3318-cdbd" type="notInstanceOf"/>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b78c-c342-c8aa-aa45" type="notInstanceOf"/>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="notInstanceOf"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
+    <entryLink id="982d-a93f-ca62-31d4" name="Infernal Guard Ironsworn" hidden="false" collective="false" import="true" targetId="2f68-7c57-f3c6-70a8" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="f36a-fba1-27f0-5834" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
+        <categoryLink id="f36a-fba1-27f0-5834" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="21d6-b9e8-fc60-a1e2" name="*Battalion: Execution Herd" hidden="false" collective="false" targetId="0201-bd62-966c-1cc6" type="selectionEntry">
+    <entryLink id="21d6-b9e8-fc60-a1e2" name="*Battalion: Execution Herd" hidden="false" collective="false" import="true" targetId="0201-bd62-966c-1cc6" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
@@ -260,7 +216,7 @@
     </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
-    <selectionEntry id="a6f6-09b4-da9c-a082" name="Shar’tor the Executioner" publicationId="8c11-75b5-pubN67268" hidden="false" collective="false" type="unit">
+    <selectionEntry id="a6f6-09b4-da9c-a082" name="Shar’tor the Executioner" publicationId="8c11-75b5-pubN67268" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="5b65-0b75-1202-2dd5" type="max"/>
       </constraints>
@@ -293,7 +249,7 @@
         <categoryLink id="75c8-cee1-171e-875c" name="New CategoryLink" hidden="false" targetId="bd49-ce5a-1c30-9366" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="c568-e91c-8bf4-e1d5" name="Darktide Axe" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="c568-e91c-8bf4-e1d5" name="Darktide Axe" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2482-9db9-9515-8173" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f892-49e0-16e4-f0fc" type="min"/>
@@ -320,7 +276,7 @@
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="5128-5770-f477-bfd3" name="Crushing Hooves" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="5128-5770-f477-bfd3" name="Crushing Hooves" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bfd0-83c5-c688-fa6a" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01b0-2f35-335a-0eb3" type="min"/>
@@ -347,7 +303,7 @@
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="884c-900f-2a17-e0fd" name="General" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="884c-900f-2a17-e0fd" name="General" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditionGroups>
@@ -376,7 +332,7 @@
         <cost name="pts" typeId="points" value="220.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5b09-6a5b-f328-5b76" name="Drazhoath the Ashen" publicationId="8c11-75b5-pubN65537" hidden="false" collective="false" type="unit">
+    <selectionEntry id="5b09-6a5b-f328-5b76" name="Drazhoath the Ashen" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="b22a-9248-4227-eb4f" type="max"/>
       </constraints>
@@ -483,7 +439,7 @@
         <categoryLink id="5471-9dc4-0c68-bbc5" name="New CategoryLink" hidden="false" targetId="4f53-8230-2f02-9639" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="6e1e-1d25-d1e6-8d15" name="The Graven Brazier" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="6e1e-1d25-d1e6-8d15" name="The Graven Brazier" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30b9-ea64-cbac-dced" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1972-0a4c-34d2-5256" type="min"/>
@@ -505,7 +461,7 @@
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="7673-3458-b0a2-19bc" name="Flames of Azgorh" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="7673-3458-b0a2-19bc" name="Flames of Azgorh" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3fd0-b8ba-f69c-9e6a" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5956-5df8-dcca-2d66" type="min"/>
@@ -522,13 +478,13 @@
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="fd06-bc09-19e3-bb83" name="MOUNT: Cinderbreath" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="fd06-bc09-19e3-bb83" name="MOUNT: Cinderbreath" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7330-7952-2708-73d1" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82c1-dbbc-c2fa-2d61" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="2eeb-c331-fe11-7d9c" name="Cinderbreath&apos;s Brazen Horns and Teeth" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="2eeb-c331-fe11-7d9c" name="Cinderbreath&apos;s Brazen Horns and Teeth" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="34b8-68da-c56d-2675" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65a8-693e-57a8-ac0a" type="min"/>
@@ -550,7 +506,7 @@
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="9b17-bc0c-2796-afc4" name="Cinderbreath&apos;s Burning Hooves" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="9b17-bc0c-2796-afc4" name="Cinderbreath&apos;s Burning Hooves" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9fd8-84ea-0bfc-8b0d" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c1c-a919-93f6-6f6a" type="min"/>
@@ -572,7 +528,7 @@
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="e5e9-08b4-2e79-2da7" name="Cinderbreath&apos;s Gouts of Flame" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="e5e9-08b4-2e79-2da7" name="Cinderbreath&apos;s Gouts of Flame" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6440-941a-151f-3b2d" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd95-fdd3-adc6-08f7" type="min"/>
@@ -601,15 +557,15 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="4157-350c-facb-ab8f" name="General" hidden="false" collective="false" targetId="88ed-914f-7045-41db" type="selectionEntry"/>
-        <entryLink id="72aa-c4e1-83b9-6ac5" name="Mystic Shield" hidden="false" collective="false" targetId="5fdd-6634-f9f8-068a" type="selectionEntry"/>
-        <entryLink id="8ce1-9812-2319-2441" name="Arcane Bolt" hidden="false" collective="false" targetId="869c-168d-eba5-eacf" type="selectionEntry"/>
+        <entryLink id="4157-350c-facb-ab8f" name="General" hidden="false" collective="false" import="true" targetId="88ed-914f-7045-41db" type="selectionEntry"/>
+        <entryLink id="72aa-c4e1-83b9-6ac5" name="Mystic Shield" hidden="false" collective="false" import="true" targetId="5fdd-6634-f9f8-068a" type="selectionEntry"/>
+        <entryLink id="8ce1-9812-2319-2441" name="Arcane Bolt" hidden="false" collective="false" import="true" targetId="869c-168d-eba5-eacf" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="320.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0a2d-7e3a-3be2-00bc" name="Infernal Guard Castellan" publicationId="8c11-75b5-pubN65537" hidden="false" collective="false" type="unit">
+    <selectionEntry id="0a2d-7e3a-3be2-00bc" name="Infernal Guard Castellan" publicationId="8c11-75b5-pubN65537" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="6ff2-b8af-59ef-74d0" name="Infernal Guard Castellan" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
@@ -633,7 +589,7 @@
         <categoryLink id="b8bc-ad10-7dff-6c96" name="New CategoryLink" hidden="false" targetId="d1c3-a6db-df1d-9d9c" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="1ab2-5d3e-1777-fde6" name="Darkforged Weapon &amp; Pyrelock Pistol" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="1ab2-5d3e-1777-fde6" name="Darkforged Weapon &amp; Pyrelock Pistol" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4f42-bff6-2181-049a" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ee5-ffbe-6d2a-6b93" type="min"/>
@@ -652,7 +608,7 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="86a2-86a2-9772-6cca" name="Pyrelock Pistol" hidden="false" targetId="9e82-7753-6293-a60e" type="profile"/>
+            <infoLink id="86a2-86a2-9772-6cca" name="Pyrelock Pistol" hidden="false" targetId="3333-01d6-ab45-2ea8" type="profile"/>
             <infoLink id="8e01-c75d-2479-2815" name="Pyrelock Pistol" hidden="false" targetId="ba39-c89e-6c7d-0575" type="profile"/>
           </infoLinks>
           <costs>
@@ -661,15 +617,15 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="e18f-7a3f-26a1-dc50" name="General" hidden="false" collective="false" targetId="88ed-914f-7045-41db" type="selectionEntry"/>
-        <entryLink id="3445-2621-0981-7159" name="Artefacts of Power" hidden="false" collective="false" targetId="475c-1632-c526-a073" type="selectionEntryGroup"/>
-        <entryLink id="f694-b698-ed34-89b1" name="Command Traits" hidden="false" collective="false" targetId="c403-6e43-5398-19ac" type="selectionEntryGroup"/>
+        <entryLink id="e18f-7a3f-26a1-dc50" name="General" hidden="false" collective="false" import="true" targetId="88ed-914f-7045-41db" type="selectionEntry"/>
+        <entryLink id="3445-2621-0981-7159" name="Artefacts of Power" hidden="false" collective="false" import="true" targetId="475c-1632-c526-a073" type="selectionEntryGroup"/>
+        <entryLink id="f694-b698-ed34-89b1" name="Command Traits" hidden="false" collective="false" import="true" targetId="c403-6e43-5398-19ac" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="120.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9e19-65b2-2ada-6966" name="Infernal Guard Battle Standard Bearer" publicationId="8c11-75b5-pubN65537" hidden="false" collective="false" type="unit">
+    <selectionEntry id="9e19-65b2-2ada-6966" name="Infernal Guard Battle Standard Bearer" publicationId="8c11-75b5-pubN65537" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="0107-1b08-90ae-edee" name="Infernal Guard Battle Standard Bearer" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
@@ -694,7 +650,7 @@
         <categoryLink id="b374-d582-cb24-b09d" name="New CategoryLink" hidden="false" targetId="bf81-a10b-77a0-f509" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="1151-6dd7-d3ce-d29d" name="Darkforged Weapon" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="1151-6dd7-d3ce-d29d" name="Darkforged Weapon" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1994-0086-621f-3f37" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d588-83ab-79a6-844c" type="min"/>
@@ -708,15 +664,15 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="885d-404f-3560-8be9" name="General" hidden="false" collective="false" targetId="88ed-914f-7045-41db" type="selectionEntry"/>
-        <entryLink id="cb4f-41f8-9a55-0347" name="Artefacts of Power" hidden="false" collective="false" targetId="475c-1632-c526-a073" type="selectionEntryGroup"/>
-        <entryLink id="6d14-7022-fec4-0e87" name="Command Traits" hidden="false" collective="false" targetId="c403-6e43-5398-19ac" type="selectionEntryGroup"/>
+        <entryLink id="885d-404f-3560-8be9" name="General" hidden="false" collective="false" import="true" targetId="88ed-914f-7045-41db" type="selectionEntry"/>
+        <entryLink id="cb4f-41f8-9a55-0347" name="Artefacts of Power" hidden="false" collective="false" import="true" targetId="475c-1632-c526-a073" type="selectionEntryGroup"/>
+        <entryLink id="6d14-7022-fec4-0e87" name="Command Traits" hidden="false" collective="false" import="true" targetId="c403-6e43-5398-19ac" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="100.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="16e0-5e2f-bbed-429b" name="Daemonsmith" publicationId="8c11-75b5-pubN65537" hidden="false" collective="false" type="unit">
+    <selectionEntry id="16e0-5e2f-bbed-429b" name="Daemonsmith" publicationId="8c11-75b5-pubN65537" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="f8b9-1087-b586-a92d" name="Daemonsmith" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
@@ -726,7 +682,7 @@
             <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">4+</characteristic>
           </characteristics>
         </profile>
-        <profile id="a8ad-eb28-942c-22bc" name="Encorcelled Armour" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+        <profile id="a8ad-eb28-942c-22bc" name="Ensorcelled Armour" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Add 1 to unbinding rolls for this model if 1 or more wounds have been allocated to this model.</characteristic>
           </characteristics>
@@ -755,7 +711,7 @@
         <categoryLink id="bd26-efa5-be1c-e8fe" name="New CategoryLink" hidden="false" targetId="d65d-7735-aafd-2303" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="57ca-2536-9451-5df4" name="Ash Storm" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="57ca-2536-9451-5df4" name="Ash Storm" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1185-c078-4e3b-dc62" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9cd-fd3c-28d3-3597" type="min"/>
@@ -772,7 +728,7 @@
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="0035-e2e2-162d-029e" name="Blood of Hashut" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="0035-e2e2-162d-029e" name="Blood of Hashut" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2dc8-0e02-46d3-9e2c" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4cbc-bd3e-3d06-bba2" type="max"/>
@@ -796,12 +752,13 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="2587-75d5-4837-2302" name="Weapon Options" hidden="false" collective="false">
+        <selectionEntryGroup id="2587-75d5-4837-2302" name="Weapon Options" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0339-3e6a-8851-6441" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c0d4-c630-6173-1ce2" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="bd3f-bed7-419d-a584" name="Pyre Rune Staff" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="bd3f-bed7-419d-a584" name="Pyre Rune Staff" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="e8dc-7375-4210-78c0" name="Pyre Rune Staff" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
                   <characteristics>
@@ -819,7 +776,7 @@
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="cff6-dea4-f8eb-3712" name="Darkforged Weapon" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="cff6-dea4-f8eb-3712" name="Darkforged Weapon" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
                 <infoLink id="19f9-964d-7169-0f8d" name="Darkforged Weapon" hidden="false" targetId="ab73-0d85-a8d8-c815" type="profile"/>
               </infoLinks>
@@ -831,17 +788,17 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="ed29-56c1-2004-eb2a" name="General" hidden="false" collective="false" targetId="88ed-914f-7045-41db" type="selectionEntry"/>
-        <entryLink id="ebf0-a6c0-088f-eaf0" name="Artefacts of Power" hidden="false" collective="false" targetId="475c-1632-c526-a073" type="selectionEntryGroup"/>
-        <entryLink id="d457-133f-cd79-d667" name="Command Traits" hidden="false" collective="false" targetId="c403-6e43-5398-19ac" type="selectionEntryGroup"/>
-        <entryLink id="6d11-9ee5-cc5f-96b8" name="Mystic Shield" hidden="false" collective="false" targetId="5fdd-6634-f9f8-068a" type="selectionEntry"/>
-        <entryLink id="1159-64f1-ee5c-0297" name="Arcane Bolt" hidden="false" collective="false" targetId="869c-168d-eba5-eacf" type="selectionEntry"/>
+        <entryLink id="ed29-56c1-2004-eb2a" name="General" hidden="false" collective="false" import="true" targetId="88ed-914f-7045-41db" type="selectionEntry"/>
+        <entryLink id="ebf0-a6c0-088f-eaf0" name="Artefacts of Power" hidden="false" collective="false" import="true" targetId="475c-1632-c526-a073" type="selectionEntryGroup"/>
+        <entryLink id="d457-133f-cd79-d667" name="Command Traits" hidden="false" collective="false" import="true" targetId="c403-6e43-5398-19ac" type="selectionEntryGroup"/>
+        <entryLink id="6d11-9ee5-cc5f-96b8" name="Mystic Shield" hidden="false" collective="false" import="true" targetId="5fdd-6634-f9f8-068a" type="selectionEntry"/>
+        <entryLink id="1159-64f1-ee5c-0297" name="Arcane Bolt" hidden="false" collective="false" import="true" targetId="869c-168d-eba5-eacf" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="100.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2f68-7c57-f3c6-70a8" name="Infernal Guard Ironsworn" publicationId="8c11-75b5-pubN65537" hidden="false" collective="false" type="unit">
+    <selectionEntry id="2f68-7c57-f3c6-70a8" name="Infernal Guard Ironsworn" publicationId="8c11-75b5-pubN65537" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="aa0b-71c4-5664-189e" name="Infernal Guard Ironsworn" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
@@ -851,15 +808,25 @@
             <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">4+</characteristic>
           </characteristics>
         </profile>
+        <profile id="7a2c-6771-ee2c-d9d5" name="Ironsworn Deathmask" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">The leader of this unit is an Ironsworn Deathmask. An Ironsworn Deathmask is armed an Ashsteel Hand Weapon and Pyrelock Pistol instead of being armed with a Ashsteel Hand Weapon and carrying a Spiteshield.</characteristic>
+          </characteristics>
+        </profile>
       </profiles>
+      <infoLinks>
+        <infoLink id="f377-c5ef-8ed7-c7a6" name="Drummer" hidden="false" targetId="7a48-3797-75a9-5214" type="profile"/>
+        <infoLink id="3280-1e23-3303-c421" name="Icon of Dominion Bearer" hidden="false" targetId="ef78-7b59-29a0-3c32" type="profile"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="c5c1-19a8-4dad-a44c" name="New CategoryLink" hidden="false" targetId="7cdd-80ea-cbeb-8e16" primary="false"/>
         <categoryLink id="d075-6bd1-f200-51e7" name="New CategoryLink" hidden="false" targetId="ac6e-c8dc-e517-c58a" primary="false"/>
         <categoryLink id="7c54-a1c2-c0cf-8dbd" name="New CategoryLink" hidden="false" targetId="3e20-3d2c-7218-4498" primary="false"/>
         <categoryLink id="36b5-899c-2cf8-1e06" name="New CategoryLink" hidden="false" targetId="4c95-71f1-1d6a-eea4" primary="false"/>
+        <categoryLink id="a121-84f0-0dbc-74f7" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="5b76-4b94-9779-b649" name="10 Infernal Guard Ironsworn" hidden="false" collective="false" type="model">
+        <selectionEntry id="5b76-4b94-9779-b649" name="10 Infernal Guard Ironsworn" hidden="false" collective="false" import="true" type="model">
           <modifiers>
             <modifier type="decrement" field="points" value="10">
               <conditions>
@@ -875,75 +842,51 @@
             <cost name="pts" typeId="points" value="90.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="1565-67ca-85a4-384a" name="Deathmask" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="d042-1982-dfbd-71ea" name="Ashsteel Hand Weapon &amp; Spiteshield" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d137-d795-e23b-44b5" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f145-64e0-2dc6-4830" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a19f-9001-581d-a015" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5e1-b844-bf2c-3916" type="min"/>
           </constraints>
-          <profiles>
-            <profile id="59fa-c063-3d89-ace3" name="Deathmask" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">The leader of this unit is a Deathmask. Some Deathmasks wield an Ashsteel Hand Weapon and Spiteshield, while others choose to carry a Pyrelock Pistol instead of their Spiteshield. A Deathmask makes 2 attacks with his Ashsteel Hand Weapon.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <entryLinks>
-            <entryLink id="bfae-a7d9-f814-da18" name="Ashsteel Hand Weapon &amp; Pyrelock Pistol" hidden="false" collective="false" targetId="89c8-4d82-4d7b-7350" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c756-dec4-c573-20eb" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a516-ee9e-3970-b728" type="min"/>
-              </constraints>
-            </entryLink>
-          </entryLinks>
+          <infoLinks>
+            <infoLink id="2895-297d-44ec-b490" name="Spiteshield" hidden="false" targetId="41fb-ae7b-7cc8-a676" type="profile"/>
+            <infoLink id="b002-6266-4da6-48a5" name="Ashteel Hand Weapon" hidden="false" targetId="ba19-13eb-90b8-823e" type="profile"/>
+          </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="4490-7c4a-6204-051c" name="Drummer" hidden="false" collective="false" targetId="2512-a09a-21c2-a529" type="selectionEntry"/>
-        <entryLink id="bd3d-cd38-08d6-a056" name="Icon Bearer" hidden="false" collective="false" targetId="aa76-74bb-42ca-00b8" type="selectionEntry"/>
-        <entryLink id="fe72-013f-d798-78e4" name="Ashsteel Hand Weapon &amp; Spiteshield" hidden="false" collective="false" targetId="8a35-f019-2f05-ee87" type="selectionEntry">
+        <entryLink id="fa44-4a26-3cf1-1306" name="Ashsteel Hand Weapon &amp; Pyrelock Pistol" hidden="false" collective="false" import="true" targetId="9d62-a98b-38b1-39c4" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb70-e6df-dcef-9338" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="aadf-bd30-0176-20b3" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8e1d-2ea1-5a25-1a77" type="min"/>
           </constraints>
+          <infoLinks>
+            <infoLink id="2224-0d7b-6439-bf81" name="Pyrelock Pistol" hidden="false" targetId="3333-01d6-ab45-2ea8" type="profile"/>
+          </infoLinks>
         </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2512-a09a-21c2-a529" name="Drummer" hidden="false" collective="false" type="upgrade">
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2362-49ce-2f64-c4a2" type="max"/>
-      </constraints>
-      <profiles>
-        <profile id="ddfa-0948-d02c-e768" name="Drummer" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-          <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">1 model in this unit can be a Drummer. Add 1 to run rolls for a unit that includes a Drummer</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="aa76-74bb-42ca-00b8" name="Icon of Dominion Bearer" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="aa76-74bb-42ca-00b8" name="Icon of Dominion Bearer" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e93e-968f-6c8d-8ed9" type="max"/>
       </constraints>
-      <profiles>
-        <profile id="a2bc-32a5-5988-b493" name="Icon of Dominion Bearer" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-          <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">1 model in this unit can be Icon of Dominion Bearer. Add 1 to the Bravery characteristic of a unit that includes an Icon of Dominion Bearer.</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e4a6-dabb-cad7-b02d" name="Infernal Guard Fireglaives" publicationId="8c11-75b5-pubN65537" hidden="false" collective="false" type="unit">
+    <selectionEntry id="e4a6-dabb-cad7-b02d" name="Infernal Guard Fireglaives" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set-primary" field="category" value="e9f2-765a-b7b8-ce8e">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed37-3e74-a225-25ce" type="greaterThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile id="86d8-1693-9432-db25" name="Infernal Guard Fireglaive" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
@@ -953,12 +896,16 @@
             <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">4+</characteristic>
           </characteristics>
         </profile>
-        <profile id="f930-1c87-d22f-4522" name="Pyrelock Weapons" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+        <profile id="96cf-8b10-5ee6-e78b" name="Fireglaive Deathmask" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If the unmodified hit roll for an attack made with a Pyrelock Pistol or Pyrelock Fireglaive is 6, that attack inflicts 1 mortal wound on the target in addition to any normal damage. In addition, you can re-roll hit rolls of 1 for attacks made with this unit’s Pyrelock Fireglaives if this unit has not made a move in the same turn.</characteristic>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">The leader of this unit is a Fireglaive Deathmask. A Fireglaive Deathmask is armed with an Ashsteel Hand Weapon and Pyrelock Pistol instead of a Pyrelock Fireglaive and a Pyrelock Fireglaive’s Bayonet-cleaver.</characteristic>
           </characteristics>
         </profile>
       </profiles>
+      <infoLinks>
+        <infoLink id="6c1f-df97-aee9-b1fc" name="Drummer" hidden="false" targetId="7a48-3797-75a9-5214" type="profile"/>
+        <infoLink id="ca49-4af3-366d-926f" name="Icon of Dominion Bearer" hidden="false" targetId="ef78-7b59-29a0-3c32" type="profile"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="a6cb-18bf-520e-98b7" name="New CategoryLink" hidden="false" targetId="7cdd-80ea-cbeb-8e16" primary="false"/>
         <categoryLink id="70f8-75ce-50ce-66fe" name="New CategoryLink" hidden="false" targetId="ac6e-c8dc-e517-c58a" primary="false"/>
@@ -966,7 +913,7 @@
         <categoryLink id="6107-9799-bde4-f630" name="New CategoryLink" hidden="false" targetId="ba8c-71b6-31a0-dd59" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="2ab8-73bd-a6a4-ff53" name="10 Infernal Guard Fireglaives" hidden="false" collective="false" type="model">
+        <selectionEntry id="2ab8-73bd-a6a4-ff53" name="10 Infernal Guard Fireglaives" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="db9a-0fa7-c09e-2e3c" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7ff5-1f51-f72b-91b2" type="max"/>
@@ -975,40 +922,32 @@
             <cost name="pts" typeId="points" value="100.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="5618-cf59-c666-25c9" name="Deathmask" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="2515-7fa0-a54b-ea46" name="Pyrelock Fireglaive" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8cdd-6881-f7a9-1078" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="acb7-6350-39c3-de3a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1edd-2f18-793c-3892" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d4ee-3027-dcfd-a801" type="min"/>
           </constraints>
           <profiles>
-            <profile id="ef4c-5eee-4c40-d581" name="Fireglaive Deathmask" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+            <profile id="753f-8395-74ad-1229" name="Pyrelock Weapons" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
               <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">The leader of this unit is a Fireglaive Deathmask. A Fireglaive Deathmask is armed with an Ashsteel Hand Weapon and Pyrelock Pistol instead of a Pyrelock Fireglaive and a Pyrelock Fireglaive’s Bayonet-cleaver.</characteristic>
+                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If the unmodified hit roll for an attack made with a Pyrelock Pistol or Pyrelock Fireglaive is 6, that attack inflicts 1 mortal wound on the target in addition to any normal damage. In addition, you can re-roll hit rolls of 1 for attacks made with this unit’s Pyrelock Fireglaives if this unit has not made a move in the same turn.</characteristic>
               </characteristics>
             </profile>
           </profiles>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="58ff-c9d4-e352-9f39" name="Weapon Options" hidden="false" collective="false"/>
-          </selectionEntryGroups>
-          <entryLinks>
-            <entryLink id="8bc0-594e-5aea-d52a" name="Ashsteel Hand Weapon &amp; Pyrelock Pistol" hidden="false" collective="false" targetId="89c8-4d82-4d7b-7350" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e9c6-f90c-dde1-a775" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="de2b-41dd-80b9-2de7" type="max"/>
-              </constraints>
-            </entryLink>
-          </entryLinks>
+          <infoLinks>
+            <infoLink id="bbcb-865f-1b2e-3e32" name="Pyrelock Fireglaive" hidden="false" targetId="7313-b871-0343-351b" type="profile"/>
+            <infoLink id="d566-5cf9-7ea9-56ee" name="Pyrelock Fireglaive’s Bayonet-cleaver" hidden="false" targetId="96b4-8194-7a57-b5b1" type="profile"/>
+          </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="9319-afcb-3bee-d2c1" name="Drummer" hidden="false" collective="false" targetId="2512-a09a-21c2-a529" type="selectionEntry"/>
-        <entryLink id="5752-4cae-a2c8-15d0" name="Icon of Dominion Bearer" hidden="false" collective="false" targetId="aa76-74bb-42ca-00b8" type="selectionEntry"/>
-        <entryLink id="05c0-1a0c-c058-f502" name="Pyrelock Fireglaive" hidden="false" collective="false" targetId="aaea-24d8-2fc6-b484" type="selectionEntry">
+        <entryLink id="511c-aa8e-9fc8-f3aa" name="Ashsteel Hand Weapon &amp; Pyrelock Pistol" hidden="false" collective="false" import="true" targetId="9d62-a98b-38b1-39c4" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="244a-2144-8460-6b21" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d4e4-ef8e-0f3e-6c6d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7213-db1f-82db-8df1" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
@@ -1016,7 +955,7 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="26b1-dafe-11b2-5cc0" name="K&apos;daai Fireborn" publicationId="8c11-75b5-pubN65537" hidden="false" collective="false" type="unit">
+    <selectionEntry id="26b1-dafe-11b2-5cc0" name="K&apos;daai Fireborn" publicationId="8c11-75b5-pubN65537" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="d60d-b36b-1526-8da1" name="K&apos;daai Fireborn" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
@@ -1048,7 +987,7 @@
         <categoryLink id="13ef-254a-9607-2f26" name="New CategoryLink" hidden="false" targetId="3e20-3d2c-7218-4498" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="ca13-e1aa-1378-0051" name="3 K&apos;daai Fireborn" hidden="false" collective="false" type="model">
+        <selectionEntry id="ca13-e1aa-1378-0051" name="3 K&apos;daai Fireborn" hidden="false" collective="false" import="true" type="model">
           <modifiers>
             <modifier type="decrement" field="points" value="20">
               <conditions>
@@ -1064,7 +1003,7 @@
             <cost name="pts" typeId="points" value="140.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="aeee-24c2-44b8-1aa3" name="Burning Irons" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="aeee-24c2-44b8-1aa3" name="Burning Irons" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a950-8cda-69b0-2def" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9e6-e38c-09fa-132e" type="min"/>
@@ -1091,7 +1030,7 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5c3d-5a69-c9f0-f6b4" name="Bull Centaur Renders" publicationId="8c11-75b5-pubN65537" hidden="false" collective="false" type="unit">
+    <selectionEntry id="5c3d-5a69-c9f0-f6b4" name="Bull Centaur Renders" publicationId="8c11-75b5-pubN65537" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="7617-a401-8f41-01e6" name="Bull Centaur Renders" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
@@ -1113,7 +1052,7 @@
         <categoryLink id="ca10-867f-03bf-c581" name="New CategoryLink" hidden="false" targetId="bc87-8623-2da4-3e93" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="97b0-0b34-6c60-0e3f" name="3 Bull Centaur Renders" hidden="false" collective="false" type="model">
+        <selectionEntry id="97b0-0b34-6c60-0e3f" name="3 Bull Centaur Renders" hidden="false" collective="false" import="true" type="model">
           <modifiers>
             <modifier type="decrement" field="points" value="20">
               <conditions>
@@ -1129,7 +1068,7 @@
             <cost name="pts" typeId="points" value="180.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="2446-6605-db13-1ea4" name="Crushing Hooves" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="2446-6605-db13-1ea4" name="Crushing Hooves" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a544-696a-9d9c-c458" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="748c-0efa-99c8-836a" type="max"/>
@@ -1151,7 +1090,7 @@
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="0374-401c-4216-7352" name="Darkforged Weapon &amp; Spiteshield" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="0374-401c-4216-7352" name="Darkforged Weapon &amp; Spiteshield" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6619-4169-016a-7a35" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9932-c949-6430-cb21" type="max"/>
@@ -1170,7 +1109,7 @@
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="9097-12ad-30e8-f092" name="Spiteshield" hidden="false" targetId="09ad-19b0-4a45-cfcd" type="profile"/>
+            <infoLink id="9097-12ad-30e8-f092" name="Spiteshield" hidden="false" targetId="41fb-ae7b-7cc8-a676" type="profile"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
@@ -1181,7 +1120,7 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c44c-2b12-5f83-8be9" name="Bull Centaur Taur&apos;ruk" publicationId="8c11-75b5-pubN65537" hidden="false" collective="false" type="unit">
+    <selectionEntry id="c44c-2b12-5f83-8be9" name="Bull Centaur Taur&apos;ruk" publicationId="8c11-75b5-pubN65537" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="10e0-b707-a89c-c9a5" name="Bull Centaur Taur&apos;ruk" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
@@ -1209,7 +1148,7 @@
         <categoryLink id="cfeb-c76f-4476-7a6e" name="New CategoryLink" hidden="false" targetId="bc87-8623-2da4-3e93" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="3970-5b01-c079-5e94" name="Crushing Hooves" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="3970-5b01-c079-5e94" name="Crushing Hooves" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f155-a59d-0048-84d6" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf2e-e080-0387-7688" type="max"/>
@@ -1231,7 +1170,7 @@
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="b821-25ae-566a-0c53" name="Darkforged Great Weapon" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="b821-25ae-566a-0c53" name="Darkforged Great Weapon" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="60d4-c81b-5d3b-1076" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a3ec-dcc4-6488-b06e" type="min"/>
@@ -1255,15 +1194,15 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="49e5-c186-8246-1260" name="Artefacts of Power" hidden="false" collective="false" targetId="475c-1632-c526-a073" type="selectionEntryGroup"/>
-        <entryLink id="8bb5-bd95-7a71-f15d" name="Command Traits" hidden="false" collective="false" targetId="c403-6e43-5398-19ac" type="selectionEntryGroup"/>
-        <entryLink id="8f47-ad33-89a9-e714" name="General" hidden="false" collective="false" targetId="88ed-914f-7045-41db" type="selectionEntry"/>
+        <entryLink id="49e5-c186-8246-1260" name="Artefacts of Power" hidden="false" collective="false" import="true" targetId="475c-1632-c526-a073" type="selectionEntryGroup"/>
+        <entryLink id="8bb5-bd95-7a71-f15d" name="Command Traits" hidden="false" collective="false" import="true" targetId="c403-6e43-5398-19ac" type="selectionEntryGroup"/>
+        <entryLink id="8f47-ad33-89a9-e714" name="General" hidden="false" collective="false" import="true" targetId="88ed-914f-7045-41db" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="160.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c630-ea56-761c-4c04" name="Iron Daemon War Engine" publicationId="8c11-75b5-pubN65537" hidden="false" collective="false" type="unit">
+    <selectionEntry id="c630-ea56-761c-4c04" name="Iron Daemon War Engine" publicationId="8c11-75b5-pubN65537" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="21e8-02a9-9eac-7600" name="Iron Daemon War Engine" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
@@ -1338,7 +1277,7 @@
         <categoryLink id="6a75-f6c7-e116-72bd" name="New CategoryLink" hidden="false" targetId="9f0f-e75f-84e4-5f33" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="3041-d6b6-1cce-e35e" name="Steam Cannonade" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="3041-d6b6-1cce-e35e" name="Steam Cannonade" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c1b-daf8-d471-0f88" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a44-4c12-be84-86a2" type="min"/>
@@ -1360,7 +1299,7 @@
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="928b-c112-14db-3aed" name="Crushing Bulk" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="928b-c112-14db-3aed" name="Crushing Bulk" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8806-7397-5ea8-bd21" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="015a-707f-a8a2-3349" type="min"/>
@@ -1387,7 +1326,7 @@
         <cost name="pts" typeId="points" value="180.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="12dc-3982-1d36-ddb7" name="Skullcracker War Engine" publicationId="8c11-75b5-pubN65537" hidden="false" collective="false" type="unit">
+    <selectionEntry id="12dc-3982-1d36-ddb7" name="Skullcracker War Engine" publicationId="8c11-75b5-pubN65537" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="0bd6-96b0-2e24-7e09" name="Skullcracker War Engine" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
@@ -1404,7 +1343,7 @@
         </profile>
         <profile id="d842-5e9b-8166-65a3" name="Beaten into Scrap" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">You can re-roll wound rolls for attacks made with this model’s Hammer and Picks that target a War Machine.</characteristic>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">You can re-roll wound rolls for attacks made with this model’s Hammer and Picks that target a WAR MACHINE.</characteristic>
           </characteristics>
         </profile>
         <profile id="8ed5-43e1-b92d-7645" name="WoundTable0" hidden="false" typeId="90d1-a434-348d-a861" typeName="Damage Table">
@@ -1467,7 +1406,7 @@
         <categoryLink id="1599-ae89-2fd2-3848" name="New CategoryLink" hidden="false" targetId="d6a5-424f-8044-1d7d" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="8ea3-aa84-c551-dae5" name="Hammers and Picks" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="8ea3-aa84-c551-dae5" name="Hammers and Picks" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4fb4-73c7-4777-ea18" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="494e-9661-35ef-24af" type="min"/>
@@ -1489,7 +1428,7 @@
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="191b-2f46-bb3c-e319" name="Crushing Bulk" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="191b-2f46-bb3c-e319" name="Crushing Bulk" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6274-bf94-aaab-dd7b" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe41-c279-6004-1127" type="min"/>
@@ -1516,7 +1455,7 @@
         <cost name="pts" typeId="points" value="200.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e639-c727-48a8-7070" name="Deathshrieker Rocket Launcher" publicationId="8c11-75b5-pubN65537" hidden="false" collective="false" type="unit">
+    <selectionEntry id="e639-c727-48a8-7070" name="Deathshrieker Rocket Launcher" publicationId="8c11-75b5-pubN65537" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="6776-02b0-3d2b-5392" name="Deathshrieker Rocket Launcher" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
@@ -1548,7 +1487,7 @@
         <categoryLink id="ad80-d445-a98f-323a" name="New CategoryLink" hidden="false" targetId="9142-537b-04c1-9d92" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="1548-6132-fcab-e616" name="Deathshrieker Rockets" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="1548-6132-fcab-e616" name="Deathshrieker Rockets" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6648-929a-022d-994d" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47ba-4a94-75b9-b56c" type="min"/>
@@ -1570,25 +1509,14 @@
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="f552-2c28-0e54-86fd" name="CREW (treated in the same manner as a mount)" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="3123-42b9-3a87-6a52" name="Improvised Weapons" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7618-0b4b-f691-6da7" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c35b-7046-d75c-d7b9" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0eb4-7b8d-49c5-1cee" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3803-36b3-e9aa-1578" type="max"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="ca92-1c7e-cee1-4ada" name="Crew&apos;s Improvised Weapons" hidden="false" collective="false" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce76-bc3c-326e-c775" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1a1-e9d5-3165-b818" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="2a3f-3052-a034-76c6" name="Crew’s Improvised Weapons" hidden="false" targetId="52de-b365-14ee-ce66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
+          <infoLinks>
+            <infoLink id="eb61-b952-3a9c-650e" name="Crew’s Improvised Weapons" hidden="false" targetId="52de-b365-14ee-ce66" type="profile"/>
+          </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
@@ -1598,7 +1526,7 @@
         <cost name="pts" typeId="points" value="120.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="f715-f879-b9b4-b0fb" name="Magma Cannon" publicationId="8c11-75b5-pubN65537" hidden="false" collective="false" type="unit">
+    <selectionEntry id="f715-f879-b9b4-b0fb" name="Magma Cannon" publicationId="8c11-75b5-pubN65537" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="4964-39e3-87c1-a300" name="Magma Cannon" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
@@ -1625,7 +1553,7 @@
         <categoryLink id="1b26-949a-528b-410d" name="New CategoryLink" hidden="false" targetId="3e20-3d2c-7218-4498" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="647e-9ae5-a9ed-fdc0" name="Magma Blast" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="647e-9ae5-a9ed-fdc0" name="Magma Blast" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e4be-8631-1d00-594d" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7c7-f6ff-dbee-fa10" type="max"/>
@@ -1652,13 +1580,13 @@
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="e51f-fd5a-d30c-e358" name="CREW (treated in the same manner as a mount)" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="e51f-fd5a-d30c-e358" name="CREW (treated in the same manner as a mount)" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="acff-cf77-ba49-ded5" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0893-f063-13ac-4588" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="c8c3-f178-e52f-7b38" name="Crew&apos;s Improvised Weapons" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="c8c3-f178-e52f-7b38" name="Crew&apos;s Improvised Weapons" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1fa0-939d-80c5-9d38" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5133-a41a-389b-b0d1" type="max"/>
@@ -1680,7 +1608,7 @@
         <cost name="pts" typeId="points" value="140.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8260-d945-aa2f-4b19" name="Dreadquake Mortar" publicationId="8c11-75b5-pubN65537" hidden="false" collective="false" type="unit">
+    <selectionEntry id="8260-d945-aa2f-4b19" name="Dreadquake Mortar" publicationId="8c11-75b5-pubN65537" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="72a0-f2e2-4a3b-5b4d" name="Dreadquake Mortar" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
@@ -1690,19 +1618,19 @@
             <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">4+</characteristic>
           </characteristics>
         </profile>
-        <profile id="1287-2c5f-a556-4f8b" name="Arching Shot" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+        <profile id="738c-0649-5c40-d2e5" name="Cruel Overlords" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">This model can shoot at enemy units that are not visible to it.</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="738c-0649-5c40-d2e5" name="Cruel Slave-masters" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-          <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Before shooting with this model’s Dreadquake Bomb, you can choose to lash the Slave Ogor if there are any friendly Daemonsmiths within 3&quot; of it. If you do so, roll a D6. On a 1, this model suffers D3 mortal wounds and you may not attack with this model’s Dreadquake Bomb this phase; on a 2-3, you can shoot with this model’s Dreadquake Bomb as normal this phase; on a 4+, add 1 to the Attacks characteristic of this model’s Dreadquake Bomb this phase.</characteristic>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">When this model is picked to shoot in your shooting phase, you can say that the Slavemasters are lashing the Slave Ogor. If you do so, roll a dice. On a 1 or 2, this unit suffers D3 mortal wounds (if it is not slain it can shoot normally). On a 3+, add 1 to the Attacks characteristic of this model’s Dreadquake Bombs for that phase. </characteristic>
           </characteristics>
         </profile>
         <profile id="97aa-259a-b162-467d" name="Quake Blast" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">A Dreadquake Bomb has a Damage characteristic of 2D6 if the target unit has 10 or more models. In addition, a unit targeted by a Dreadquake Bomb cannot run in its next turn if any its models were slain.</characteristic>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">This model’s Dreadquake Bomb can target enemy units that are not visible to the attacking model. In addition, you can re-roll the dice that determines the Damage characteristic of this model’s Dreadquake Bomb if the target unit has 10 or more models. </characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d9f1-3012-9754-7b4c" name="Infernal Engineers" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Add 1 to the Attacks characteristic of this model’s Dreadquake Bomb while this model is within 3&quot; of a friendly Daemonsmith.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -1717,7 +1645,7 @@
         <categoryLink id="d514-30e8-7397-728a" name="New CategoryLink" hidden="false" targetId="e24d-ff4c-5eca-fbbd" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="e7de-afb8-b469-8608" name="Crew&apos;s Improvised Weapons" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="e7de-afb8-b469-8608" name="Crew&apos;s Improvised Weapons" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b733-5a31-f052-61fb" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4496-d79d-747e-7280" type="max"/>
@@ -1729,20 +1657,20 @@
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="6b8e-226c-86b8-c776" name="Slave Ogor Loader’s Fists and Chains" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="6b8e-226c-86b8-c776" name="Fists and Chains" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="efe9-bdfb-e1e3-7d50" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80c4-d323-d3b0-0fdb" type="max"/>
           </constraints>
           <profiles>
-            <profile id="a496-07de-f293-9d0d" name="Slave Ogor Loader’s Fists and Chains" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
+            <profile id="a496-07de-f293-9d0d" name="Fists and Chains" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                 <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
                 <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">2</characteristic>
                 <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">4+</characteristic>
-                <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">4+</characteristic>
-                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-</characteristic>
+                <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
+                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-1</characteristic>
                 <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
               </characteristics>
             </profile>
@@ -1751,7 +1679,7 @@
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="1702-5ba1-a514-fb8a" name="Dreadquake Bomb" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="1702-5ba1-a514-fb8a" name="Dreadquake Bomb" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="308e-8210-acef-1ddc" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e7e3-7015-5aeb-4a5f" type="max"/>
@@ -1760,9 +1688,9 @@
             <profile id="7dbe-8c22-e251-5070" name="Dreadquake Bomb" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Missile</characteristic>
-                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">12&quot;-40&quot;</characteristic>
+                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">40&quot;</characteristic>
                 <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">1</characteristic>
-                <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">3+</characteristic>
+                <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">4+</characteristic>
                 <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
                 <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-2</characteristic>
                 <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">D6</characteristic>
@@ -1778,7 +1706,7 @@
         <cost name="pts" typeId="points" value="180.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6638-1032-9e14-e0e8" name="Battalion: Hashut&apos;s Wrath Artillery Train" publicationId="8c11-75b5-pubN65537" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="6638-1032-9e14-e0e8" name="Battalion: Hashut&apos;s Wrath Artillery Train" publicationId="8c11-75b5-pubN65537" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="657a-5122-22a5-83da" name="Murderous Barrage" hidden="false" typeId="bdc6-78da-3796-60a3" typeName="Battalion Abilities">
           <characteristics>
@@ -1787,7 +1715,7 @@
         </profile>
       </profiles>
       <selectionEntries>
-        <selectionEntry id="05e8-03dc-b5ec-9b2f" name="Hashut&apos;s Wrath Artillery Train" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="05e8-03dc-b5ec-9b2f" name="Hashut&apos;s Wrath Artillery Train" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0cc8-34a4-18ea-3cce" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="77da-5145-b413-bea7" type="min"/>
@@ -1798,54 +1726,54 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="7bc5-de4d-c214-b425" name="1 Daemonsmith" hidden="false" collective="false">
+        <selectionEntryGroup id="7bc5-de4d-c214-b425" name="1 Daemonsmith" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="746c-7ac8-3d51-ec53" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff0a-09cd-9e5e-f837" type="min"/>
           </constraints>
           <entryLinks>
-            <entryLink id="3f02-9328-2a2a-ced9" name="Daemonsmith" hidden="false" collective="false" targetId="16e0-5e2f-bbed-429b" type="selectionEntry">
+            <entryLink id="3f02-9328-2a2a-ced9" name="Daemonsmith" hidden="false" collective="false" import="true" targetId="16e0-5e2f-bbed-429b" type="selectionEntry">
               <categoryLinks>
                 <categoryLink id="e0d2-877f-94e3-d188" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
               </categoryLinks>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="decf-cd78-4d83-c132" name="1 Iron Daemon War Engine" hidden="false" collective="false">
+        <selectionEntryGroup id="decf-cd78-4d83-c132" name="1 Iron Daemon War Engine" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b42c-2acc-28b9-600a" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8806-87e7-5aa6-4a7e" type="min"/>
           </constraints>
           <entryLinks>
-            <entryLink id="0601-2f85-dd14-dcd3" name="Iron Daemon War Engine" hidden="false" collective="false" targetId="c630-ea56-761c-4c04" type="selectionEntry">
+            <entryLink id="0601-2f85-dd14-dcd3" name="Iron Daemon War Engine" hidden="false" collective="false" import="true" targetId="c630-ea56-761c-4c04" type="selectionEntry">
               <categoryLinks>
                 <categoryLink id="1cd8-7af2-0b93-9c71" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="true"/>
               </categoryLinks>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="da64-0ff7-7de8-7f48" name="Any 3 models chosen from the following:" hidden="false" collective="false">
+        <selectionEntryGroup id="da64-0ff7-7de8-7f48" name="Any 3 models chosen from the following:" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b9e-4604-c6a4-a314" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c40d-2ede-0d04-37e8" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="93f9-8fa6-260c-eb53" name="Deathshrieker Rocket Launcher" hidden="false" collective="false" targetId="e639-c727-48a8-7070" type="selectionEntry">
+            <entryLink id="93f9-8fa6-260c-eb53" name="Deathshrieker Rocket Launcher" hidden="false" collective="false" import="true" targetId="e639-c727-48a8-7070" type="selectionEntry">
               <categoryLinks>
                 <categoryLink id="2df7-3ff9-8965-1d9f" name="New CategoryLink" hidden="false" targetId="1d26-07fc-6a66-d73e" primary="true"/>
               </categoryLinks>
             </entryLink>
-            <entryLink id="1d92-abe9-769e-0066" name="Dreadquake Mortar" hidden="false" collective="false" targetId="8260-d945-aa2f-4b19" type="selectionEntry">
+            <entryLink id="1d92-abe9-769e-0066" name="Dreadquake Mortar" hidden="false" collective="false" import="true" targetId="8260-d945-aa2f-4b19" type="selectionEntry">
               <categoryLinks>
                 <categoryLink id="2896-75c6-c539-7235" name="New CategoryLink" hidden="false" targetId="1d26-07fc-6a66-d73e" primary="true"/>
               </categoryLinks>
             </entryLink>
-            <entryLink id="af93-9955-3195-fa7f" name="Magma Cannon" hidden="false" collective="false" targetId="f715-f879-b9b4-b0fb" type="selectionEntry">
+            <entryLink id="af93-9955-3195-fa7f" name="Magma Cannon" hidden="false" collective="false" import="true" targetId="f715-f879-b9b4-b0fb" type="selectionEntry">
               <categoryLinks>
                 <categoryLink id="12f5-43c7-cfc8-c3d0" name="New CategoryLink" hidden="false" targetId="1d26-07fc-6a66-d73e" primary="true"/>
               </categoryLinks>
             </entryLink>
-            <entryLink id="e9af-227a-2b1f-9f9f" name="Iron Daemon War Engine" hidden="false" collective="false" targetId="c630-ea56-761c-4c04" type="selectionEntry">
+            <entryLink id="e9af-227a-2b1f-9f9f" name="Iron Daemon War Engine" hidden="false" collective="false" import="true" targetId="c630-ea56-761c-4c04" type="selectionEntry">
               <categoryLinks>
                 <categoryLink id="5635-1de3-1db0-80f6" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="true"/>
               </categoryLinks>
@@ -1857,7 +1785,7 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="cf30-69b6-b5bd-4cb1" name="Battalion: Blackshard Warhost" publicationId="8c11-75b5-pubN65537" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="cf30-69b6-b5bd-4cb1" name="Battalion: Blackshard Warhost" publicationId="8c11-75b5-pubN65537" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="75c4-1af7-d5cd-f30a" name="Unyielding Slaughterers" hidden="false" typeId="bdc6-78da-3796-60a3" typeName="Battalion Abilities">
           <characteristics>
@@ -1866,7 +1794,7 @@
         </profile>
       </profiles>
       <selectionEntries>
-        <selectionEntry id="09d0-2a94-e1a6-2be1" name="Blackshard Warhost" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="09d0-2a94-e1a6-2be1" name="Blackshard Warhost" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="13f9-d94c-d0b2-70d2" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91b5-9b00-8b7a-ffb6" type="min"/>
@@ -1877,39 +1805,39 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="0d70-a8bb-cfed-dc5e" name="1 Infernal Guard Castellan" hidden="false" collective="false">
+        <selectionEntryGroup id="0d70-a8bb-cfed-dc5e" name="1 Infernal Guard Castellan" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f36-6d47-3019-2ac2" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e53-b4bf-cf74-c42b" type="min"/>
           </constraints>
           <entryLinks>
-            <entryLink id="bd8b-7ab5-9151-db16" name="Infernal Guard Castellan" hidden="false" collective="false" targetId="0a2d-7e3a-3be2-00bc" type="selectionEntry">
+            <entryLink id="bd8b-7ab5-9151-db16" name="Infernal Guard Castellan" hidden="false" collective="false" import="true" targetId="0a2d-7e3a-3be2-00bc" type="selectionEntry">
               <categoryLinks>
                 <categoryLink id="256a-d8d8-5681-bdfe" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
               </categoryLinks>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="892d-5460-f937-7aeb" name="1 Infernal Guard Battle Standard Bearer" hidden="false" collective="false">
+        <selectionEntryGroup id="892d-5460-f937-7aeb" name="1 Infernal Guard Battle Standard Bearer" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e62-6241-2c2c-cff4" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7545-d430-5bc7-110f" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="88af-3243-cf05-9ee2" name="Infernal Guard Battle Standard Bearer" hidden="false" collective="false" targetId="9e19-65b2-2ada-6966" type="selectionEntry">
+            <entryLink id="88af-3243-cf05-9ee2" name="Infernal Guard Battle Standard Bearer" hidden="false" collective="false" import="true" targetId="9e19-65b2-2ada-6966" type="selectionEntry">
               <categoryLinks>
                 <categoryLink id="b2a0-1551-c18b-0120" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
               </categoryLinks>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="0e5f-aa4e-630e-15c5" name="2 units of Infernal Guard Ironsworn" hidden="false" collective="false">
+        <selectionEntryGroup id="0e5f-aa4e-630e-15c5" name="2 units of Infernal Guard Ironsworn" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c844-bdca-8303-adc3" type="min"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9de3-621f-a94b-8e7e" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="18a3-0f65-837b-5b02" name="Infernal Guard Ironsworn" hidden="false" collective="false" targetId="2f68-7c57-f3c6-70a8" type="selectionEntry">
+            <entryLink id="18a3-0f65-837b-5b02" name="Infernal Guard Ironsworn" hidden="false" collective="false" import="true" targetId="2f68-7c57-f3c6-70a8" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditionGroups>
@@ -1927,20 +1855,20 @@
                 <categoryLink id="589a-5001-e69c-3fb7" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
               </categoryLinks>
             </entryLink>
-            <entryLink id="50e0-012a-2243-b534" name="Infernal Guard Ironsworn" hidden="false" collective="false" targetId="2f68-7c57-f3c6-70a8" type="selectionEntry">
+            <entryLink id="50e0-012a-2243-b534" name="Infernal Guard Ironsworn" hidden="false" collective="false" import="true" targetId="2f68-7c57-f3c6-70a8" type="selectionEntry">
               <categoryLinks>
                 <categoryLink id="2282-bcf2-fac3-11aa" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true"/>
               </categoryLinks>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="1e4e-be19-298a-13bf" name="2 units of Infernal Guard Fireglaives" hidden="false" collective="false">
+        <selectionEntryGroup id="1e4e-be19-298a-13bf" name="2 units of Infernal Guard Fireglaives" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a29d-f218-05be-862e" type="min"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6985-6120-ba56-e1b5" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="8781-8653-b7f7-9a8c" name="Infernal Guard Fireglaives" hidden="false" collective="false" targetId="e4a6-dabb-cad7-b02d" type="selectionEntry">
+            <entryLink id="8781-8653-b7f7-9a8c" name="Infernal Guard Fireglaives" hidden="false" collective="false" import="true" targetId="e4a6-dabb-cad7-b02d" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
@@ -1952,7 +1880,7 @@
                 <categoryLink id="c5f0-44e9-e19d-895d" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
               </categoryLinks>
             </entryLink>
-            <entryLink id="0c00-752c-ab6e-3b98" name="Infernal Guard Fireglaives" hidden="false" collective="false" targetId="e4a6-dabb-cad7-b02d" type="selectionEntry">
+            <entryLink id="0c00-752c-ab6e-3b98" name="Infernal Guard Fireglaives" hidden="false" collective="false" import="true" targetId="e4a6-dabb-cad7-b02d" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditionGroups>
@@ -1978,20 +1906,20 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="904c-53b5-501f-08e0" name="Allegiance" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="904c-53b5-501f-08e0" name="Allegiance" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0bf4-588a-ea62-504f" type="min"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b30-0603-7001-faa1" type="max"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43af-324b-fef9-d5ad" type="min"/>
       </constraints>
       <selectionEntryGroups>
-        <selectionEntryGroup id="ee8d-10b3-706d-ea7a" name="Allegiance" hidden="false" collective="false" defaultSelectionEntryId="ed37-3e74-a225-25ce">
+        <selectionEntryGroup id="ee8d-10b3-706d-ea7a" name="Allegiance" hidden="false" collective="false" import="true" defaultSelectionEntryId="ed37-3e74-a225-25ce">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d79e-c6e4-7315-a107" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec2c-4448-c668-aa8c" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="ce74-fe99-620c-0868" name="Allegiance: Chaos" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="ce74-fe99-620c-0868" name="Allegiance: Chaos" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
                 <infoLink id="15f2-097f-e587-dfa1" name="Unpredictable Destruction" hidden="false" targetId="6884-967e-0150-274e" type="profile"/>
               </infoLinks>
@@ -2002,7 +1930,7 @@
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="ed37-3e74-a225-25ce" name="Allegiance: Legion of Azgorh" publicationId="8c11-75b5-pubN65537" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="ed37-3e74-a225-25ce" name="Allegiance: Legion of Azgorh" publicationId="8c11-75b5-pubN65537" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="cc39-e510-96c7-c0a7" name="Blackshard Armor" hidden="false" typeId="c137-4d1f-9d1a-524d" typeName="Battle Trait">
                   <characteristics>
@@ -2020,9 +1948,6 @@
                   </characteristics>
                 </profile>
               </profiles>
-              <infoLinks>
-                <infoLink id="d64a-e282-0d4f-5e49" name="Fireball" hidden="false" targetId="03db-a8ab-3343-9804" type="profile"/>
-              </infoLinks>
               <categoryLinks>
                 <categoryLink id="1e41-d4d4-bc14-7a39" name="New CategoryLink" hidden="false" targetId="3e20-3d2c-7218-4498" primary="false"/>
               </categoryLinks>
@@ -2037,7 +1962,7 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="88ed-914f-7045-41db" name="General" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="88ed-914f-7045-41db" name="General" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
@@ -2061,44 +1986,7 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8a35-f019-2f05-ee87" name="Ashsteel Hand Weapon &amp; Spiteshield" hidden="false" collective="false" type="upgrade">
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a82-9cb8-a8cb-a6a8" type="max"/>
-      </constraints>
-      <infoLinks>
-        <infoLink id="f8a1-aa6c-3b4c-6525" name="Spiteshield" hidden="false" targetId="09ad-19b0-4a45-cfcd" type="profile"/>
-        <infoLink id="2855-3f22-ff53-6b81" name="Ashteel Hand Weapon" hidden="false" targetId="ba19-13eb-90b8-823e" type="profile"/>
-      </infoLinks>
-      <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="89c8-4d82-4d7b-7350" name="Ashsteel Hand Weapon &amp; Pyrelock Pistol" hidden="false" collective="false" type="upgrade">
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de2c-8094-808a-ea59" type="max"/>
-      </constraints>
-      <infoLinks>
-        <infoLink id="38a8-01e6-6a4a-4145" name="Pyrelock Pistol" hidden="false" targetId="9e82-7753-6293-a60e" type="profile"/>
-        <infoLink id="22a0-47a5-af98-2aee" name="Ashsteel Hand Weapon" hidden="false" targetId="ba19-13eb-90b8-823e" type="profile"/>
-        <infoLink id="eb74-60da-77fd-c333" name="Pyrelock Pistol" hidden="false" targetId="ba39-c89e-6c7d-0575" type="profile"/>
-      </infoLinks>
-      <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="aaea-24d8-2fc6-b484" name="Pyrelock Fireglaive" hidden="false" collective="false" type="upgrade">
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de26-7838-d20e-4350" type="max"/>
-      </constraints>
-      <infoLinks>
-        <infoLink id="9955-7b63-cd4a-4d14" name="Pyrelock Fireglaive" hidden="false" targetId="7313-b871-0343-351b" type="profile"/>
-        <infoLink id="4747-3096-550a-aed0" name="Pyrelock Fireglaive’s Bayonet-cleaver" hidden="false" targetId="96b4-8194-7a57-b5b1" type="profile"/>
-      </infoLinks>
-      <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="0201-bd62-966c-1cc6" name="Battalion: Execution Herd" publicationId="8c11-75b5-pubN65537" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="0201-bd62-966c-1cc6" name="Battalion: Execution Herd" publicationId="8c11-75b5-pubN65537" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="5c21-591c-6a9b-156a" name="Marked for Death" hidden="false" typeId="bdc6-78da-3796-60a3" typeName="Battalion Abilities">
           <characteristics>
@@ -2107,7 +1995,7 @@
         </profile>
       </profiles>
       <selectionEntries>
-        <selectionEntry id="353c-5ac2-4c21-51ed" name="Execution Herd" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="353c-5ac2-4c21-51ed" name="Execution Herd" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a6f9-5618-de6c-c2f7" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b3a-f5ce-0b8e-09f2" type="min"/>
@@ -2118,39 +2006,39 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="dc01-e48e-3e6e-00ee" name="1 Shar&apos;tor the Executioner" hidden="false" collective="false">
+        <selectionEntryGroup id="dc01-e48e-3e6e-00ee" name="1 Shar&apos;tor the Executioner" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe27-d5b4-b5b9-3d6f" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="294f-8ce7-6f28-dc2f" type="min"/>
           </constraints>
           <entryLinks>
-            <entryLink id="fdda-b9f6-d37d-eda5" name="*Shar’tor the Executioner" hidden="false" collective="false" targetId="a6f6-09b4-da9c-a082" type="selectionEntry">
+            <entryLink id="fdda-b9f6-d37d-eda5" name="*Shar’tor the Executioner" hidden="false" collective="false" import="true" targetId="a6f6-09b4-da9c-a082" type="selectionEntry">
               <categoryLinks>
                 <categoryLink id="1baa-0572-1b9d-0b2c" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
               </categoryLinks>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="7583-591a-d2b1-9b9e" name="1 Bull Centaur Taur&apos;ruk" hidden="false" collective="false">
+        <selectionEntryGroup id="7583-591a-d2b1-9b9e" name="1 Bull Centaur Taur&apos;ruk" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b6e5-21ae-946a-5bd9" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9bba-7003-e9e8-cef6" type="min"/>
           </constraints>
           <entryLinks>
-            <entryLink id="4ed6-8c93-9c8a-4d11" name="*Bull Centaur Taur&apos;ruk" hidden="false" collective="false" targetId="c44c-2b12-5f83-8be9" type="selectionEntry">
+            <entryLink id="4ed6-8c93-9c8a-4d11" name="*Bull Centaur Taur&apos;ruk" hidden="false" collective="false" import="true" targetId="c44c-2b12-5f83-8be9" type="selectionEntry">
               <categoryLinks>
                 <categoryLink id="53da-591d-dc27-e096" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
               </categoryLinks>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="fa33-9ad2-7a72-0034" name="3 Units of Bull Centaur Renderers" hidden="false" collective="false">
+        <selectionEntryGroup id="fa33-9ad2-7a72-0034" name="3 Units of Bull Centaur Renderers" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23ad-98ef-bcb4-f7e2" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe14-f537-656b-1c59" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="612b-8af1-fcf7-61d9" name="*Bull Centaur Renders" hidden="false" collective="false" targetId="5c3d-5a69-c9f0-f6b4" type="selectionEntry">
+            <entryLink id="612b-8af1-fcf7-61d9" name="*Bull Centaur Renders" hidden="false" collective="false" import="true" targetId="5c3d-5a69-c9f0-f6b4" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditionGroups>
@@ -2167,7 +2055,7 @@
                 <categoryLink id="365b-9809-62af-55cc" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
               </categoryLinks>
             </entryLink>
-            <entryLink id="0054-1238-d9e8-d1c1" name="*Bull Centaur Renders" hidden="false" collective="false" targetId="5c3d-5a69-c9f0-f6b4" type="selectionEntry">
+            <entryLink id="0054-1238-d9e8-d1c1" name="*Bull Centaur Renders" hidden="false" collective="false" import="true" targetId="5c3d-5a69-c9f0-f6b4" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditionGroups>
@@ -2191,9 +2079,21 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="9d62-a98b-38b1-39c4" name="Ashsteel Hand Weapon &amp; Pyrelock Pistol" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1da-271c-66c1-6ebc" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="12a0-7a16-cc3b-59ef" name="Ashsteel Hand Weapon" hidden="false" targetId="ba19-13eb-90b8-823e" type="profile"/>
+        <infoLink id="3401-d3cc-38c7-d3b7" name="Pyrelock Pistol" hidden="false" targetId="ba39-c89e-6c7d-0575" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
-    <selectionEntryGroup id="475c-1632-c526-a073" name="Artefacts of Power" hidden="false" collective="false">
+    <selectionEntryGroup id="475c-1632-c526-a073" name="Artefacts of Power" hidden="false" collective="false" import="true">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
@@ -2217,7 +2117,7 @@
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a62e-ae93-7767-0046" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="2837-33c5-7fb4-bb09" name="Artefacts of Chaos" hidden="false" collective="false" targetId="3c13-922a-683d-7de7" type="selectionEntryGroup">
+        <entryLink id="2837-33c5-7fb4-bb09" name="Artefacts of Chaos" hidden="false" collective="false" import="true" targetId="3c13-922a-683d-7de7" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -2226,11 +2126,11 @@
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="fcd3-c58c-a657-cdf4" name="Realm Artefacts of Power" hidden="false" collective="false" targetId="37b0-af21-630c-d8af" type="selectionEntryGroup"/>
-        <entryLink id="5193-adc5-1068-f745" name="Legion Artefacts of Power" hidden="false" collective="false" targetId="86b1-7f49-6b79-eb16" type="selectionEntryGroup"/>
+        <entryLink id="fcd3-c58c-a657-cdf4" name="Realm Artefacts of Power" hidden="false" collective="false" import="true" targetId="37b0-af21-630c-d8af" type="selectionEntryGroup"/>
+        <entryLink id="5193-adc5-1068-f745" name="Legion Artefacts of Power" hidden="false" collective="false" import="true" targetId="86b1-7f49-6b79-eb16" type="selectionEntryGroup"/>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="c403-6e43-5398-19ac" name="Command Traits" hidden="false" collective="false">
+    <selectionEntryGroup id="c403-6e43-5398-19ac" name="Command Traits" hidden="false" collective="false" import="true">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -2243,7 +2143,7 @@
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1ba6-f158-6b78-f00b" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="5b22-a550-4a81-3ad5" name="Chaos Command Traits" hidden="false" collective="false" targetId="f179-9104-3d7f-1ea1" type="selectionEntryGroup">
+        <entryLink id="5b22-a550-4a81-3ad5" name="Chaos Command Traits" hidden="false" collective="false" import="true" targetId="f179-9104-3d7f-1ea1" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -2252,10 +2152,10 @@
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="9c57-f8f4-04df-b97a" name="Legion Command Traits" hidden="false" collective="false" targetId="4b18-6e6f-4b97-eb5c" type="selectionEntryGroup"/>
+        <entryLink id="9c57-f8f4-04df-b97a" name="Legion Command Traits" hidden="false" collective="false" import="true" targetId="4b18-6e6f-4b97-eb5c" type="selectionEntryGroup"/>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="86b1-7f49-6b79-eb16" name="Legion Artefacts of Power" hidden="false" collective="false">
+    <selectionEntryGroup id="86b1-7f49-6b79-eb16" name="Legion Artefacts of Power" hidden="false" collective="false" import="true">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -2267,7 +2167,7 @@
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2485-9348-ca07-a518" type="max"/>
       </constraints>
       <selectionEntries>
-        <selectionEntry id="08dc-4364-defb-a856" name="1. Black Hammer of Hashut" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="08dc-4364-defb-a856" name="1. Black Hammer of Hashut" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8303-f719-91f4-7e0c" type="max"/>
           </constraints>
@@ -2285,7 +2185,7 @@
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="4cc3-e71f-998d-d9f8" name="2. Armor of Bazherak the Cruel" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="4cc3-e71f-998d-d9f8" name="2. Armor of Bazherak the Cruel" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0389-0ade-65c0-cb8a" type="max"/>
           </constraints>
@@ -2303,7 +2203,7 @@
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="1d18-fc20-d9ea-13a6" name="3. Chalice of Blood and Darkness" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="1d18-fc20-d9ea-13a6" name="3. Chalice of Blood and Darkness" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d68f-cd3a-f681-015f" type="max"/>
           </constraints>
@@ -2323,7 +2223,7 @@
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
-    <selectionEntryGroup id="4b18-6e6f-4b97-eb5c" name="Legion Command Traits" hidden="false" collective="false">
+    <selectionEntryGroup id="4b18-6e6f-4b97-eb5c" name="Legion Command Traits" hidden="false" collective="false" import="true">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -2335,7 +2235,7 @@
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="241f-2427-795a-ca2f" type="max"/>
       </constraints>
       <selectionEntries>
-        <selectionEntry id="2d80-b10c-a7a9-1db6" name="1. Contemptuous" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="2d80-b10c-a7a9-1db6" name="1. Contemptuous" hidden="false" collective="false" import="true" type="upgrade">
           <profiles>
             <profile id="94e7-5a59-3b0b-3f17" name="Contemptuous" hidden="false" typeId="c749-bae4-71a8-0c36" typeName="Command Trait">
               <characteristics>
@@ -2347,7 +2247,7 @@
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="536c-dc19-6293-40b3" name="2. Relentless" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="536c-dc19-6293-40b3" name="2. Relentless" hidden="false" collective="false" import="true" type="upgrade">
           <profiles>
             <profile id="ee6e-1245-c847-6e01" name="Relentless" hidden="false" typeId="bdc6-78da-3796-60a3" typeName="Battalion Abilities">
               <characteristics>
@@ -2359,7 +2259,7 @@
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="bcdd-7263-ca91-4288" name="3. Grotesque" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="bcdd-7263-ca91-4288" name="3. Grotesque" hidden="false" collective="false" import="true" type="upgrade">
           <profiles>
             <profile id="9283-a1c4-dba0-d0c9" name="Grotesque" hidden="false" typeId="bdc6-78da-3796-60a3" typeName="Battalion Abilities">
               <characteristics>
@@ -2395,16 +2295,6 @@
         <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">4+</characteristic>
         <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-1</characteristic>
         <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="9e82-7753-6293-a60e" name="Pyrelock Pistol" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-      <characteristics>
-        <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If the unmodified hit roll for an attack made with a Pyrelock Pistol is 6, that attack inflicts 1 mortal wound on the target in addition to any normal damage.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="09ad-19b0-4a45-cfcd" name="Spiteshield" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-      <characteristics>
-        <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If the unmodified save roll for an attack with a melee weapon that targets a unit that includes any models carrying a Spiteshield is 6, the attacking unit suffers 1 mortal wound.</characteristic>
       </characteristics>
     </profile>
     <profile id="9ce2-e6b2-c52d-b535" name="Blackshard Armour" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
@@ -2445,12 +2335,6 @@
         <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
       </characteristics>
     </profile>
-    <profile id="f0da-1e0e-52df-7e33" name="Summon K&apos;daai Fireborn" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
-      <characteristics>
-        <characteristic name="Casting Value" typeId="2508-b604-1258-a920">6</characteristic>
-        <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, you can set up a unit of up to 3 K’daai Fireborn within 18&quot; of the caster and more than 9&quot; from any enemy models. The unit is added to your army, but cannot move in the following movement phase. If the result of the casting roll was 11 or more, set up a unit of up to 6 K’daai Fireborn instead.</characteristic>
-      </characteristics>
-    </profile>
     <profile id="8611-4d98-6075-d058" name="Trample and Gore" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
       <characteristics>
         <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Add 1 to charge rolls for this unit. In addition, this unit’s Crushing Hooves have a Damage characteristic of D3 instead of 1 if this unit made a charge move in the same turn.</characteristic>
@@ -2461,12 +2345,12 @@
         <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">At the start of your movement phase, you can pick 1 friendly Deathshrieker Rocket Launcher, Magma Cannon, or Dreadquake Mortar unit within 1&quot; of this model. If you do so, that unit can use this model’s Move characteristic during that movement phase, as long as it is within 1&quot; of this model at the end of that movement phase.</characteristic>
       </characteristics>
     </profile>
-    <profile id="f2c9-120a-c352-6d6c" name="Seige Artillery" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+    <profile id="f2c9-120a-c352-6d6c" name="Siege Artillery" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
       <characteristics>
         <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">This unit cannot run or make charge moves. In addition, add 1 to save rolls for attacks made with missile weapons that target this model.</characteristic>
       </characteristics>
     </profile>
-    <profile id="52de-b365-14ee-ce66" name="Crew’s Improvised Weapons" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
+    <profile id="52de-b365-14ee-ce66" name="Improvised Weapons" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
       <characteristics>
         <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
         <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
@@ -2488,6 +2372,26 @@
       <characteristics>
         <characteristic name="Casting Value" typeId="2508-b604-1258-a920">5</characteristic>
         <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, pick 1 enemy unit within 18&quot; of the caster that is visible to them. If the enemy unit consists of one model it suffers 1 mortal wound, if it has 2 to 9 models it suffers D3 mortal wounds, and if it has 10 or more models it suffers D6 mortal wounds.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="7a48-3797-75a9-5214" name="Drummer" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+      <characteristics>
+        <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">1 model in this unit can be a Drummer. Add 1 to run rolls for a unit that includes a Drummer.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="ef78-7b59-29a0-3c32" name="Icon of Dominion Bearer" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+      <characteristics>
+        <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">1 model in this unit can be Icon of Dominion Bearer. Add 1 to the Bravery characteristic of a unit that includes an Icon of Dominion Bearer.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="41fb-ae7b-7cc8-a676" name="Spiteshield" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+      <characteristics>
+        <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If the unmodified save roll for an attack with a melee weapon that targets a unit that includes any models carrying a Spiteshield is 6, the attacking unit suffers 1 mortal wound.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="3333-01d6-ab45-2ea8" name="Pyrelock Pistol" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+      <characteristics>
+        <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If the unmodified hit roll for an attack made with a Pyrelock Pistol is 6, that attack inflicts 1 mortal wound on the target in addition to any normal damage.</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/Death - Flesh-eater Courts.cat
+++ b/Death - Flesh-eater Courts.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6d29-cde4-372b-08d3" name="Death: Flesh-eater Courts" revision="23" battleScribeVersion="2.03" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="7" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="6d29-cde4-372b-08d3" name="Death: Flesh-eater Courts" revision="24" battleScribeVersion="2.03" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="7" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="6d29-cde4-pubN65537" name="Battletome: Flesh-eater Courts 2019"/>
     <publication id="6d29-cde4-pubN65555" name="Battletome: Flesh-eater Courts"/>
@@ -486,7 +486,7 @@
     </entryLink>
     <entryLink id="c554-d2c5-8d8d-b5a0" name="Charnel Throne" hidden="false" collective="false" import="true" targetId="abc8-2377-3094-ae06" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="dd48-31cc-2053-c0df" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
+        <categoryLink id="dd48-31cc-2053-c0df" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="747d-4e40-c2c3-7c31" name="Battalion: The Arcasanctorian Guard" hidden="false" collective="false" import="true" targetId="1576-648f-5235-a453" type="selectionEntry">
@@ -3335,6 +3335,7 @@
         <categoryLink id="2ac1-24cd-91a5-7965" name="CHARNEL THRONE" hidden="false" targetId="2b69-7ea2-a20e-27d1" primary="false"/>
         <categoryLink id="35d4-42e2-d1c3-d6f3" name="FLESH-EATER COURTS" hidden="false" targetId="6b35-0508-c6cc-6592" primary="false"/>
         <categoryLink id="ce8f-2d33-01af-2b9f" name="SCENERY" hidden="false" targetId="8910-7c1d-6c74-37ff" primary="false"/>
+        <categoryLink id="59d2-8198-25bb-7f2a" name="New CategoryLink" hidden="false" targetId="bc8a-9257-1601-6d62" primary="true"/>
       </categoryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>

--- a/Destruction - Gloomspite Gitz.cat
+++ b/Destruction - Gloomspite Gitz.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="750c-157c-3186-61d3" name="Destruction - Gloomspite Gitz" revision="19" battleScribeVersion="2.03" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="46" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="750c-157c-3186-61d3" name="Destruction - Gloomspite Gitz" revision="20" battleScribeVersion="2.03" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="46" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="3323-8984-c803-feb5" name="Gloomspite Errata/Points, July 2019"/>
   </publications>
@@ -4226,17 +4226,6 @@
             <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">6+</characteristic>
           </characteristics>
         </profile>
-        <profile id="3199-05c2-f53b-7c18" name="Barbed Net" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
-          <characteristics>
-            <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
-            <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">2&quot;</characteristic>
-            <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">3</characteristic>
-            <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">4+</characteristic>
-            <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">5+</characteristic>
-            <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-</characteristic>
-            <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
-          </characteristics>
-        </profile>
         <profile id="12ff-9884-3cf4-0d2c" name="Backstabbing Mob" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Add 1 to wound rolls for attacks made with melee weapons by this unit while it has at least 15 models. Add 2 to the wound rolls made with melee weapons by this unit instead while it has at least 30 models. </characteristic>
@@ -4245,11 +4234,6 @@
         <profile id="8c2f-815a-2c10-7044" name="Moon Shields" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Add 1 to save rolls for attacks that target this unit while it has at least 10 models with Moon Shields.</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="eddf-ed87-dd7d-07fc" name="Netters" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-          <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Subtract 1 from hit rolls for attacks made by enemy models while they are within 2&quot; of any friendly models with a Barbed Net.</characteristic>
           </characteristics>
         </profile>
         <profile id="f142-d277-ff4e-a3b9" name="Moonclan Boss" hidden="false" typeId="8b8c-5816-cbdb-9763" typeName="Unit Leader">
@@ -4284,121 +4268,113 @@
         </selectionEntry>
         <selectionEntry id="67d1-4084-739e-e146" name="Gong Basher" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
-            <modifier type="set" field="6e47-7fe4-6ef0-0594" value="2">
-              <conditions>
-                <condition field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9379-5c13-bfd0-98f8" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="6e47-7fe4-6ef0-0594" value="3">
-              <conditions>
-                <condition field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9379-5c13-bfd0-98f8" type="equalTo"/>
-              </conditions>
+            <modifier type="increment" field="6e47-7fe4-6ef0-0594" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9379-5c13-bfd0-98f8" repeats="1" roundUp="false"/>
+              </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e47-7fe4-6ef0-0594" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e47-7fe4-6ef0-0594" type="max"/>
           </constraints>
-          <rules>
-            <rule id="9c3e-a141-b771-8087" name="Gong Basher" hidden="false">
-              <description>1 in every 20 models in this unit can be a Gong Basher. Add 2 to run rolls for a unit that includes any Gong Bashers.</description>
-            </rule>
-          </rules>
+          <infoLinks>
+            <infoLink id="5305-439c-4270-41dc" name="Gong Basher" hidden="false" targetId="52d6-740a-35fb-ea0d" type="profile"/>
+          </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="261e-83df-236c-7e6b" name="Standard Bearer" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="b6ba-f9c8-815d-0bc6" name="x3 Barbed Net" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
-            <modifier type="set" field="7b20-e33a-f62f-4e95" value="2">
-              <conditions>
-                <condition field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9379-5c13-bfd0-98f8" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="7b20-e33a-f62f-4e95" value="3">
-              <conditions>
-                <condition field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9379-5c13-bfd0-98f8" type="equalTo"/>
-              </conditions>
+            <modifier type="increment" field="3f90-d44d-6cfe-90bb" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9379-5c13-bfd0-98f8" repeats="1" roundUp="false"/>
+              </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b20-e33a-f62f-4e95" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f90-d44d-6cfe-90bb" type="max"/>
           </constraints>
-          <rules>
-            <rule id="8f00-594e-dd2f-63ad" name="Standard Bearer" hidden="false">
-              <description>1 in every 20 models in this unit can either be a Moonclan Flag Bearer or a Bad Moon Icon Bearer. Add 1 to the Bravery characteristic of a unit that includes any Moonclan Flag Bearers. Add 1 to save rolls for attacks made with missile weapons that target a unit that includes any Bad Moon Icon Bearers.</description>
-            </rule>
-          </rules>
-          <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="1e47-11ba-f39f-54ba" name="Stabba" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9078-8f21-8c4c-b89e" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ed3-4335-1742-c967" type="min"/>
-          </constraints>
-          <profiles>
-            <profile id="3577-e4a3-4a0d-e93b" name="Stabba" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
-              <characteristics>
-                <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
-                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
-                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">1</characteristic>
-                <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">4+</characteristic>
-                <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">4+</characteristic>
-                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-</characteristic>
-                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="b923-2056-cb35-65d5" name="Pokin&apos; Spear" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e564-3057-2aaf-098d" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f43-5df2-9b08-bf00" type="min"/>
-          </constraints>
-          <profiles>
-            <profile id="b8fa-2e36-46ed-d335" name="Pokin&apos; Spear" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
-              <characteristics>
-                <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
-                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">2&quot;</characteristic>
-                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">1</characteristic>
-                <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">5+</characteristic>
-                <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">4+</characteristic>
-                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-</characteristic>
-                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="b6ba-f9c8-815d-0bc6" name="Barbed Net" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f90-d44d-6cfe-90bb" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c45e-b3c8-25a8-e299" type="min"/>
-          </constraints>
-          <profiles>
-            <profile id="d8c3-5d5a-0855-da10" name="Barbed Net" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
-              <characteristics>
-                <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
-                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">2&quot;</characteristic>
-                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">3</characteristic>
-                <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">4+</characteristic>
-                <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">5+</characteristic>
-                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-</characteristic>
-                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
+          <infoLinks>
+            <infoLink id="0576-9cef-df5c-8999" name="Netters" hidden="false" targetId="521f-3831-fde3-1891" type="profile"/>
+            <infoLink id="0978-6665-4a9c-a255" name="Barbed Net" hidden="false" targetId="4ab6-9aab-5be6-6c51" type="profile"/>
+          </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="3a6f-1d9d-cd2f-4204" name="Weapon Option" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7ae-61b7-1667-41ec" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9165-19ac-f3f6-46d1" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="923b-d5d2-5ab9-3a12" name="Stabba" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45c5-6aea-7291-0cb3" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="76a6-191d-b5c9-fa81" name="Stabba" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
+                    <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
+                    <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">1</characteristic>
+                    <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">4+</characteristic>
+                    <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">4+</characteristic>
+                    <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-</characteristic>
+                    <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ee63-4205-f623-1c65" name="Pokin&apos; Spear" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6500-9c9e-e04f-e0aa" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="a1bb-388b-af65-6a69" name="Pokin&apos; Spear" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
+                    <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">2&quot;</characteristic>
+                    <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">1</characteristic>
+                    <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">5+</characteristic>
+                    <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">4+</characteristic>
+                    <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-</characteristic>
+                    <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="ffd3-0c3d-d28a-5826" name="Standard Bearer Option" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="increment" field="45b0-dca3-2a0e-154f" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9379-5c13-bfd0-98f8" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45b0-dca3-2a0e-154f" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="2dab-abab-242d-c5fb" name="Standard Bearer" hidden="false" targetId="b67d-49c7-e0ef-7951" type="profile"/>
+          </infoLinks>
+          <selectionEntries>
+            <selectionEntry id="bba3-bc22-22d5-1364" name="Bad Moon Icon" hidden="false" collective="false" import="true" type="upgrade"/>
+            <selectionEntry id="e2df-d361-170c-b345" name="Moon Clan Flag" hidden="false" collective="false" import="true" type="upgrade"/>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
@@ -4410,25 +4386,9 @@
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Add 1 to wound rolls for attacks made with melee weapons by this unit while it has at least 15 models. Add 2 to the wound rolls made with melee weapons by this unit instead while it has at least 30 models. </characteristic>
           </characteristics>
         </profile>
-        <profile id="60cb-b17c-1a63-f1e8" name="Barbed Net" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
-          <characteristics>
-            <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
-            <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">2&quot;</characteristic>
-            <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">3</characteristic>
-            <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">4+</characteristic>
-            <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">5+</characteristic>
-            <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-</characteristic>
-            <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
-          </characteristics>
-        </profile>
         <profile id="0167-fb84-3a56-8d87" name="Moon Shields" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Add 1 to save rolls for attacks that target this unit while it has at least 10 models with Moon Shields.</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="1f14-39fd-6c85-f8d6" name="Netters" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-          <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Subtract 1 from hit rolls for attacks made by enemy models while they are within 2&quot; of any friendly models with a Barbed Net.</characteristic>
           </characteristics>
         </profile>
         <profile id="c506-a8fb-8c61-7a98" name="Shootas" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
@@ -4464,50 +4424,18 @@
         </selectionEntry>
         <selectionEntry id="a1eb-233e-ac15-6b01" name="Gong Basher" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
-            <modifier type="set" field="6483-544c-bfb0-25e5" value="2">
-              <conditions>
-                <condition field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="11ba-3041-0d9a-e4c1" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="6483-544c-bfb0-25e5" value="3">
-              <conditions>
-                <condition field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="11ba-3041-0d9a-e4c1" type="equalTo"/>
-              </conditions>
+            <modifier type="increment" field="6483-544c-bfb0-25e5" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="11ba-3041-0d9a-e4c1" repeats="1" roundUp="false"/>
+              </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6483-544c-bfb0-25e5" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6483-544c-bfb0-25e5" type="max"/>
           </constraints>
-          <rules>
-            <rule id="3734-557b-1de3-d960" name="Gong Basher" hidden="false">
-              <description>1 in every 20 models in this unit can be a Gong Basher. Add 2 to run rolls for a unit that includes any Gong Bashers.</description>
-            </rule>
-          </rules>
-          <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="f764-b2f8-e0c6-9bb6" name="Standard Bearer" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="80dd-0cea-f24f-8fe9" value="2">
-              <conditions>
-                <condition field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="11ba-3041-0d9a-e4c1" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="80dd-0cea-f24f-8fe9" value="3">
-              <conditions>
-                <condition field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="11ba-3041-0d9a-e4c1" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80dd-0cea-f24f-8fe9" type="max"/>
-          </constraints>
-          <rules>
-            <rule id="dd10-f186-ef4c-0956" name="Standard Bearer" hidden="false">
-              <description>1 in every 20 models in this unit can either be a Moonclan Flag Bearer or a Bad Moon Icon Bearer. Add 1 to the Bravery characteristic of a unit that includes any Moonclan Flag Bearers. Add 1 to save rolls for attacks made with missile weapons that target a unit that includes any Bad Moon Icon Bearers.</description>
-            </rule>
-          </rules>
+          <infoLinks>
+            <infoLink id="0d5c-6ab8-a0a6-ce26" name="Gong Basher" hidden="false" targetId="52d6-740a-35fb-ea0d" type="profile"/>
+          </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
@@ -4556,7 +4484,47 @@
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
+        <selectionEntry id="b5ae-5deb-fb34-c2cd" name="x3 Barbed Net" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="d5c6-8b76-4cb2-f779" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="11ba-3041-0d9a-e4c1" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d5c6-8b76-4cb2-f779" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="9c29-7f62-f422-428c" name="Netters" hidden="false" targetId="521f-3831-fde3-1891" type="profile"/>
+            <infoLink id="3b6a-3156-e5a8-a7e1" name="Barbed Net" hidden="false" targetId="4ab6-9aab-5be6-6c51" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
       </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="ed8d-8cb7-e336-5944" name="Standard Bearer Option" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="increment" field="2c79-8579-3e51-a617" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="11ba-3041-0d9a-e4c1" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c79-8579-3e51-a617" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="2d2f-24f0-3b21-c86d" name="Standard Bearer" hidden="false" targetId="b67d-49c7-e0ef-7951" type="profile"/>
+          </infoLinks>
+          <selectionEntries>
+            <selectionEntry id="c9ae-39c3-2632-ed6d" name="Bad Moon Icon" hidden="false" collective="false" import="true" type="upgrade"/>
+            <selectionEntry id="debc-224d-cf02-8fa9" name="Moon Clan Flag" hidden="false" collective="false" import="true" type="upgrade"/>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
@@ -7513,6 +7481,32 @@
         <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">5</characteristic>
         <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">4+</characteristic>
         <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
+        <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-</characteristic>
+        <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="52d6-740a-35fb-ea0d" name="Gong Basher" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+      <characteristics>
+        <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">1 in every 20 models in this unit can be a Gong Basher. Add 2 to run rolls for a unit that includes any Gong Bashers.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="b67d-49c7-e0ef-7951" name="Standard Bearer" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+      <characteristics>
+        <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">1 in every 20 models in this unit can either be a Moonclan Flag Bearer or a Bad Moon Icon Bearer. Add 1 to the Bravery characteristic of a unit that includes any Moonclan Flag Bearers. Add 1 to save rolls for attacks made with missile weapons that target a unit that includes any Bad Moon Icon Bearers.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="521f-3831-fde3-1891" name="Netters" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+      <characteristics>
+        <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Subtract 1 from hit rolls for attacks made by enemy models while they are within 2&quot; of any friendly models with a Barbed Net.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="4ab6-9aab-5be6-6c51" name="Barbed Net" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
+        <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">2&quot;</characteristic>
+        <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">3</characteristic>
+        <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">4+</characteristic>
+        <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">5+</characteristic>
         <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-</characteristic>
         <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
       </characteristics>

--- a/Destruction - Ogor Mawtribes.cat
+++ b/Destruction - Ogor Mawtribes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="86c6-f50d-4d44-9d02" name="Destruction - Ogor Mawtribes" revision="9" battleScribeVersion="2.03" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="6" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="86c6-f50d-4d44-9d02" name="Destruction - Ogor Mawtribes" revision="11" battleScribeVersion="2.03" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="6" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="50c5-e039-pubN80915" name="Destruction Battletomb: Ironjawz"/>
     <publication id="50c5-e039-pubN81384" name="Destruction Battletome: Ogor Mawtribes"/>
@@ -153,6 +153,8 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="dc1f-b1c5-68f7-daa2" name="Battalion: Kin-Eater&apos;s Bully Boys" hidden="false" collective="false" import="true" targetId="216f-28d8-d012-9705" type="selectionEntry"/>
+    <entryLink id="5bdf-4ecd-85c6-8a2b" name="Hrothgorn" hidden="false" collective="false" import="true" targetId="1e4c-be9c-61ea-223d" type="selectionEntry"/>
+    <entryLink id="2f45-d6aa-271e-9cb0" name="Hrothgorn&apos;s Mantrappers" hidden="false" collective="false" import="true" targetId="71ae-1d3d-07ef-327f" type="selectionEntry"/>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="9dbb-2d1a-12d8-7faf" name="Allegiance" hidden="false" collective="false" import="true" type="upgrade">
@@ -2061,6 +2063,26 @@ At the end of your movement phase, you can set up this model anywhere on the bat
             </conditionGroup>
           </conditionGroups>
         </modifier>
+        <modifier type="remove" field="category" value="fa0c-9044-2568-fa02">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="007b-7ecb-a450-1685" type="equalTo"/>
+              </conditions>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8a1f-9238-d8fc-c565" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aeb0-4dc5-86d8-5adf" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2b36-f83e-07a7-25d6" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b850-08c3-22b0-b291" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="00c6-411a-9e15-5319" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
       </modifiers>
       <profiles>
         <profile id="3c05-c180-4336-7628" name="00-02 Wounds" hidden="false" typeId="f7ce-f73f-e66e-8a92" typeName="Damage Table: Stornhorn">
@@ -2270,6 +2292,26 @@ At the end of your movement phase, you can set up this model anywhere on the bat
     <selectionEntry id="078e-320b-e175-9d00" name="Thundertusk Beastriders" publicationId="50c5-e039-pubN81384" page="115" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set-primary" field="category" value="e9f2-765a-b7b8-ce8e">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="007b-7ecb-a450-1685" type="equalTo"/>
+              </conditions>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8a1f-9238-d8fc-c565" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aeb0-4dc5-86d8-5adf" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2b36-f83e-07a7-25d6" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b850-08c3-22b0-b291" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="00c6-411a-9e15-5319" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="remove" field="category" value="fa0c-9044-2568-fa02">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
@@ -4508,6 +4550,278 @@ In addition, if this spell is successfully cast, add 1 to save rolls for attacks
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="120.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1e4c-be9c-61ea-223d" name="Hrothgorn" hidden="false" collective="false" import="true" type="model">
+      <modifiers>
+        <modifier type="set" field="5822-cd96-eb07-21ca" value="1.0">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="71ae-1d3d-07ef-327f" type="greaterThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5822-cd96-eb07-21ca" type="min"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7592-de8b-e0b7-0b10" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="b692-e3a1-893a-e5d0" name="Hrothgorn" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
+          <characteristics>
+            <characteristic name="Move" typeId="8655-6213-2824-1752">6&quot;</characteristic>
+            <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">7</characteristic>
+            <characteristic name="Bravery" typeId="0c85-bf79-836b-759e">7</characteristic>
+            <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">5+</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="05f1-a94d-cb3e-133c" name="Masters of Ambush" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Instead of setting up this model on the battlefield, you can place it to one side and say that it is set up in ambush as a reserve unit. If you do so, when you would set up a friendly Hrothgorn’s Mantrappers unit, instead of setting up that unit on the battlefield, you can say that it is joining this model in ambush as a reserve unit. 1 unit can join this model in this way. At the end of your movement phase, you can set up this model anywhere on the battlefield more than 9&quot; from any enemy units; then set up any unit that joined this model wholly within 12&quot; of this model and more than 9&quot; from any enemy units. Any reserve units in ambush that are not set up on the battlefield before the start of the fourth battle round are destroyed. </characteristic>
+          </characteristics>
+        </profile>
+        <profile id="ffab-d16d-d46b-0f2e" name="Thrafnir" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">The first time this model is set up on the battlefield, you can set up a Frost Sabres unit consisting of a single model on the battlefield and add it to your army. Set up the Frost Sabre wholly within 3&quot; of this model and more than 9&quot; from any enemy units.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink id="014e-7817-bae2-c4d1" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
+        <categoryLink id="1421-7c65-d072-e515" name="DESTRUCTION" hidden="false" targetId="d963-a5fb-c348-2371" primary="false"/>
+        <categoryLink id="96d1-4824-d203-8eda" name="OGOR MAWTRIBES" hidden="false" targetId="2246-c381-2650-4ca2" primary="false"/>
+        <categoryLink id="a7f2-4827-4233-a0fa" name="OGOR" hidden="false" targetId="1422-e165-b7d0-b2d9" primary="false"/>
+        <categoryLink id="d4df-16e8-71fa-a9d2" name="HERO" hidden="false" targetId="4e0e-664d-51ea-0929" primary="false"/>
+        <categoryLink id="68a8-d17f-d07f-6678" name="ICEBROW HUNTER" hidden="false" targetId="4d3b-7454-3924-4b1c" primary="false"/>
+        <categoryLink id="cfe4-9ee1-b27e-daf7" name="BEASTCLAW RAIDERS" hidden="false" targetId="9eb7-64ab-dc1d-56e0" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="da3c-88c6-0a63-4d87" name="Trap Launcher" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90c3-b3ed-e17e-1c6e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c39c-3f6a-23be-2bb8" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="56f9-ec9d-0e8c-00c0" name="Trap Launcher" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Type" typeId="655c-362e-a663-3e50">Missile</characteristic>
+                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">12&quot;</characteristic>
+                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">1</characteristic>
+                <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">4+</characteristic>
+                <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
+                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-</characteristic>
+                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">D3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="31fc-92d0-b5d2-f12e" name="Gulping Bite" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c409-8fd1-c8d3-60ff" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0950-838d-3b2f-4f39" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="0491-02c7-989c-a33e" name="Gulping Bite" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
+                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
+                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">1</characteristic>
+                <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">3+</characteristic>
+                <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
+                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-</characteristic>
+                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">D3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="feba-659d-9364-fced" name="Hunting Knife" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a56c-0268-10b8-7c24" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e836-eaa8-69fa-e3c3" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="790b-1160-957b-2d14" name="Hunting Knife" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
+                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
+                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">4</characteristic>
+                <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">3+</characteristic>
+                <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
+                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-</characteristic>
+                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2b17-f015-3f47-800d" name="Thrafnir" page="" hidden="false" collective="false" import="true" type="unit">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e032-14aa-614d-cb9e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2044-4e65-994a-62b7" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="5819-c9f3-d588-87d5" name="Thrafnir" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
+              <characteristics>
+                <characteristic name="Move" typeId="8655-6213-2824-1752">9&quot;</characteristic>
+                <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">2</characteristic>
+                <characteristic name="Bravery" typeId="0c85-bf79-836b-759e">5</characteristic>
+                <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">6+</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="0f19-26e2-b7e5-bb4e" name="Their Master&apos;s Voice (Thrafnir)" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+              <characteristics>
+                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Add 3 to charge rolls for this unit if it is wholly within 16&quot; of a friendly ICEBROW HUNTER when the charge roll is made.
+In addition, add 2 to the Bravery characteristic of this unit while it is wholly within 16&quot; of a friendly ICEBROW HUNTER.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <categoryLinks>
+            <categoryLink id="5105-455e-cbb5-a099" name="New CategoryLink" hidden="false" targetId="d963-a5fb-c348-2371" primary="false"/>
+            <categoryLink id="7325-261c-7b30-f209" name="New CategoryLink" hidden="false" targetId="c9df-ea2a-e040-9cf4" primary="false"/>
+            <categoryLink id="ba17-b620-b5fe-9de2" name="New CategoryLink" hidden="false" targetId="2fe3-f56d-11c0-c6eb" primary="false"/>
+            <categoryLink id="5067-a74d-9780-9479" name="OGOR MAWTRIBES" hidden="false" targetId="2246-c381-2650-4ca2" primary="false"/>
+            <categoryLink id="1f6b-59df-89ff-6dc4" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
+          </categoryLinks>
+          <selectionEntries>
+            <selectionEntry id="ba45-c317-b387-88e8" name="Elongated Fangs" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1068-e7ff-ff21-c08d" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7cc-4147-e882-170c" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="0195-542a-ae68-9c92" name="Elongated Fangs" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
+                    <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
+                    <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">3</characteristic>
+                    <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">4+</characteristic>
+                    <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
+                    <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-1</characteristic>
+                    <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="points" value="160.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="71ae-1d3d-07ef-327f" name="Hrothgorn&apos;s Mantrappers" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="ea5c-9dbe-a8c1-259a" value="1.0">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1e4c-be9c-61ea-223d" type="greaterThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="04c9-e0ef-e3b2-75b5" type="max"/>
+        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ea5c-9dbe-a8c1-259a" type="min"/>
+      </constraints>
+      <profiles>
+        <profile id="f9b4-7151-929a-4a9c" name="Hrothgorn&apos;s Mantrappers" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
+          <characteristics>
+            <characteristic name="Move" typeId="8655-6213-2824-1752">5&quot;</characteristic>
+            <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">1</characteristic>
+            <characteristic name="Bravery" typeId="0c85-bf79-836b-759e">4</characteristic>
+            <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">6+</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="297f-28e9-884d-77c8" name="Bushwakka&apos;s Trap" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0"> You receive 1 Bushwakka’s Trap marker if this unit in your army.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="c517-2ec2-ecb3-1a80" name="Shivering Gnoblars" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">This unit is not considered a BEASTCLAW RAIDERS unit for the purposes of the ‘Grasp of the Everwinter’ battle trait.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="cbc0-615b-9f1c-63c5" name="Hidden Trap" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">At the start of the first hero phase, if this unit is in your army, you can pick 1 terrain feature or objective that is not wholly within enemy territory and say that it is trapped. If you do so, place 1 Bushwakka’s Trap marker next to that terrain feature or objective.
+The first time a unit finishes a move within 1&quot; of the trapped terrain feature or objective, roll a dice. On a 2+, that unit suffers D6 mortal wounds and the Bushwakka’s Trap marker is removed.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="2b1e-348c-18bd-4adc" name="Here You Go Boss!" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">While a friendly Hrothgorn is within 3&quot; of this unit while it includes Quiv, add 1 to the Attacks characteristic of his Trap Launcher.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="4168-68ff-e41d-555b" name="Hrothgorn&apos;s Mantrappers" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Hrothgorn’s Mantrappers is a unit that has 3 models. Bushwakka, Quiv, and Luggit &amp; Thwak are each armed with a Motley Assortment of Weapons and Sharp Stuff.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink id="202e-391f-d971-ab89" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
+        <categoryLink id="6c46-9b92-317d-9fb4" name="OGOR MAWTRIBES" hidden="false" targetId="2246-c381-2650-4ca2" primary="false"/>
+        <categoryLink id="d2bc-ac29-5eb0-d101" name="BEASTCLAW RAIDERS" hidden="false" targetId="9eb7-64ab-dc1d-56e0" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="7586-0d51-1c37-8282" name="Sharp Stuff" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aceb-31a5-d1eb-acdf" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3bb-6df0-d989-e948" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="4863-059d-f663-dfd2" name="Sharp Stuff" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Type" typeId="655c-362e-a663-3e50">Missile</characteristic>
+                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">8&quot;</characteristic>
+                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">1</characteristic>
+                <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">4+</characteristic>
+                <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">5+</characteristic>
+                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-</characteristic>
+                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3c5b-84a3-23ef-361f" name="Motley Assortment of Weapons" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d05e-533b-826b-a26e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5cb5-854b-c3ae-556b" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="cb10-d50d-f6fc-bf52" name="Motley Assortment of Weapons" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
+                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
+                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">1</characteristic>
+                <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">5+</characteristic>
+                <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">5+</characteristic>
+                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-</characteristic>
+                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Destruction - Orruk Warclans.cat
+++ b/Destruction - Orruk Warclans.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="5419-b58f-5a39-0bfe" name="Destruction - Orruk Warclans" revision="8" battleScribeVersion="2.03" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="6" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="5419-b58f-5a39-0bfe" name="Destruction - Orruk Warclans" revision="9" battleScribeVersion="2.03" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="6" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="7e25-33bb-pubN65537" name="Destruction Battletome: Bonesplitterz"/>
     <publication id="7e25-33bb-pubN82863" name="Age of Sigmar: The Rules"/>
@@ -22,11 +22,18 @@
         <characteristicType id="2c27-08ec-8a3a-6a3e" name="Monster Hunters Result"/>
       </characteristicTypes>
     </profileType>
-    <profileType id="f9d0-9e02-bee9-1f0c" name="Maw-Krusha">
+    <profileType id="f9d0-9e02-bee9-1f0c" name="Wounds Suffered">
       <characteristicTypes>
         <characteristicType id="77de-c752-9ffa-f346" name="Move"/>
         <characteristicType id="bb09-d22f-2469-d46c" name="Mighty Fists"/>
         <characteristicType id="f62d-4c93-271b-b6ec" name="Destructive Bulk"/>
+      </characteristicTypes>
+    </profileType>
+    <profileType id="793b-d7fd-01ea-a61b" name="Wounds Suffered">
+      <characteristicTypes>
+        <characteristicType id="af21-cdc8-56f1-d7a0" name="Move"/>
+        <characteristicType id="1498-3aa2-c8ba-3aa0" name="Boulder Fists"/>
+        <characteristicType id="8706-d34b-5dcc-3926" name="Stompin&apos; Feet"/>
       </characteristicTypes>
     </profileType>
   </profileTypes>
@@ -119,6 +126,7 @@
     <entryLink id="6b0d-f8e7-f32f-2453" name="Gordrakk, the Fist of Gork" hidden="false" collective="false" import="true" targetId="8911-e844-4a80-59f4" type="selectionEntry"/>
     <entryLink id="4312-2b73-da85-d1fd" name="Savage Orruks Arrowboys" hidden="false" collective="false" import="true" targetId="c5d3-2af4-16d0-77cf" type="selectionEntry"/>
     <entryLink id="65ac-88ea-84b8-ff38" name="Super Battalion: Brawl" hidden="false" collective="false" import="true" targetId="5d3f-0d36-6692-069c" type="selectionEntry"/>
+    <entryLink id="a2b5-6000-cd5d-5d79" name="Rogue Idol" hidden="false" collective="false" import="true" targetId="2eee-3937-3870-783a" type="selectionEntry"/>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="9dbb-2d1a-12d8-7faf" name="Allegiance" hidden="false" collective="false" import="true" type="upgrade">
@@ -2278,35 +2286,35 @@ If the mortal wounds inflicted by this model’s Massively Destructive Bulk mean
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e31-ceab-591b-53ac" type="max"/>
           </constraints>
           <profiles>
-            <profile id="c985-1df4-16fa-346b" name="00-03" hidden="false" typeId="f9d0-9e02-bee9-1f0c" typeName="Maw-Krusha">
+            <profile id="c985-1df4-16fa-346b" name="00-03" hidden="false" typeId="f9d0-9e02-bee9-1f0c" typeName="Wounds Suffered">
               <characteristics>
                 <characteristic name="Move" typeId="77de-c752-9ffa-f346">12&quot;</characteristic>
                 <characteristic name="Mighty Fists" typeId="bb09-d22f-2469-d46c">9</characteristic>
                 <characteristic name="Destructive Bulk" typeId="f62d-4c93-271b-b6ec">9 dice</characteristic>
               </characteristics>
             </profile>
-            <profile id="6508-ff1a-1cd7-9378" name="04-06" hidden="false" typeId="f9d0-9e02-bee9-1f0c" typeName="Maw-Krusha">
+            <profile id="6508-ff1a-1cd7-9378" name="04-06" hidden="false" typeId="f9d0-9e02-bee9-1f0c" typeName="Wounds Suffered">
               <characteristics>
                 <characteristic name="Move" typeId="77de-c752-9ffa-f346">10&quot;</characteristic>
                 <characteristic name="Mighty Fists" typeId="bb09-d22f-2469-d46c">8</characteristic>
                 <characteristic name="Destructive Bulk" typeId="f62d-4c93-271b-b6ec">8 dice</characteristic>
               </characteristics>
             </profile>
-            <profile id="3872-59a9-2782-4892" name="13+" hidden="false" typeId="f9d0-9e02-bee9-1f0c" typeName="Maw-Krusha">
+            <profile id="3872-59a9-2782-4892" name="13+" hidden="false" typeId="f9d0-9e02-bee9-1f0c" typeName="Wounds Suffered">
               <characteristics>
                 <characteristic name="Move" typeId="77de-c752-9ffa-f346">4&quot;</characteristic>
                 <characteristic name="Mighty Fists" typeId="bb09-d22f-2469-d46c">5</characteristic>
                 <characteristic name="Destructive Bulk" typeId="f62d-4c93-271b-b6ec">5 dice</characteristic>
               </characteristics>
             </profile>
-            <profile id="89f1-9eae-1f37-3bab" name="10-12" hidden="false" typeId="f9d0-9e02-bee9-1f0c" typeName="Maw-Krusha">
+            <profile id="89f1-9eae-1f37-3bab" name="10-12" hidden="false" typeId="f9d0-9e02-bee9-1f0c" typeName="Wounds Suffered">
               <characteristics>
                 <characteristic name="Move" typeId="77de-c752-9ffa-f346">6&quot;</characteristic>
                 <characteristic name="Mighty Fists" typeId="bb09-d22f-2469-d46c">6</characteristic>
                 <characteristic name="Destructive Bulk" typeId="f62d-4c93-271b-b6ec">6 dice</characteristic>
               </characteristics>
             </profile>
-            <profile id="b9d3-2862-0369-8494" name="07-09" hidden="false" typeId="f9d0-9e02-bee9-1f0c" typeName="Maw-Krusha">
+            <profile id="b9d3-2862-0369-8494" name="07-09" hidden="false" typeId="f9d0-9e02-bee9-1f0c" typeName="Wounds Suffered">
               <characteristics>
                 <characteristic name="Move" typeId="77de-c752-9ffa-f346">8&quot;</characteristic>
                 <characteristic name="Mighty Fists" typeId="bb09-d22f-2469-d46c">7</characteristic>
@@ -2769,41 +2777,41 @@ If the mortal wounds inflicted by this model’s Destructive Bulk mean there are
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="9bfd-6baa-8e8a-0093" name="Maw-Krusha Damage Table" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="9bfd-6baa-8e8a-0093" name="Damage Table" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03a9-0921-9467-5849" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3dbc-3603-d702-1312" type="max"/>
           </constraints>
           <profiles>
-            <profile id="9cab-9edf-1314-c701" name="00-03" hidden="false" typeId="f9d0-9e02-bee9-1f0c" typeName="Maw-Krusha">
+            <profile id="9cab-9edf-1314-c701" name="00-03" hidden="false" typeId="f9d0-9e02-bee9-1f0c" typeName="Wounds Suffered">
               <characteristics>
                 <characteristic name="Move" typeId="77de-c752-9ffa-f346">12&quot;</characteristic>
                 <characteristic name="Mighty Fists" typeId="bb09-d22f-2469-d46c">8</characteristic>
                 <characteristic name="Destructive Bulk" typeId="f62d-4c93-271b-b6ec">8 dice</characteristic>
               </characteristics>
             </profile>
-            <profile id="f9a2-9757-aa03-49a8" name="04-06" hidden="false" typeId="f9d0-9e02-bee9-1f0c" typeName="Maw-Krusha">
+            <profile id="f9a2-9757-aa03-49a8" name="04-06" hidden="false" typeId="f9d0-9e02-bee9-1f0c" typeName="Wounds Suffered">
               <characteristics>
                 <characteristic name="Move" typeId="77de-c752-9ffa-f346">10&quot;</characteristic>
                 <characteristic name="Mighty Fists" typeId="bb09-d22f-2469-d46c">7</characteristic>
                 <characteristic name="Destructive Bulk" typeId="f62d-4c93-271b-b6ec">7 dice</characteristic>
               </characteristics>
             </profile>
-            <profile id="d77f-7a78-b0c8-fa11" name="13+" hidden="false" typeId="f9d0-9e02-bee9-1f0c" typeName="Maw-Krusha">
+            <profile id="d77f-7a78-b0c8-fa11" name="13+" hidden="false" typeId="f9d0-9e02-bee9-1f0c" typeName="Wounds Suffered">
               <characteristics>
                 <characteristic name="Move" typeId="77de-c752-9ffa-f346">4&quot;</characteristic>
                 <characteristic name="Mighty Fists" typeId="bb09-d22f-2469-d46c">4</characteristic>
                 <characteristic name="Destructive Bulk" typeId="f62d-4c93-271b-b6ec">4 dice</characteristic>
               </characteristics>
             </profile>
-            <profile id="4f9a-a5c7-1227-ecc8" name="10-12" hidden="false" typeId="f9d0-9e02-bee9-1f0c" typeName="Maw-Krusha">
+            <profile id="4f9a-a5c7-1227-ecc8" name="10-12" hidden="false" typeId="f9d0-9e02-bee9-1f0c" typeName="Wounds Suffered">
               <characteristics>
                 <characteristic name="Move" typeId="77de-c752-9ffa-f346">6&quot;</characteristic>
                 <characteristic name="Mighty Fists" typeId="bb09-d22f-2469-d46c">5</characteristic>
                 <characteristic name="Destructive Bulk" typeId="f62d-4c93-271b-b6ec">5 dice</characteristic>
               </characteristics>
             </profile>
-            <profile id="c08c-5a41-1930-c582" name="07-09" hidden="false" typeId="f9d0-9e02-bee9-1f0c" typeName="Maw-Krusha">
+            <profile id="c08c-5a41-1930-c582" name="07-09" hidden="false" typeId="f9d0-9e02-bee9-1f0c" typeName="Wounds Suffered">
               <characteristics>
                 <characteristic name="Move" typeId="77de-c752-9ffa-f346">8&quot;</characteristic>
                 <characteristic name="Mighty Fists" typeId="bb09-d22f-2469-d46c">6</characteristic>
@@ -3693,6 +3701,141 @@ In addition, add 1 to hit rolls and wound rolls for attacks made with this unit�
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="180.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2eee-3937-3870-783a" name="Rogue Idol" hidden="false" collective="false" import="true" type="model">
+      <profiles>
+        <profile id="1c5a-5563-5e34-8ead" name="Rogue Idol" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
+          <characteristics>
+            <characteristic name="Move" typeId="8655-6213-2824-1752">*</characteristic>
+            <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">16</characteristic>
+            <characteristic name="Bravery" typeId="0c85-bf79-836b-759e">10</characteristic>
+            <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">4+</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="ff56-8ce1-6ab6-6e22" name="Spirit of the Waaagh!" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">You can re-roll hit rolls of 1 for attacks made by this model if it made a charge move in the same turn.
+</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="5584-d0fd-c6ac-8bad" name="Livin’ Idol" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Add 1 to casting rolls for friendly ORRUK WIZARDS and friendly GROT WIZARDS while they are within 6&quot; of any friendly models with this ability. In addition, add 1 to the Bravery characteristic of friendly ORRUK and friendly GROT units while they are wholly within 18&quot; of any friendly models with this ability.
+</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="10c2-a9e9-99ae-2dac" name="Avalanche!" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If this model is slain, before removing the model from play, roll a dice for each unit within 3&quot; of this model. On a 4+, that unit suffers D3 mortal wounds. This model is then removed from play.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="4918-bfc5-5031-1c23" name="Da Big ’Un" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Roll a dice each time you allocate a wound or mortal wound to this model. On a 5+, that wound or mortal wound is negated.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="9939-5474-cdff-b74e" name="Rubble and Ruin" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">At the end of the combat phase, roll a dice for each enemy unit within 3&quot; of this model. On a 4+, that unit suffers 1 mortal wound. 
+
+</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink id="2ed0-cd44-a2bb-7cc7" name="BONESPLITTERZ" hidden="false" targetId="9db3-55f3-706c-01bd" primary="false"/>
+        <categoryLink id="862e-cd70-ca37-4740" name="DESTRUCTION" hidden="false" targetId="d963-a5fb-c348-2371" primary="false"/>
+        <categoryLink id="54f9-b4eb-997b-1369" name="IRONJAWZ" hidden="false" targetId="157e-e19c-bc6e-6d49" primary="false"/>
+        <categoryLink id="3374-92e6-7249-0662" name="MONSTER" hidden="false" targetId="1959-9f6a-3056-913a" primary="false"/>
+        <categoryLink id="d6d6-a7ee-94e8-7802" name="Orruk" hidden="false" targetId="f643-013c-7718-007d" primary="false"/>
+        <categoryLink id="4215-b02d-c62f-b702" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="4a20-d4f7-e5eb-fcd8" name="Damage Table" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e0d-cba8-0db3-3b15" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7609-2aba-a9ee-de41" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="5750-4f96-ca94-2a29" name="00-04" hidden="false" typeId="793b-d7fd-01ea-a61b" typeName="Wounds Suffered">
+              <characteristics>
+                <characteristic name="Move" typeId="af21-cdc8-56f1-d7a0">10&quot;</characteristic>
+                <characteristic name="Boulder Fists" typeId="1498-3aa2-c8ba-3aa0">2+</characteristic>
+                <characteristic name="Stompin&apos; Feet" typeId="8706-d34b-5dcc-3926">10</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="6ab0-09ca-df76-8e06" name="05-08" hidden="false" typeId="793b-d7fd-01ea-a61b" typeName="Wounds Suffered">
+              <characteristics>
+                <characteristic name="Move" typeId="af21-cdc8-56f1-d7a0">8&quot;</characteristic>
+                <characteristic name="Boulder Fists" typeId="1498-3aa2-c8ba-3aa0">3+</characteristic>
+                <characteristic name="Stompin&apos; Feet" typeId="8706-d34b-5dcc-3926">8</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="dbe2-db92-75ff-40c2" name="09-11" hidden="false" typeId="793b-d7fd-01ea-a61b" typeName="Wounds Suffered">
+              <characteristics>
+                <characteristic name="Move" typeId="af21-cdc8-56f1-d7a0">6&quot;</characteristic>
+                <characteristic name="Boulder Fists" typeId="1498-3aa2-c8ba-3aa0">3+</characteristic>
+                <characteristic name="Stompin&apos; Feet" typeId="8706-d34b-5dcc-3926">6</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="4ace-97cc-a5c8-3308" name="12-13" hidden="false" typeId="793b-d7fd-01ea-a61b" typeName="Wounds Suffered">
+              <characteristics>
+                <characteristic name="Move" typeId="af21-cdc8-56f1-d7a0">4&quot;</characteristic>
+                <characteristic name="Boulder Fists" typeId="1498-3aa2-c8ba-3aa0">4+</characteristic>
+                <characteristic name="Stompin&apos; Feet" typeId="8706-d34b-5dcc-3926">4</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="47a3-7279-4d3b-7f68" name="14+" hidden="false" typeId="793b-d7fd-01ea-a61b" typeName="Wounds Suffered">
+              <characteristics>
+                <characteristic name="Move" typeId="af21-cdc8-56f1-d7a0">2&quot;</characteristic>
+                <characteristic name="Boulder Fists" typeId="1498-3aa2-c8ba-3aa0">5+</characteristic>
+                <characteristic name="Stompin&apos; Feet" typeId="8706-d34b-5dcc-3926">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+        </selectionEntry>
+        <selectionEntry id="1193-d1ee-146f-7d6a" name="Boulder Fists" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c94b-a8ab-5f7c-2f33" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e754-3bd1-9048-3fe3" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="8055-ffff-3197-ade6" name="Boulder Fists" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
+                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">3&quot;</characteristic>
+                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">2</characteristic>
+                <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">3+</characteristic>
+                <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">*</characteristic>
+                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-2</characteristic>
+                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">D6</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+        </selectionEntry>
+        <selectionEntry id="b34f-062f-7ff0-afbc" name="Stompin&apos; Feet" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f836-e529-a717-1810" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8dd3-0fc6-97ce-eb50" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="6abf-2ae9-2291-a46c" name="Stompin&apos; Feet" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
+                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">2&quot;</characteristic>
+                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">*</characteristic>
+                <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">3+</characteristic>
+                <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
+                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-2</characteristic>
+                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="points" value="400.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>


### PR DESCRIPTION
>> Legion of Azgorh
Minor rule tweaks; has this thing even been updated since it came out? Points are updated, but it seems like rules haven't been. I probably missed some stuff, too, but we'll see when I go over it again sometime soon.

>> Flesh-Eater Courts
Re-categorized Charnel Throne to "Scenery"

>> Gloomspite Gitz
Minimized some rule references, added options for Standard Bearers, Stabbas/Spears

>>Orruk Warclans
Added Rogue Idol with points and rules updates post-Warclans release

>> Ogor Mawtribes
Fixed the Behemoth battleline bit, added Hrothgorn's Mantrappers