### PR TITLE
Grave Guard As Battleline Bugfix

### DIFF
--- a/Death - Data.cat
+++ b/Death - Data.cat
@@ -3632,6 +3632,7 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
+        <entryLink id="e415-97f5-fcc6-c90e" name="General" hidden="false" collective="false" import="true" targetId="88d2-d540-0573-3402" type="selectionEntry"/>
         <entryLink id="263d-3380-554d-c604" name="Spell Lores" hidden="false" collective="false" import="true" targetId="8417-93fc-9562-a748" type="selectionEntryGroup"/>
         <entryLink id="a8cf-ace8-9f5f-c872" name="Artefacts" hidden="false" collective="false" import="true" targetId="a2c1-3fba-5acb-d560" type="selectionEntryGroup"/>
         <entryLink id="bc2a-f212-ebd8-5726" name="Command Traits" hidden="false" collective="false" import="true" targetId="eda1-7945-4fea-a145" type="selectionEntryGroup"/>

--- a/Death - Data.cat
+++ b/Death - Data.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="e37a-2f18-f168-6ed3" name="Death Data" revision="57" battleScribeVersion="2.03" authorName="" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="true" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="87" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="e37a-2f18-f168-6ed3" name="Death Data" revision="58" battleScribeVersion="2.03" authorName="" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="true" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="87" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="e320-d5ec-pubN65537" name="Battletome: Legions of Nagash and Battletome: Nighthaunt"/>
     <publication id="e320-d5ec-pubN65555" name="Battletome: Nighthaunt"/>
@@ -1441,14 +1441,9 @@
     <selectionEntry id="ae91-dab3-c987-4379" name="Grave Guard" publicationId="7a08-6611-3750-6469" page="125" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set-primary" field="category" value="e9f2-765a-b7b8-ce8e">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="68a9-4974-9c08-1a4b" type="equalTo"/>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="66e5-e8a2-5bf7-b4a1" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="77b2-a277-acc5-3b11" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <profiles>
@@ -1588,14 +1583,9 @@
         <entryLink id="93b3-5769-3e1a-b7d3" name="Reinforced" hidden="false" collective="false" import="true" targetId="0a8d-cde8-fba1-6c0d" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="95f2-6885-756f-9ea5" value="2.0">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="68a9-4974-9c08-1a4b" type="equalTo"/>
-                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="66e5-e8a2-5bf7-b4a1" type="equalTo"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="77b2-a277-acc5-3b11" type="equalTo"/>
+              </conditions>
             </modifier>
           </modifiers>
           <costs>
@@ -3642,7 +3632,6 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="e415-97f5-fcc6-c90e" name="General" hidden="false" collective="false" import="true" targetId="88d2-d540-0573-3402" type="selectionEntry"/>
         <entryLink id="263d-3380-554d-c604" name="Spell Lores" hidden="false" collective="false" import="true" targetId="8417-93fc-9562-a748" type="selectionEntryGroup"/>
         <entryLink id="a8cf-ace8-9f5f-c872" name="Artefacts" hidden="false" collective="false" import="true" targetId="a2c1-3fba-5acb-d560" type="selectionEntryGroup"/>
         <entryLink id="bc2a-f212-ebd8-5726" name="Command Traits" hidden="false" collective="false" import="true" targetId="eda1-7945-4fea-a145" type="selectionEntryGroup"/>
@@ -4043,7 +4032,6 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="66e5-e8a2-5bf7-b4a1" name="General" hidden="false" collective="false" import="true" targetId="88d2-d540-0573-3402" type="selectionEntry"/>
         <entryLink id="5316-8a48-62ea-2cc6" name="Artefacts" hidden="false" collective="false" import="true" targetId="a2c1-3fba-5acb-d560" type="selectionEntryGroup"/>
         <entryLink id="9d6f-f2a2-3c76-bc31" name="Command Traits" hidden="false" collective="false" import="true" targetId="eda1-7945-4fea-a145" type="selectionEntryGroup"/>
         <entryLink id="90ad-2cb9-9f14-9acb" name="Battalions" hidden="false" collective="false" import="true" targetId="9df7-269b-fa20-74b2" type="selectionEntryGroup"/>
@@ -4056,6 +4044,7 @@
             </modifier>
           </modifiers>
         </entryLink>
