### PR TITLE
Fix: Typos - KO (Data)

### DIFF
--- a/Order - Kharadron Overlords - Data.cat
+++ b/Order - Kharadron Overlords - Data.cat
@@ -186,7 +186,7 @@
         </profile>
         <profile id="13b3-1cf2-4e73-9a55" name="Aetherstorm" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">In your hero phase, you can pick 1 enemy unit within 36&quot; of this model that is visible to them and can fly, and roll a dice. On a 1-2 nothing happen. On a 3-5 halve the Move characteristic of that unit until your next hero phase, and that unit suffers D3 mortal wounds.</characteristic>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">In your hero phase, you can pick 1 enemy unit within 36&quot; of this model that is visible to them and can fly, and roll a dice. On a 1-2 nothing happens. On a 3-5 halve the Move characteristic of that unit until your next hero phase, and that unit suffers D3 mortal wounds.</characteristic>
           </characteristics>
         </profile>
         <profile id="e76a-dc9b-9ebb-b510" name="Read the Winds" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
@@ -636,9 +636,9 @@ In addition, roll a dice before you allocate a wound or mortal wound to a friend
         </profile>
         <profile id="4d7e-5fbf-f376-1c8c" name="Flying Transport (Frigate)" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">This model can fly, and can be garrisoned by up to 15 friendly MARINE models even though it is not a terrain feature. 
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">This model can fly, and can be garrisoned by up to 15 friendly MARINE models even though it is not a terrain feature.
 
-Halve this model’s Move characteristic and it cannot Fly High if there are 11 or more models in its garrison. Units cannot join or leave this model’s garrison if it has made a move or flown high in the same phase (they can join or leave before it does so). Models in the garrison are not counted towards gaining control of an objective. 
+Halve this model’s Move characteristic and it cannot Fly High if there are 11 or more models in its garrison. Units cannot join or leave this model’s garrison if it has made a move or flown high in the same phase (they can join or leave before it does so). Models in the garrison are not counted towards gaining control of an objective.
 
 An attack made by a weapon that is in range of this model can target either this model or a unit in its garrison. If this model is destroyed, before it is removed from play, roll 1 dice for each model in its garrison. On a 1, that model is slain. Set up any surviving models wholly within 3&quot; of this model and more than 3&quot; from any enemy units.</characteristic>
           </characteristics>
@@ -827,9 +827,9 @@ An attack made by a weapon that is in range of this model can target either this
         </profile>
         <profile id="a2d7-4ff9-9b80-d20a" name="Flying Transport (Ironclad)" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">This model can fly, and can be garrisoned by up to 25 friendly MARINE models even though it is not a terrain feature. 
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">This model can fly, and can be garrisoned by up to 25 friendly MARINE models even though it is not a terrain feature.
 
-Halve this model’s Move characteristic and it cannot Fly High if there are 16 or more models in its garrison. Units cannot join or leave this model’s garrison if it has made a move or flown high in the same phase (they can join or leave before it does so). Models in the garrison are not counted towards gaining control of an objective. 
+Halve this model’s Move characteristic and it cannot Fly High if there are 16 or more models in its garrison. Units cannot join or leave this model’s garrison if it has made a move or flown high in the same phase (they can join or leave before it does so). Models in the garrison are not counted towards gaining control of an objective.
 
 An attack made by a weapon that is in range of this model can target either this model or a unit in its garrison. If this model is destroyed, before it is removed from play, roll 1 dice for each model in its garrison. On a 1, that model is slain. Set up any surviving models wholly within 3&quot; of this model and more than 3&quot; from any enemy units.</characteristic>
           </characteristics>
@@ -1109,7 +1109,7 @@ An attack made by a weapon that is in range of this model can target either this
       <profiles>
         <profile id="a74e-eaf3-7fc7-ff61" name="Focused Fire" hidden="false" typeId="bdc6-78da-3796-60a3" typeName="Battalion Abilities">
           <characteristics>
-            <characteristic name="Battalion Ability Details" typeId="08e0-9ead-1dbe-c801">At the start of your shooting phase, you can pick 1 enemy unit for this battalion to focus fire on. If you do so, you can re-roll hit rolls of 1 for attacks made by unuts from this battalion that target that unit in that phase.</characteristic>
+            <characteristic name="Battalion Ability Details" typeId="08e0-9ead-1dbe-c801">At the start of your shooting phase, you can pick 1 enemy unit for this battalion to focus fire on. If you do so, you can re-roll hit rolls of 1 for attacks made by units from this battalion that target that unit in that phase.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -2346,7 +2346,7 @@ An attack made by a weapon that is in range of this model can target either this
                   <characteristics>
                     <characteristic name="Battle Trait Details" typeId="9fdd-b4b1-5f7a-0970">Each KHARADRON OVERLORDS HERO, SKYVESSEL, and KHARADRON OVERLORDS unit with 10 or more models starts a battle with 1 share of aether-gold.
 
-Once per phase, you can say that 1 unit from your army that has any shares of aether-gold will spend 1 of them. If you do so, subtract 1 rom that unit&apos;s Bravery characteristic for the rest of the battle, but you can pick a triumph it is eligible to use an immediately apply its effect to that unit. Ignore any restrictions on a triumph that say it can only be used once per battle if you pay to use it with a share of aether-gold.</characteristic>
+Once per phase, you can say that 1 unit from your army that has any shares of aether-gold will spend 1 of them. If you do so, subtract 1 from that unit&apos;s Bravery characteristic for the rest of the battle, but you can pick a triumph it is eligible to use and immediately apply its effect to that unit. Ignore any restrictions on a triumph that say it can only be used once per battle if you pay to use it with a share of aether-gold.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -2419,7 +2419,7 @@ Once per phase, you can say that 1 unit from your army that has any shares of ae
                       <profiles>
                         <profile id="a3fa-aa72-81c4-532f" name="Deeds, Not Words" hidden="false" typeId="c137-4d1f-9d1a-524d" typeName="Battle Trait">
                           <characteristics>
