### PR TITLE
Initial Lumineth catalog.

### DIFF
--- a/Age of Sigmar.gst
+++ b/Age of Sigmar.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="e51d-b1a3-75fc-dc33" name="Age of Sigmar" revision="61" battleScribeVersion="2.03" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="e51d-b1a3-75fc-dc33" name="Age of Sigmar" revision="62" battleScribeVersion="2.03" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <publications>
     <publication id="e51d-b1a3-pubEC" name="The General&apos;s Handbook"/>
     <publication id="e51d-b1a3-pubEQ" name="Core Rules"/>
@@ -223,6 +223,7 @@
     <categoryEntry id="798c-6e4e-1793-2fd9" name="STORMVAULT" hidden="false"/>
     <categoryEntry id="e7f6-c6e9-1728-1807" name="PENUMBRAL ENGINE" hidden="false"/>
     <categoryEntry id="bc8a-9257-1601-6d62" name="Scenery" hidden="false"/>
+    <categoryEntry id="a64e-c067-e836-3c21" name="LUMINETH REALM-LORDS" hidden="false"/>
   </categoryEntries>
   <forceEntries>
     <forceEntry id="36b7-ee1e-0855-f23f" name="**Pitched Battle**" hidden="false">

--- a/Order - Lumineth.cat
+++ b/Order - Lumineth.cat
@@ -1,0 +1,489 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="3a4f-b93a-26ba-a2d1" name="Order - Lumineth" revision="8" battleScribeVersion="2.03" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="62" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <categoryEntries>
+    <categoryEntry id="8856-e945-3c75-2c04" name="AURALAN WARDENS" hidden="false"/>
+    <categoryEntry id="e242-d4cd-5ab5-5586" name="VANARI" hidden="false"/>
+    <categoryEntry id="cdcd-ad32-37d3-ce1d" name="DAWNRIDERS" hidden="false"/>
+    <categoryEntry id="fb8f-1a73-179d-e1f2" name="LIGHT OF ELTHARION" hidden="false"/>
+    <categoryEntry id="a5b9-bc50-8b42-8152" name="AELF" hidden="false"/>
+  </categoryEntries>
+  <entryLinks>
+    <entryLink id="b19d-f049-a9f9-1026" name="Vanari Dawnriders" hidden="false" collective="false" import="true" targetId="3747-0abb-f1c7-a143" type="selectionEntry"/>
+    <entryLink id="2249-c919-580f-d2b3" name="Vanari Auralan Wardens" hidden="false" collective="false" import="true" targetId="3b53-dbf5-8f73-b10d" type="selectionEntry"/>
+    <entryLink id="15ba-1dcf-2955-7e5f" name="The Light of Eltharion" hidden="false" collective="false" import="true" targetId="723c-27b0-a0d6-c7df" type="selectionEntry"/>
+    <entryLink id="1620-2c95-6697-d21a" name="Allegiance" hidden="false" collective="false" import="true" targetId="6548-ab09-c1f0-3594" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f79c-e161-4ad3-876d" type="instanceOf"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="81f0-4826-0ecb-2e1b" name="New CategoryLink" hidden="false" targetId="87e8-c095-f059-5f7b" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+  </entryLinks>
+  <sharedSelectionEntries>
+    <selectionEntry id="6548-ab09-c1f0-3594" name="Allegiance" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f81d-d938-a9cb-1f37" type="min"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4adf-7f11-9b84-c6d1" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="0467-18b7-a67c-1edc" name="New CategoryLink" hidden="false" targetId="87e8-c095-f059-5f7b" primary="true"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="59bb-d9cb-4259-fbca" name="Allegiance" hidden="false" collective="false" import="true" defaultSelectionEntryId="8eb2-2489-29ec-c757">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0414-e83b-2b2f-1d7d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="02a5-fc5d-5b0b-c88a" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="8eb2-2489-29ec-c757" name="Allegiance: Lumineth" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e635-e34d-bb4f-b84c" name="Allegiance: *Order*" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3747-0abb-f1c7-a143" name="Vanari Dawnriders" hidden="false" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="7d69-76d9-0dd8-cc8c" name="Lances of the Dawn" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If this unit made a charge move in the same turn, add 1 to wound rolls for attacks made with this unit’s Sunmetal Lances and improve the Rend characteristic of that weapon by 1.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="b5fa-c1d8-94e8-2f85" name="Sunmetal Weapons" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If the unmodified hit roll for an attack made with a Sunmetal Lance is 6, that attack inflicts 1 mortal wound on the target and the attack sequence ends (do not make a wound or save roll).</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="ab78-33df-8c0d-6717" name="Deathly Furrows" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">At the start of the combat phase, you can say that this unit will use its Deathly Furrows ability. If you do so, in that phase, you can either add 1 to the Attacks characteristic of this unit’s melee weapons, but it can only target units that have a Wounds characteristic of 1 or 2 and do not have a mount, or you can add 2 to the Attacks characteristic of this unit’s melee weapons, but it can only target units that have a Wounds characteristic of 1 and do not have a mount.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="cf97-01e3-db71-6b54" name="Vanari Dawnriders (Magic)" hidden="false" typeId="f55d-ee3a-1597-110f" typeName="Magic">
+          <characteristics>
+            <characteristic name="Cast/Unbind" typeId="8294-f605-2c0f-8f92">1/1</characteristic>
+            <characteristic name="Spells Known" typeId="dc9c-47d3-6931-859c">Power of Hysh</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="22eb-a773-315c-f7c5" name="Vanari Dawnriders" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
+          <characteristics>
+            <characteristic name="Move" typeId="8655-6213-2824-1752">14&quot;</characteristic>
+            <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">2</characteristic>
+            <characteristic name="Bravery" typeId="0c85-bf79-836b-759e">7</characteristic>
+            <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">4+</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="49c6-fca0-d00f-455c" name="Power of Hysh" hidden="false" targetId="d1d7-5f61-4f19-5b5f" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="94f1-bd4f-5e87-7a78" name="AELF" hidden="false" targetId="a5b9-bc50-8b42-8152" primary="false"/>
+        <categoryLink id="0045-13bd-5d7a-3fb3" name="DAWNRIDERS" hidden="false" targetId="cdcd-ad32-37d3-ce1d" primary="false"/>
+        <categoryLink id="aadd-3ac0-22cb-3c0d" name="Other" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
+        <categoryLink id="03dc-cd5b-95a3-b082" name="VANARI" hidden="false" targetId="e242-d4cd-5ab5-5586" primary="false"/>
+        <categoryLink id="fff2-db03-a8e4-c46a" name="ORDER" hidden="false" targetId="b970-b3bf-e1a4-a6fc" primary="false"/>
+        <categoryLink id="3819-b27e-aa5f-06e4" name="LUMINETH REALM-LORDS" hidden="false" targetId="a64e-c067-e836-3c21" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="9187-7c51-b869-afee" name="5 Vanari Dawnriders" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="312b-3ab4-870e-bf1d" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1221-de05-a4e9-309d" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="points" value="130.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3f62-7e04-356a-274a" name="Steedmaster" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="96fe-d7cb-e494-c06c" value="0.0"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96fe-d7cb-e494-c06c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c799-22ba-d298-8e49" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="fc78-32bc-3168-7348" name="Steedmaster" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+              <characteristics>
+                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">1 model in this unit can be a Steedmaster. A Steedmaster is armed with a Sunmetal Lance and a Guardian’s Sword.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <selectionEntries>
+            <selectionEntry id="2754-c373-df58-7799" name="Guardian&apos;s Sword" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="374c-6b86-d51a-992d" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0fa5-1588-1a7d-0bcd" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="9de3-8239-ec0f-69e2" name="Guardian&apos;s Sword" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
+                    <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
+                    <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">2</characteristic>
+                    <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">3+</characteristic>
+                    <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">4+</characteristic>
+                    <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-1</characteristic>
+                    <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ae76-2c33-447f-252a" name="Dashing Hooves" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7714-cfe8-5bd4-d01b" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c74-8bb4-f431-2dbc" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="4f11-7634-fd0a-b1ce" name="Dashing Hooves" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
+                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
+                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">2</characteristic>
+                <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">4+</characteristic>
+                <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">4+</characteristic>
+                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-</characteristic>
+                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b4f4-455b-5110-1807" name="Sunmetal Lance" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6fe6-9006-1d37-b412" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b38-5a9c-c351-ff9d" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="606e-72ef-f75b-aef3" name="Sunmetal Lance" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
+                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">2&quot;</characteristic>
+                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">1</characteristic>
+                <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">3+</characteristic>
+                <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">4+</characteristic>
+                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-</characteristic>
+                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="4f6f-efa1-dff7-3494" name="Standard Bearer" hidden="false" collective="false" import="true" targetId="4375-bc92-f8f9-9836" type="selectionEntry">
+          <modifiers>
+            <modifier type="increment" field="0d1b-4d2b-27c9-b9f9" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d1b-4d2b-27c9-b9f9" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4375-bc92-f8f9-9836" name="Standard Bearer" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="1d81-2a3e-98e9-a840" value="0.0"/>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d81-2a3e-98e9-a840" type="min"/>
+      </constraints>
+      <profiles>
+        <profile id="a4e1-9870-96bd-9a44" name="Standard Bearer" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">1 in every 5 models in this unit can be a Standard Bearer. You can re-roll battleshock tests for units that include any Standard Bearers.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3b53-dbf5-8f73-b10d" name="Vanari Auralan Wardens" hidden="false" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="6a0a-ce17-bcc9-2250" name="Vanari Auralan Wardens" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
+          <characteristics>
+            <characteristic name="Move" typeId="8655-6213-2824-1752">6&quot;</characteristic>
+            <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">1</characteristic>
+            <characteristic name="Bravery" typeId="0c85-bf79-836b-759e">6</characteristic>
+            <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">4+</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="16fb-4d21-9ff7-6655" name="Wall of Blades" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If the target unit made a charge move in the same turn, add 1 to wound rolls for attacks made with this unit’s Warden’s Pikes and improve the Rend characteristic of that weapon by 1.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="4b22-6134-b50c-631a" name="High Warden (Magic)" hidden="false" typeId="f55d-ee3a-1597-110f" typeName="Magic">
+          <characteristics>
+            <characteristic name="Cast/Unbind" typeId="8294-f605-2c0f-8f92">1/1</characteristic>
+            <characteristic name="Spells Known" typeId="dc9c-47d3-6931-859c">Power of Hysh</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="f4bb-2e51-79a1-ec96" name="Power of Hysh" hidden="false" targetId="d1d7-5f61-4f19-5b5f" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="e367-3a48-cc51-19e3" name="AELF" hidden="false" targetId="a5b9-bc50-8b42-8152" primary="false"/>
+        <categoryLink id="8118-a582-3062-f060" name="ORDER" hidden="false" targetId="b970-b3bf-e1a4-a6fc" primary="false"/>
+        <categoryLink id="2108-38df-a7cd-a685" name="AURALAN WARDENS" hidden="false" targetId="8856-e945-3c75-2c04" primary="false"/>
+        <categoryLink id="1350-0624-75c0-3f2f" name="VANARI" hidden="false" targetId="e242-d4cd-5ab5-5586" primary="false"/>
+        <categoryLink id="a04a-9ae6-bf8d-e3e3" name="LUMINETH REALM-LORDS" hidden="false" targetId="a64e-c067-e836-3c21" primary="false"/>
+        <categoryLink id="8c7e-2254-c7e7-99e8" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="3647-edfd-338b-b854" name="10 Vanari Auralan Wardens" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7187-4c14-0a56-4b5f" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d136-b5bf-2a84-118a" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="points" value="120.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b4fb-b0b9-41d6-022f" name="High Warden" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5196-5b00-6214-f729" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2aad-965a-e2c2-1750" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="9b02-cfcd-5ee4-16ac" name="High Warden" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+              <characteristics>
+                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">1 model in this unit can be a High Warden. A High Warden is armed with a Champion’s Blade instead of a Warden’s Pike.</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="80f9-e5b9-da90-708d" name="Moonfire Flask" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+              <characteristics>
+                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Once per battle, at the start of the combat phase, you can pick 1 enemy unit within 3&quot; of this unit’s High Warden and roll a dice. On a 2+, that enemy unit suffers D3 mortal wounds.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <selectionEntries>
+            <selectionEntry id="d6cc-57e2-81d0-e7a5" name="Champion&apos;s Blade" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9cbf-f502-e0a9-9cbf" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8697-46c5-1316-faaf" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="3d12-e56d-aea3-40a4" name="Champion&apos;s Blade" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
+                    <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
+                    <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">2</characteristic>
+                    <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">3+</characteristic>
+                    <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">4+</characteristic>
+                    <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-1</characteristic>
+                    <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1893-d618-6e53-cfed" name="Warden&apos;s Pike" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d960-97ad-200b-5c65" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="463c-e66c-b5b1-a220" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="9878-9084-15bc-3107" name="Warden&apos;s Pike" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
+                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">3&quot;</characteristic>
+                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">2</characteristic>
+                <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">3+</characteristic>
+                <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">4+</characteristic>
+                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-</characteristic>
+                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="c5c6-649f-ea5b-3a86" name="Sunmetal Weapons" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+              <characteristics>
+                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If the unmodified hit roll for an attack made with a Warden&apos;s Pike is 6, that attack inflicts 1 mortal wound on the target and the attack sequence ends (do not make a wound or save roll).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="723c-27b0-a0d6-c7df" name="The Light of Eltharion" hidden="false" collective="false" import="true" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d116-2f07-ea43-eedd" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43ea-5f4a-6542-5d2b" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="6c44-9c99-f3cc-ed17" name="The Light of Eltharion" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
+          <characteristics>
+            <characteristic name="Move" typeId="8655-6213-2824-1752">6&quot;</characteristic>
+            <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">7</characteristic>
+            <characteristic name="Bravery" typeId="0c85-bf79-836b-759e">10</characteristic>
+            <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">3+</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="af93-ba36-2239-259f" name="Searing Darts of Light" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">In your shooting phase, you can pick 1 enemy unit within 18&quot; of this model that is visible to them and roll a dice. On a 1, nothing happens. On a 2-4, that unit suffers D3 mortal wounds. On a 5+, that unit suffers D6 mortal wounds.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="a9da-2428-52f7-807a" name="Supreme Swordmaster" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Ignore negative modifiers when making hit rolls for attacks made by this model. In addition, if the unmodified hit roll for an attack made by this model is 6, that attack scores 2 hits on the target instead of 1. Make a wound and save roll for each hit.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="dccd-0166-6d9f-daed" name="Unflinching Valour" hidden="false" typeId="f71f-b0a4-730e-ced3" typeName="Command Abilities">
+          <characteristics>
+            <characteristic name="Command Ability Details" typeId="1b71-4c83-4e8c-093f">You can use this command ability at the start of the battleshock phase. If you do so, pick 1 friendly model with this command ability. Until the end of that phase, all friendly Lumineth Realm-lords units wholly within 24&quot; of that model are treated as having a Bravery characteristic of 10.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink id="cc8a-4c6d-fbd9-b681" name="AELF" hidden="false" targetId="a5b9-bc50-8b42-8152" primary="false"/>
+        <categoryLink id="1b6a-170b-ab6f-b573" name="HERO" hidden="false" targetId="4e0e-664d-51ea-0929" primary="false"/>
+        <categoryLink id="6239-018b-7f9e-ca07" name="LIGHT OF ELTHARION" hidden="false" targetId="fb8f-1a73-179d-e1f2" primary="false"/>
+        <categoryLink id="78d1-8519-c7e1-336e" name="ORDER" hidden="false" targetId="b970-b3bf-e1a4-a6fc" primary="false"/>
+        <categoryLink id="c0e7-747c-e956-0336" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
+        <categoryLink id="6b12-b7c5-31e9-ae0e" name="LUMINETH REALM-LORDS" hidden="false" targetId="a64e-c067-e836-3c21" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="2943-da0b-c4c5-689e" name="Fangsword of Eltharion" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac0a-d6d6-d850-bd94" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95a5-1cd0-5221-d28c" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="489c-66ac-d066-e7f5" name="Fangsword of Eltharion" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
+                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
+                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">4</characteristic>
+                <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">2+</characteristic>
+                <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
+                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-3</characteristic>
+                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">D3</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="3003-7119-06d7-fca5" name="Fangsword of Eltharion" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+              <characteristics>
+                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Add 1 to wound rolls for attacks made with this model’s Fangsword of Eltharion if this model made a charge move in the same turn. In addition, if the unmodified wound roll for an attack made with this model’s Fangsword of Eltharion is 6, that attack inflicts 1 mortal wound on the target in addition to any normal damage.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="548b-ae95-7800-80c8" name="Celennari Blade" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="192d-8dc9-3851-9c2a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2bbe-a85a-04e8-4552" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="43c5-00a6-53de-723a" name="Celennari Blade" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
+                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
+                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">2</characteristic>
+                <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">2+</characteristic>
+                <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
+                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-1</characteristic>
+                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">D3</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="a6ab-6080-a1e2-87db" name="Celennari Blade" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+              <characteristics>
+                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">At the start of the combat phase, you can pick 1 enemy Hero within 3&quot; of this model. If you do so, add 1 to the damage inflicted by successful attacks made with this model’s Celennari Blade that target that Hero in that phase.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="db74-4a2c-be82-c812" name="General" hidden="false" collective="false" import="true" targetId="ad2a-0c5e-e657-4141" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="220.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ad2a-0c5e-e657-4141" name="General" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1ad-6fd4-e06a-ac02" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="b09c-620c-d61e-3c39" name="New CategoryLink" hidden="false" targetId="b745-17c4-8fbf-8b04" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedProfiles>
+    <profile id="d1d7-5f61-4f19-5b5f" name="Power of Hysh" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
+      <characteristics>
+        <characteristic name="Casting Value" typeId="2508-b604-1258-a920">6</characteristic>
+        <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, until your next hero phase, the Sunmetal Weapons ability for the caster and/or the unit they are part of causes mortal wounds to be inflicted on an unmodified hit roll of 5+ instead of 6. Any number of Lumineth Realm-lords Wizards can attempt to cast Power of Hysh in the same hero phase.</characteristic>
+      </characteristics>
+    </profile>
+  </sharedProfiles>
+</catalogue>


### PR DESCRIPTION
First pass of a Lumineth catalog.  Initial release only includes units from the box set.   Allegience abilities and additional units are TBD as I do not have a copy of the Battletome.

Address issue #1376.
