### PR TITLE
Adjust mortal wounds from Grudgehammer

### DIFF
--- a/Order - Kharadron Overlords - Data.cat
+++ b/Order - Kharadron Overlords - Data.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="3981-271d-5871-845b" name="Order - Kharadron Overlords - Data" revision="9" battleScribeVersion="2.03" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="true" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="61" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="3981-271d-5871-845b" name="Order - Kharadron Overlords - Data" revision="10" battleScribeVersion="2.03" authorName="https://gitter.im/BSData/warhammer-age-of-sigmar" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="true" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="61" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="e23c-3deb-pubN65537" name="Order Battletome: Kharadron Overlords"/>
     <publication id="e23c-3deb-pubN66862" name="Order Official FAQs and errata, Version 1.4"/>
@@ -4609,7 +4609,7 @@ Once per phase, you can say that 1 unit from your army that has any shares of ae
               <profiles>
                 <profile id="16ae-bceb-ddda-b3bf" name="Grudgehammer" hidden="false" typeId="0ac4-aacb-2481-8e72" typeName="Artefact">
                   <characteristics>
-                    <characteristic name="Artefact Details" typeId="0918-c47a-d84e-c0cf">Pick 1 of the bearer&apos;s melee weapons. Add 1 to hit rolls for attacks made by that weapon. In addition, if the unmodified wound roll for an attack made by that weapon targets an enemy unit which was picked for the Chronicle of Grudges artycle is 6, that attack inflicts 3 mortal wounds on the target in addition to any normal damage.</characteristic>
+                    <characteristic name="Artefact Details" typeId="0918-c47a-d84e-c0cf">Pick 1 of the bearer&apos;s melee weapons. Add 1 to hit rolls for attacks made by that weapon. In addition, if the unmodified wound roll for an attack made by that weapon targets an enemy unit which was picked for the Chronicle of Grudges artycle is 6, that attack inflicts D3 mortal wounds on the target in addition to any normal damage.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>


### PR DESCRIPTION
Change 3 Mortal Wounds to D3 Mortal Wounds for Grudgehammer artefact.

Source: Page 73, KO Battletome (2nd Version)