### PR TITLE
Allow any GG hero to take Jaws or Mork CT or artefacts.

### DIFF
--- a/Destruction - Gloomspite Gitz.cat
+++ b/Destruction - Gloomspite Gitz.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="750c-157c-3186-61d3" name="Destruction - Gloomspite Gitz" revision="34" battleScribeVersion="2.03" authorName="" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="64" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="750c-157c-3186-61d3" name="Destruction - Gloomspite Gitz" revision="35" battleScribeVersion="2.03" authorName="" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="64" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="3323-8984-c803-feb5" name="Gloomspite Errata/Points, July 2019"/>
     <publication id="0dee-8846-061a-5504" name="White Dwarf - Issue 455" shortName="White Dwarf" publisher="Issue 455" publicationDate="August 2020"/>
@@ -6779,7 +6779,6 @@
                 <conditionGroup type="or">
                   <conditions>
                     <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e623-c44c-8ce4-b443" type="equalTo"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="647a-69d4-fe9c-2491" type="notInstanceOf"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -6913,7 +6912,6 @@
                 <conditionGroup type="or">
                   <conditions>
                     <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e623-c44c-8ce4-b443" type="equalTo"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="647a-69d4-fe9c-2491" type="notInstanceOf"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>


### PR DESCRIPTION
Resolve #1584.   While not very fluffy, the Jaws of Mork rules as written allow any GG hero to take JoM artefacts and command traits rather than just GG heroes with a squig.