-                            <characteristic name="Battle Trait Details" typeId="9fdd-b4b1-5f7a-0970">Add 1 to wound rolls for attacks made with melee weapons for friendly SKYFARERS units that made a charge move in the same turn, and add 1 to hit rolls for attacks made with mlee weapons by friendly SKYWARDEN units that made a charge move in the same turn.</characteristic>
+                            <characteristic name="Battle Trait Details" typeId="9fdd-b4b1-5f7a-0970">Add 1 to wound rolls for attacks made with melee weapons for friendly SKYFARERS units that made a charge move in the same turn, and add 1 to hit rolls for attacks made with melee weapons by friendly SKYWARDEN units that made a charge move in the same turn.</characteristic>
                           </characteristics>
                         </profile>
                       </profiles>
@@ -2535,7 +2535,7 @@ Once per phase, you can say that 1 unit from your army that has any shares of ae
                       <profiles>
                         <profile id="2056-8ef1-dcf8-7006" name="Fearsome Raiders" hidden="false" typeId="c137-4d1f-9d1a-524d" typeName="Battle Trait">
                           <characteristics>
-                            <characteristic name="Battle Trait Details" typeId="9fdd-b4b1-5f7a-0970">Subtract 1 from the bravery characteristic of enemy units whil they are within 6&quot; of any friendly BARAK-MHORNAR units.</characteristic>
+                            <characteristic name="Battle Trait Details" typeId="9fdd-b4b1-5f7a-0970">Subtract 1 from the bravery characteristic of enemy units while they are within 6&quot; of any friendly BARAK-MHORNAR units.</characteristic>
                           </characteristics>
                         </profile>
                       </profiles>
@@ -2671,7 +2671,7 @@ Once per phase, you can say that 1 unit from your army that has any shares of ae
                               <profiles>
                                 <profile id="bd3b-036e-39f7-d80a" name="Settle the Grudges" hidden="false" typeId="011e-0bf8-5310-7fc6" typeName="1) Artycle">
                                   <characteristics>
-                                    <characteristic name="Details" typeId="f6f3-7ccb-f03b-76de">After armies are set up but beforre the first battle round begins, pick 1 enemy unit. You can re-roll hit rolls of 1 for attacks made by friendly KHARADRON OVERLORDS units that target that unit.</characteristic>
+                                    <characteristic name="Details" typeId="f6f3-7ccb-f03b-76de">After armies are set up but before the first battle round begins, pick 1 enemy unit. You can re-roll hit rolls of 1 for attacks made by friendly KHARADRON OVERLORDS units that target that unit.</characteristic>
                                   </characteristics>
                                 </profile>
                               </profiles>
@@ -2707,7 +2707,7 @@ Once per phase, you can say that 1 unit from your army that has any shares of ae
                               <profiles>
                                 <profile id="9993-a04a-4755-893a" name="Trust To Your Guns" hidden="false" typeId="302d-acaa-ec63-d964" typeName="2) Amendment">
                                   <characteristics>
-                                    <characteristic name="Details" typeId="b7b8-2932-5eae-1dd0">Add 1 to the Bravery characteristic of friendly KHARADRON OVERLORDS unuts while they are more than 3&quot; from enemy units.</characteristic>
+                                    <characteristic name="Details" typeId="b7b8-2932-5eae-1dd0">Add 1 to the Bravery characteristic of friendly KHARADRON OVERLORDS units while they are more than 3&quot; from enemy units.</characteristic>
                                   </characteristics>
                                 </profile>
                               </profiles>
@@ -4002,7 +4002,7 @@ Once per phase, you can say that 1 unit from your army that has any shares of ae
               <profiles>
                 <profile id="b774-1bc0-323c-2654" name="Diviner" hidden="false" typeId="c749-bae4-71a8-0c36" typeName="Command Trait">
                   <characteristics>
-                    <characteristic name="Command Trait Details" typeId="ee96-6f3a-e5ca-2350">After armies are set up, pick 1 terrain feature or objective. Do not take battleshock tests for friendly KHARADRON OVERLORDS units while they are whollywithin 12&quot; of that terrain feature or objective.</characteristic>
+                    <characteristic name="Command Trait Details" typeId="ee96-6f3a-e5ca-2350">After armies are set up, pick 1 terrain feature or objective. Do not take battleshock tests for friendly KHARADRON OVERLORDS units while they are wholly within 12&quot; of that terrain feature or objective.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>

--- a/Order - Kharadron Overlords - Data.cat
+++ b/Order - Kharadron Overlords - Data.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="3981-271d-5871-845b" name="Order - Kharadron Overlords - Data" revision="8" battleScribeVersion="2.03" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="true" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="61" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="3981-271d-5871-845b" name="Order - Kharadron Overlords - Data" revision="9" battleScribeVersion="2.03" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="true" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="61" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="e23c-3deb-pubN65537" name="Order Battletome: Kharadron Overlords"/>
     <publication id="e23c-3deb-pubN66862" name="Order Official FAQs and errata, Version 1.4"/>


### PR DESCRIPTION
Fixes some typos and grammar issues in the Kharadron Overlords data file.

My VSC also trimmed a couple of lines of whitespace. 