### PR TITLE
2xSlaughterHostFix

### DIFF
--- a/Chaos - Khorne.cat
+++ b/Chaos - Khorne.cat
@@ -3012,9 +3012,6 @@
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="9aa4-f4aa-cb66-06d3" name="Slaughterhost" hidden="false" collective="false" import="true" targetId="92c7-7625-2526-73bc" type="selectionEntryGroup"/>
-      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0"/>
       </costs>


### PR DESCRIPTION
Removed Slaughter host  menu link from the main alliance tab so it is not repeated twice. Tested and verified it worked on a local PC BattleScribe