### PR TITLE
Remove old wrath of the everchose categories from Nurgle.

### DIFF
--- a/Chaos Data.cat
+++ b/Chaos Data.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="0339-0157-6910-d29c" name="Chaos Data" revision="151" battleScribeVersion="2.03" authorName="" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="true" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="138" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="0339-0157-6910-d29c" name="Chaos Data" revision="152" battleScribeVersion="2.03" authorName="" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="true" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="140" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="c9b2-1fe6-pubN65537" name="Battletome: Beasts of Chaos"/>
     <publication id="6894-a70d-pubN65537" name="Chaos Battletome: Maggotkin of Nurgle"/>
@@ -857,9 +857,6 @@ At the start of the battleshock phase, for each disease point that an enemy unit
                   </characteristics>
                 </profile>
               </profiles>
-              <categoryLinks>
-                <categoryLink id="0c35-6f37-7b89-1565" name="Wrath of the Everchosen" hidden="false" targetId="2890-73a3-1898-f20a" primary="false"/>
-              </categoryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
@@ -875,9 +872,6 @@ At the start of the battleshock phase, for each disease point that an enemy unit
                   </characteristics>
                 </profile>
               </profiles>
-              <categoryLinks>
-                <categoryLink id="ccb2-1a00-14d6-f01a" name="Wrath of the Everchosen" hidden="false" targetId="2890-73a3-1898-f20a" primary="false"/>
-              </categoryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
@@ -893,9 +887,6 @@ At the start of the battleshock phase, for each disease point that an enemy unit
                   </characteristics>
                 </profile>
               </profiles>
-              <categoryLinks>
-                <categoryLink id="570c-fc90-f3b5-822f" name="Wrath of the Everchosen" hidden="false" targetId="2890-73a3-1898-f20a" primary="false"/>
-              </categoryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
@@ -911,9 +902,6 @@ At the start of the battleshock phase, for each disease point that an enemy unit
                   </characteristics>
                 </profile>
               </profiles>
-              <categoryLinks>
-                <categoryLink id="6321-71b2-fe80-9ffe" name="Wrath of the Everchosen" hidden="false" targetId="2890-73a3-1898-f20a" primary="false"/>
-              </categoryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>


### PR DESCRIPTION
Fix #2824