### PR TITLE
Allow Mark of Chaos selection for StD units allied from BoC.

### DIFF
--- a/Chaos - Beasts of Chaos - Data.cat
+++ b/Chaos - Beasts of Chaos - Data.cat
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="a990-882b-7e62-27e9" name="Chaos - Beasts of Chaos - Data" revision="71" battleScribeVersion="2.03" authorName="" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="true" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="138" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="a990-882b-7e62-27e9" name="Chaos - Beasts of Chaos - Data" revision="72" battleScribeVersion="2.03" authorName="" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="true" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="141" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="c9b2-1fe6-pubN65537" name="Battletome: Beasts of Chaos"/>
-    <publication id="c9b2-1fe6-pubN83353" name="1"/>
     <publication id="ec9c-1f93-d9ca-18c7" name="White Dwarf 473" publisher="White Dwarf 473"/>
   </publications>
   <profileTypes>
@@ -3572,7 +3571,7 @@ In addition, each time an enemy unit within 3&quot; of any units in your army wi
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f08-a801-f373-7e4f" type="max"/>
           </constraints>
           <profiles>
-            <profile id="019a-e4fc-8b72-4f7f" name="Ritual Dagger" publicationId="c9b2-1fe6-pubN83353" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
+            <profile id="019a-e4fc-8b72-4f7f" name="Ritual Dagger" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                 <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>

--- a/Chaos - Slaves to Darkness Data.cat
+++ b/Chaos - Slaves to Darkness Data.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="e0d8-b631-6934-ee34" name="Chaos - Slaves to Darkness Data" revision="95" battleScribeVersion="2.03" authorName="" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="true" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="138" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="e0d8-b631-6934-ee34" name="Chaos - Slaves to Darkness Data" revision="96" battleScribeVersion="2.03" authorName="" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="true" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="141" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profileTypes>
     <profileType id="56f6-e336-faed-bb00" name="Aura of Chaos Power">
       <characteristicTypes>
@@ -10405,6 +10405,7 @@ Choose 1 unit from the following list:
                         <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b541-3b22-08bb-d772" type="equalTo"/>
                         <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4bd5-9ba3-7bfb-49ef" type="equalTo"/>
                         <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="812a-a8b3-7158-4adb" type="equalTo"/>
+                        <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="04c9-810f-2f9a-91d2" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -10465,6 +10466,7 @@ Choose 1 unit from the following list:
                     <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ff93-966b-c16d-8149" type="equalTo"/>
                     <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4bd5-9ba3-7bfb-49ef" type="equalTo"/>
                     <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="812a-a8b3-7158-4adb" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="04c9-810f-2f9a-91d2" type="equalTo"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -10523,6 +10525,7 @@ Choose 1 unit from the following list:
                     <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d7d9-b723-6fdb-51cb" type="equalTo"/>
                     <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4bd5-9ba3-7bfb-49ef" type="equalTo"/>
                     <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="812a-a8b3-7158-4adb" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="04c9-810f-2f9a-91d2" type="equalTo"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -10581,6 +10584,7 @@ Choose 1 unit from the following list:
                     <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="065f-c64d-3eb7-79d2" type="equalTo"/>
                     <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4bd5-9ba3-7bfb-49ef" type="equalTo"/>
                     <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="812a-a8b3-7158-4adb" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="04c9-810f-2f9a-91d2" type="equalTo"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -10625,6 +10629,7 @@ Choose 1 unit from the following list:
                   <conditions>
                     <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4bd5-9ba3-7bfb-49ef" type="equalTo"/>
                     <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="812a-a8b3-7158-4adb" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="04c9-810f-2f9a-91d2" type="equalTo"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -11195,5 +11200,6 @@ Choose 1 unit from the following list:
   </sharedProfiles>
   <catalogueLinks>
     <catalogueLink id="e2ba-3838-2584-6349" name="Chaos Data" targetId="0339-0157-6910-d29c" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="8a98-9e0a-c187-d7fb" name="Chaos - Beasts of Chaos - Data" targetId="a990-882b-7e62-27e9" type="catalogue" importRootEntries="true"/>
   </catalogueLinks>
 </catalogue>


### PR DESCRIPTION
Allow Slaves to Darkness units allied into a Beasts of Chaos roster to have Mark of Chaos selection.