### PR TITLE
Grim Garland wording fix

### DIFF
--- a/Death - Flesh-eater Courts.cat
+++ b/Death - Flesh-eater Courts.cat
@@ -4520,7 +4520,7 @@
           <profiles>
             <profile id="de6d-673e-78d8-6025" name="The Grim Garland" hidden="false" typeId="0ac4-aacb-2481-8e72" typeName="Artefact">
               <characteristics>
-                <characteristic name="Artefact Details" typeId="0918-c47a-d84e-c0cf">Subtract 2 from the Bravery of enemy units while they are within 6&quot; of the bearer.</characteristic>
+                <characteristic name="Artefact Details" typeId="0918-c47a-d84e-c0cf">Subtract 2 from the Bravery characteristic of enemy units while they are within 6&quot; of the bearer.</characteristic>
               </characteristics>
             </profile>
           </profiles>

--- a/Death - Flesh-eater Courts.cat
+++ b/Death - Flesh-eater Courts.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6d29-cde4-372b-08d3" name="Death - Flesh-eater Courts" revision="36" battleScribeVersion="2.03" authorName="https://discord.gg/4MSsD7" authorContact="" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="68" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="6d29-cde4-372b-08d3" name="Death - Flesh-eater Courts" revision="37" battleScribeVersion="2.03" authorName="https://discord.gg/4MSsD7" authorContact="" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="68" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="6d29-cde4-pubN65537" name="Battletome: Flesh-eater Courts 2019"/>
     <publication id="6d29-cde4-pubN65555" name="Battletome: Flesh-eater Courts"/>


### PR DESCRIPTION
The details of the grim garland did not match the wording in the book. The word characteristic was missing.