### PR TITLE
Rename Zarshia Bittersould -> Zarshia Bittersoul

### DIFF
--- a/Chaos - Slaves to Darkness Data.cat
+++ b/Chaos - Slaves to Darkness Data.cat
@@ -7592,7 +7592,7 @@ The unit can receive the following commands if they are issued by its master:</c
         <cost name="pts" typeId="points" value="235.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="ef2f-5128-8625-da03" name="Zarshia Bittersould" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="ef2f-5128-8625-da03" name="Zarshia Bittersoul" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="6d03-8b74-c2b4-a88f" value="1.0">
           <conditions>

--- a/Chaos - Slaves to Darkness Data.cat
+++ b/Chaos - Slaves to Darkness Data.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="e0d8-b631-6934-ee34" name="Chaos - Slaves to Darkness Data" revision="120" battleScribeVersion="2.03" authorName="" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="true" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="146" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="e0d8-b631-6934-ee34" name="Chaos - Slaves to Darkness Data" revision="121" battleScribeVersion="2.03" authorName="" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="true" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="146" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profileTypes>
     <profileType id="56f6-e336-faed-bb00" name="Aura of Chaos Power">
       <characteristicTypes>

--- a/Chaos - Slaves to Darkness.cat
+++ b/Chaos - Slaves to Darkness.cat
@@ -111,7 +111,7 @@
     <entryLink id="db43-4347-f4ff-264b" name="Centurion Marshall" hidden="false" collective="false" import="true" targetId="ee6f-2bbd-7500-1738" type="selectionEntry"/>
     <entryLink id="b31c-970b-18df-9360" name="Eternus, Blade of the First Prince" hidden="false" collective="false" import="true" targetId="b7d4-cf7e-4103-332d" type="selectionEntry"/>
     <entryLink id="9d25-16e5-1b52-7894" name="Ogroid Theridons" hidden="false" collective="false" import="true" targetId="7d3b-0a65-a89a-9928" type="selectionEntry"/>
-    <entryLink id="6e9d-a864-0fdb-43ac" name="Zarshia Bittersould" hidden="false" collective="false" import="true" targetId="ef2f-5128-8625-da03" type="selectionEntry"/>
+    <entryLink id="6e9d-a864-0fdb-43ac" name="Zarshia Bittersoul" hidden="false" collective="false" import="true" targetId="ef2f-5128-8625-da03" type="selectionEntry"/>
     <entryLink id="e6af-a789-c5ec-4f24" name="Slaves to Darkness Gaunt Summoner of Tzeentch" hidden="false" collective="false" import="true" targetId="3cb1-8ae1-fc85-7c95" type="selectionEntry"/>
     <entryLink id="b4fc-f3d2-2065-aa69" name="Slaves to Darkness Daemon Prince" hidden="false" collective="false" import="true" targetId="e66d-3ffc-473d-885f" type="selectionEntry"/>
     <entryLink id="49ed-3c61-dd82-ca82" name="Ogroid Theridons" hidden="true" collective="false" import="true" targetId="7d3b-0a65-a89a-9928" type="selectionEntry">

--- a/Chaos - Slaves to Darkness.cat
+++ b/Chaos - Slaves to Darkness.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="798b-2f60-3166-c5bf" name="Chaos - Slaves to Darkness" revision="55" battleScribeVersion="2.03" authorName="" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="145" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="798b-2f60-3166-c5bf" name="Chaos - Slaves to Darkness" revision="56" battleScribeVersion="2.03" authorName="" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="145" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="798b-2f60-pubN65537" name="Grand Alliance: Chaos"/>
     <publication id="798b-2f60-pubN85643" name="Forgeworld: Monstrous Arcanum"/>


### PR DESCRIPTION
See https://github.com/BSData/warhammer-age-of-sigmar/issues/2982 , fixes typo.