### PR TITLE
Auralan Legion battalion improvements.

### DIFF
--- a/Order - Lumineth.cat
+++ b/Order - Lumineth.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="3a4f-b93a-26ba-a2d1" name="Order - Lumineth" revision="18" battleScribeVersion="2.03" authorName="" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="64" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="3a4f-b93a-26ba-a2d1" name="Order - Lumineth" revision="19" battleScribeVersion="2.03" authorName="" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="64" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="695b-f18a-c0a9-6bf4" name="Order Battletome - Lumineth Realm-Lords"/>
   </publications>
@@ -1799,7 +1799,7 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="65ab-346a-c374-c535" name="2. Vanari Auralan Sentinels and Vanari Auralan Wardens (2-4)" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="65ab-346a-c374-c535" name="2. Vanari Auralan Sentinels (2-4)" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a27-a28d-4c75-bec2" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d86f-2b16-64ad-e9bb" type="max"/>
@@ -1829,7 +1829,15 @@
                 <categoryLink id="c4d5-346b-338e-cb43" name="Other" hidden="false" targetId="065e-fda7-fd27-1f40" primary="false"/>
               </categoryLinks>
             </entryLink>
-            <entryLink id="9f5b-975c-55ce-9cdc" name="Vanari Auralan Wardens" hidden="false" collective="false" import="true" targetId="3b53-dbf5-8f73-b10d" type="selectionEntry">
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6725-ec77-ded4-59c5" name="3. Vanari Auralan Wardens (equal number as Sentinels)" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f5d0-182f-017e-2743" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a0bd-f9f2-fb42-9b6d" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="1db6-cac9-69f3-be45" name="Vanari Auralan Wardens" hidden="false" collective="false" import="true" targetId="3b53-dbf5-8f73-b10d" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
@@ -1838,10 +1846,10 @@
                 </modifier>
               </modifiers>
               <categoryLinks>
-                <categoryLink id="6223-0c00-c22e-3bd1" name="Battleline" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="false"/>
+                <categoryLink id="8ce3-d8d5-0f98-dd95" name="Battleline" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="false"/>
               </categoryLinks>
             </entryLink>
-            <entryLink id="40d8-d19d-bd2e-7f66" name="Vanari Auralan Wardens" hidden="false" collective="false" import="true" targetId="3b53-dbf5-8f73-b10d" type="selectionEntry">
+            <entryLink id="5d46-5a45-cdaa-25f5" name="Vanari Auralan Wardens" hidden="false" collective="false" import="true" targetId="3b53-dbf5-8f73-b10d" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
@@ -1850,7 +1858,7 @@
                 </modifier>
               </modifiers>
               <categoryLinks>
-                <categoryLink id="af8c-ce19-bae8-7405" name="Other" hidden="false" targetId="065e-fda7-fd27-1f40" primary="false"/>
+                <categoryLink id="2d27-abaf-e2c5-01d4" name="Other" hidden="false" targetId="065e-fda7-fd27-1f40" primary="false"/>
               </categoryLinks>
             </entryLink>
           </entryLinks>


### PR DESCRIPTION
Work around to improve Auralan Legion battalion unit requirements.  Address #1589 .

Logic is not fully correct as the battalion requires and equal number of Sentinels and Wardens.   Not sure how to express this rule in Battlescribe.   Instead, the battalion requires you add 2-4 units of both and leaves the equal-number constraint to the author.