### PR TITLE
Fix "Chaos - Skaven Data" in LotFP

### DIFF
--- a/Chaos - Legion of the First Prince.cat
+++ b/Chaos - Legion of the First Prince.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="f5ce-a49e-6f51-07cf" name="Chaos - Legion of the First Prince" revision="14" battleScribeVersion="2.03" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="127" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="f5ce-a49e-6f51-07cf" name="Chaos - Legion of the First Prince" revision="15" battleScribeVersion="2.03" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="127" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="7668-9a83-68ed-e4c5" name="Skull Cannons" hidden="false" collective="false" import="true" targetId="ae26-5d97-dc6e-1e89" type="selectionEntry"/>
     <entryLink id="02a3-921b-e73c-1110" name="Herald of Khorne on Blood Throne" hidden="false" collective="false" import="true" targetId="f3e2-3df3-198b-52b3" type="selectionEntry"/>
@@ -565,7 +565,7 @@
   </sharedSelectionEntries>
   <catalogueLinks>
     <catalogueLink id="e40d-aeda-4c1e-409b" name="Chaos Data" targetId="0339-0157-6910-d29c" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="f843-3f97-9e5c-1258" name="Chaos - Skaven Data" targetId="de06-0235-6a96-193b" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="f843-3f97-9e5c-1258" name="Chaos - Skaven - Data" targetId="de06-0235-6a96-193b" type="catalogue" importRootEntries="true"/>
     <catalogueLink id="4875-6ae6-a473-f806" name="Chaos - Slaves to Darkness Data" targetId="e0d8-b631-6934-ee34" type="catalogue" importRootEntries="true"/>
     <catalogueLink id="6f06-f79c-8705-5fbe" name="Destruction - Sons of Behemat" targetId="f904-b52f-810a-e446" type="catalogue" importRootEntries="true"/>
     <catalogueLink id="e695-d079-6c81-17b5" name="Endless Spells" targetId="f0db-356d-9f9f-662d" type="catalogue" importRootEntries="true"/>


### PR DESCRIPTION
With this, all names seem to be correct within all `catalogueLinks` that aren't `ZZ` or `[LEGENDS]`.