### PR TITLE
Chosen selections and Tzeench artifact.

### DIFF
--- a/Chaos - Slaves to Darkness Data.cat
+++ b/Chaos - Slaves to Darkness Data.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="e0d8-b631-6934-ee34" name="Chaos - Slaves to Darkness Data" revision="126" battleScribeVersion="2.03" authorName="" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="true" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="155" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="e0d8-b631-6934-ee34" name="Chaos - Slaves to Darkness Data" revision="127" battleScribeVersion="2.03" authorName="" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="true" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="155" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profileTypes>
     <profileType id="56f6-e336-faed-bb00" name="Aura of Chaos Power">
       <characteristicTypes>
@@ -398,16 +398,6 @@
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If this unit is part of a Slaves to Darkness army, after deployment, you can roll once of the Eye of the Gods table for this unit.</characteristic>
           </characteristics>
         </profile>
-        <profile id="863e-1a2b-56a9-467a" name="Musician" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-          <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">1 in every 5 models in this unit can be a Skull Drummer. Add 1 to charge rolls for this unit while it includes any Skull Drummers.</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="26c7-08f7-dae4-9760" name="Standard Bearer" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-          <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">1 in every 5 models in this unit can be an Icon Bearer. Add 1 to the Bravery characteristic of this unit if it includes any Icon Bearers.</characteristic>
-          </characteristics>
-        </profile>
       </profiles>
       <categoryLinks>
         <categoryLink id="e1be-84a3-eec6-07e1" name="New CategoryLink" hidden="false" targetId="34db-a213-41b8-ec7e" primary="false"/>
@@ -465,6 +455,30 @@
           <costs>
             <cost name="pts" typeId="points" value="240.0"/>
           </costs>
+        </selectionEntry>
+        <selectionEntry id="4adb-e84d-8026-9635" name="Musician" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9aaf-5480-bfb4-7bd9" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="d09d-c201-3953-7086" name="Musician" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+              <characteristics>
+                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">1 in every 5 models in this unit can be a Skull Drummer. Add 1 to charge rolls for this unit while it includes any Skull Drummers.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+        </selectionEntry>
+        <selectionEntry id="c005-241b-fe89-906b" name="Standard Bearer" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6e4-b481-6c6f-ef4e" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="0262-ac0d-b309-56fb" name="Standard Bearer" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+              <characteristics>
+                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">1 in every 5 models in this unit can be an Icon Bearer. Add 1 to the Bravery characteristic of this unit if it includes any Icon Bearers.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>

--- a/Chaos Data.cat
+++ b/Chaos Data.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="0339-0157-6910-d29c" name="Chaos Data" revision="189" battleScribeVersion="2.03" authorName="" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="true" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="155" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="0339-0157-6910-d29c" name="Chaos Data" revision="190" battleScribeVersion="2.03" authorName="" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="true" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="155" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="c9b2-1fe6-pubN65537" name="Battletome: Beasts of Chaos"/>
     <publication id="6894-a70d-pubN65537" name="Chaos Battletome: Maggotkin of Nurgle"/>
@@ -14041,6 +14041,21 @@ If a model already has a Change Coven keyword on its warscroll, it cannot gain a
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
+            </selectionEntry>
+            <selectionEntry id="a697-bd31-769e-762a" name="Timeslip Pendant" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="117f-3914-a34a-f6a9" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="5fd9-5664-2531-c34a" name="Timeslip Pendant" hidden="false" typeId="0ac4-aacb-2481-8e72" typeName="Artefact">
+                  <characteristics>
+                    <characteristic name="Artefact Details" typeId="0918-c47a-d84e-c0cf">Once per battle, in the combat phase, after the bearer has fought for the first time in that phase, you can say that they are using the Timeslip Pendant. If you do so, they do not count as having fought in that phase but the strike-last effect applies to them until the end of that phase.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <categoryLinks>
+                <categoryLink id="a44c-03b0-b07e-6994" name="Artefact" hidden="false" targetId="3564-4c26-10b4-d953" primary="false"/>
+              </categoryLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>


### PR DESCRIPTION
Make Chosen standard bearers and musician selectable.  Add missing Tzeentch artefact.
Fix #3001 
Fix #3002 
