### PR TITLE
Add Endless Spells catalogueLink for OBR

### DIFF
--- a/Death - Ossiarch Bonereapers.cat
+++ b/Death - Ossiarch Bonereapers.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="b3c2-9aff-8664-1d07" name="Death - Ossiarch Bonereapers" revision="63" battleScribeVersion="2.03" authorName="TigerWraith" authorContact="TigerWraith#5618 on Discord" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="138" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="b3c2-9aff-8664-1d07" name="Death - Ossiarch Bonereapers" revision="64" battleScribeVersion="2.03" authorName="TigerWraith" authorContact="TigerWraith#5618 on Discord" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="138" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="cb62-7d89-9fa6-76ad" name="Battletome: Ossiarch Bonereapers"/>
     <publication id="254c-b9bb-a650-0c40" name="White Dwarf Issue 472"/>
@@ -4543,5 +4543,6 @@ You can roll D3 additional dice when this LIEGE uses their Unstoppable Charge ab
   <catalogueLinks>
     <catalogueLink id="0b46-379d-3e59-1e04" name="Death - Data" targetId="e37a-2f18-f168-6ed3" type="catalogue" importRootEntries="true"/>
     <catalogueLink id="1e36-015e-fbad-9112" name="Destruction - Sons of Behemat" targetId="f904-b52f-810a-e446" type="catalogue" importRootEntries="false"/>
+    <catalogueLink id="9987-28e6-1f21-2f9f" name="Endless Spells" targetId="f0db-356d-9f9f-662d" type="catalogue" importRootEntries="true"/>
   </catalogueLinks>
 </catalogue>


### PR DESCRIPTION
The OBR catalogue makes reference to [several Endless Spells](https://github.com/BSData/warhammer-age-of-sigmar/blob/master/Death%20-%20Ossiarch%20Bonereapers.cat#L286-L288).