### PR TITLE
Allow cultists to take mark of chaos for idolator general.

### DIFF
--- a/Chaos - Slaves to Darkness Data.cat
+++ b/Chaos - Slaves to Darkness Data.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="e0d8-b631-6934-ee34" name="Chaos - Slaves to Darkness Data" revision="110" battleScribeVersion="2.03" authorName="" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="true" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="144" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="e0d8-b631-6934-ee34" name="Chaos - Slaves to Darkness Data" revision="111" battleScribeVersion="2.03" authorName="" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="true" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="144" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profileTypes>
     <profileType id="56f6-e336-faed-bb00" name="Aura of Chaos Power">
       <characteristicTypes>
@@ -3230,6 +3230,15 @@
           </costs>
         </entryLink>
         <entryLink id="b3d1-bc47-f59d-a95f" name="Battalions" hidden="false" collective="false" import="true" targetId="f862-da0a-22bb-e3c1" type="selectionEntryGroup"/>
+        <entryLink id="5238-223e-28aa-5028" name="Marks of Chaos" hidden="true" collective="false" import="true" targetId="a8e3-b2cd-762d-14e3" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="42fd-6560-50ca-66a8" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
@@ -3370,6 +3379,15 @@
           </costs>
         </entryLink>
         <entryLink id="d817-b90e-8acd-68d9" name="Battalions" hidden="false" collective="false" import="true" targetId="f862-da0a-22bb-e3c1" type="selectionEntryGroup"/>
+        <entryLink id="7cde-6ca3-2939-d75d" name="Marks of Chaos" hidden="true" collective="false" import="true" targetId="a8e3-b2cd-762d-14e3" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="42fd-6560-50ca-66a8" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
@@ -3527,6 +3545,15 @@
           </costs>
         </entryLink>
         <entryLink id="5732-92d7-9d53-6b3e" name="Battalions" hidden="false" collective="false" import="true" targetId="f862-da0a-22bb-e3c1" type="selectionEntryGroup"/>
+        <entryLink id="dd3b-11e1-513d-03e8" name="Marks of Chaos" hidden="true" collective="false" import="true" targetId="a8e3-b2cd-762d-14e3" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="42fd-6560-50ca-66a8" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
@@ -3684,6 +3711,15 @@
           </costs>
         </entryLink>
         <entryLink id="ce04-c82f-a2cb-69cb" name="Battalions" hidden="false" collective="false" import="true" targetId="f862-da0a-22bb-e3c1" type="selectionEntryGroup"/>
+        <entryLink id="e34b-a2cc-4d58-b39c" name="Marks of Chaos" hidden="true" collective="false" import="true" targetId="a8e3-b2cd-762d-14e3" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="42fd-6560-50ca-66a8" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
@@ -3841,6 +3877,15 @@
           </costs>
         </entryLink>
         <entryLink id="573f-ad6b-e42d-1cf4" name="Battalions" hidden="false" collective="false" import="true" targetId="f862-da0a-22bb-e3c1" type="selectionEntryGroup"/>
+        <entryLink id="f242-467d-b043-c27d" name="Marks of Chaos" hidden="true" collective="false" import="true" targetId="a8e3-b2cd-762d-14e3" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="42fd-6560-50ca-66a8" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
@@ -3998,6 +4043,15 @@
           </costs>
         </entryLink>
         <entryLink id="7271-6d05-0bfb-e3f1" name="Battalions" hidden="false" collective="false" import="true" targetId="f862-da0a-22bb-e3c1" type="selectionEntryGroup"/>
+        <entryLink id="1b04-c4d9-b213-be75" name="Marks of Chaos" hidden="true" collective="false" import="true" targetId="a8e3-b2cd-762d-14e3" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="42fd-6560-50ca-66a8" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
@@ -5694,6 +5748,15 @@ The unit can receive the following commands if they are issued by its master:</c
           </costs>
         </entryLink>
         <entryLink id="ee2d-1643-add0-f604" name="Battalions" hidden="false" collective="false" import="true" targetId="f862-da0a-22bb-e3c1" type="selectionEntryGroup"/>
+        <entryLink id="f0bb-4de2-1823-e4ff" name="Marks of Chaos" hidden="true" collective="false" import="true" targetId="a8e3-b2cd-762d-14e3" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="42fd-6560-50ca-66a8" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
@@ -6179,7 +6242,15 @@ The unit can receive the following commands if they are issued by its master:</c
           </costs>
         </entryLink>
         <entryLink id="365f-b846-51e5-8616" name="Battalions" hidden="false" collective="false" import="true" targetId="f862-da0a-22bb-e3c1" type="selectionEntryGroup"/>
-        <entryLink id="1c4d-fa0a-4a48-2ee8" name="Marks of Chaos" hidden="false" collective="false" import="true" targetId="a8e3-b2cd-762d-14e3" type="selectionEntryGroup"/>
+        <entryLink id="1c4d-fa0a-4a48-2ee8" name="Marks of Chaos" hidden="true" collective="false" import="true" targetId="a8e3-b2cd-762d-14e3" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="42fd-6560-50ca-66a8" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
@@ -6454,6 +6525,15 @@ The unit can receive the following commands if they are issued by its master:</c
           </costs>
         </entryLink>
         <entryLink id="0622-cb56-b85a-2b0c" name="Battalions" hidden="false" collective="false" import="true" targetId="f862-da0a-22bb-e3c1" type="selectionEntryGroup"/>
+        <entryLink id="d412-99a8-8055-d1bc" name="Marks of Chaos" hidden="true" collective="false" import="true" targetId="a8e3-b2cd-762d-14e3" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="42fd-6560-50ca-66a8" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>


### PR DESCRIPTION
Fix #2937

Cultists may select Mark of Chaos when general has Idolator command trait.   Not implement is the automatic selection of the mark based on the general's mark.