+        <entryLink id="e410-470f-53da-722c" name="General" hidden="false" collective="false" import="true" targetId="77b2-a277-acc5-3b11" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="115.0"/>
@@ -4139,7 +4128,6 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="68a9-4974-9c08-1a4b" name="General" hidden="false" collective="false" import="true" targetId="88d2-d540-0573-3402" type="selectionEntry"/>
         <entryLink id="ba81-c19c-b1c6-5df2" name="Artefacts" hidden="false" collective="false" import="true" targetId="a2c1-3fba-5acb-d560" type="selectionEntryGroup"/>
         <entryLink id="530e-8424-79ec-5404" name="Command Traits" hidden="false" collective="false" import="true" targetId="eda1-7945-4fea-a145" type="selectionEntryGroup"/>
         <entryLink id="8774-a056-7f86-6167" name="Battalions" hidden="false" collective="false" import="true" targetId="9df7-269b-fa20-74b2" type="selectionEntryGroup"/>
@@ -4152,6 +4140,7 @@
             </modifier>
           </modifiers>
         </entryLink>
+        <entryLink id="960a-d30a-eb0a-7325" name="General" hidden="false" collective="false" import="true" targetId="77b2-a277-acc5-3b11" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="130.0"/>
@@ -10530,6 +10519,35 @@ If the enemy had a Wounds characteristic of 2 or less:
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="77b2-a277-acc5-3b11" name="General" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24d6-500b-7e3f-1470" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5c1d-d0be-e5cf-9fe3" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="88f2-a5fd-1371-927b" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5bdb-45f2-1aef-6a82" type="max"/>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9fda-b772-7ba8-b4a4" type="min"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="bb7b-9894-5c0d-f408" name="Endless Legions" hidden="false" targetId="327f-b655-f2de-3d3b" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="d84d-6ab1-fd23-4358" name="New CategoryLink" hidden="false" targetId="b745-17c4-8fbf-8b04" primary="false"/>
+      </categoryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>

--- a/Death - Data.cat
+++ b/Death - Data.cat
@@ -4032,6 +4032,7 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
+        <entryLink id="e410-470f-53da-722c" name="General" hidden="false" collective="false" import="true" targetId="77b2-a277-acc5-3b11" type="selectionEntry"/>
         <entryLink id="5316-8a48-62ea-2cc6" name="Artefacts" hidden="false" collective="false" import="true" targetId="a2c1-3fba-5acb-d560" type="selectionEntryGroup"/>
         <entryLink id="9d6f-f2a2-3c76-bc31" name="Command Traits" hidden="false" collective="false" import="true" targetId="eda1-7945-4fea-a145" type="selectionEntryGroup"/>
         <entryLink id="90ad-2cb9-9f14-9acb" name="Battalions" hidden="false" collective="false" import="true" targetId="9df7-269b-fa20-74b2" type="selectionEntryGroup"/>
@@ -4044,7 +4045,6 @@
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="e410-470f-53da-722c" name="General" hidden="false" collective="false" import="true" targetId="77b2-a277-acc5-3b11" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="115.0"/>
@@ -4128,6 +4128,7 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
+        <entryLink id="960a-d30a-eb0a-7325" name="General" hidden="false" collective="false" import="true" targetId="77b2-a277-acc5-3b11" type="selectionEntry"/>
         <entryLink id="ba81-c19c-b1c6-5df2" name="Artefacts" hidden="false" collective="false" import="true" targetId="a2c1-3fba-5acb-d560" type="selectionEntryGroup"/>
         <entryLink id="530e-8424-79ec-5404" name="Command Traits" hidden="false" collective="false" import="true" targetId="eda1-7945-4fea-a145" type="selectionEntryGroup"/>
         <entryLink id="8774-a056-7f86-6167" name="Battalions" hidden="false" collective="false" import="true" targetId="9df7-269b-fa20-74b2" type="selectionEntryGroup"/>
@@ -4140,7 +4141,6 @@
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="960a-d30a-eb0a-7325" name="General" hidden="false" collective="false" import="true" targetId="77b2-a277-acc5-3b11" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="130.0"/>


### PR DESCRIPTION
Fixes an issue where grave guard would always appear as battleline once a general was selected.
In this cat file general is a link, and therefore the condition check for wight king was true no matter what leader was the general. In order to fix this i created a second general entry linked only to wight kings.