### PR TITLE
Fix Gristlegore behemoths.

### DIFF
--- a/Death - Flesh-eater Courts.cat
+++ b/Death - Flesh-eater Courts.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6d29-cde4-372b-08d3" name="Death - Flesh-eater Courts" revision="34" battleScribeVersion="2.03" authorName="https://discord.gg/4MSsD7" authorContact="" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="65" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="6d29-cde4-372b-08d3" name="Death - Flesh-eater Courts" revision="35" battleScribeVersion="2.03" authorName="https://discord.gg/4MSsD7" authorContact="" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="66" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="6d29-cde4-pubN65537" name="Battletome: Flesh-eater Courts 2019"/>
     <publication id="6d29-cde4-pubN65555" name="Battletome: Flesh-eater Courts"/>
@@ -412,7 +412,6 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="053f-4624-a1b0-920f" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false"/>
         <categoryLink id="5d3c-f493-a301-7b5e" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true"/>
       </categoryLinks>
     </entryLink>
@@ -430,7 +429,6 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="d679-86c1-e1cd-4a78" name="New CategoryLink" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false"/>
         <categoryLink id="c6d4-28b3-bd64-ca66" name="New CategoryLink" hidden="false" targetId="e9f2-765a-b7b8-ce8e" primary="true"/>
       </categoryLinks>
     </entryLink>


### PR DESCRIPTION
Fix #1719 
Remove behemoth tag for Terrorgheist and Zombie Dragon when using Gristlegore.