### PR TITLE
New FEC book

### DIFF
--- a/Death - Flesh-eater Courts.cat
+++ b/Death - Flesh-eater Courts.cat
@@ -384,6 +384,7 @@
         <entryLink id="6c50-ce8c-fb83-5e18" name="Battalions" hidden="false" collective="false" import="true" targetId="3f3e-293b-65ed-e3fa" type="selectionEntryGroup"/>
         <entryLink id="2477-4f87-8461-0b7b" name="Incarnate Bonding" hidden="false" collective="false" import="true" targetId="c890-acbd-0c80-55c9" type="selectionEntryGroup"/>
         <entryLink id="7586-8f34-3277-64b1" name="Unique Enhancements" hidden="false" collective="false" import="true" targetId="62f4-174e-c529-75fe" type="selectionEntryGroup"/>
+        <entryLink import="true" name="Prayer Scriptures" hidden="false" type="selectionEntryGroup" id="a090-f131-d352-14fd" targetId="ec11-dabf-5c8-1a21"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="130"/>
@@ -550,6 +551,7 @@
         <entryLink id="356f-84db-ee61-f2b5" name="Battalions" hidden="false" collective="false" import="true" targetId="3f3e-293b-65ed-e3fa" type="selectionEntryGroup"/>
         <entryLink id="3d5b-36f9-75c5-2a19" name="Incarnate Bonding" hidden="false" collective="false" import="true" targetId="c890-acbd-0c80-55c9" type="selectionEntryGroup"/>
         <entryLink id="6b12-c18f-2201-4e2f" name="Unique Enhancements" hidden="false" collective="false" import="true" targetId="62f4-174e-c529-75fe" type="selectionEntryGroup"/>
+        <entryLink import="true" name="Prayer Scriptures" hidden="false" type="selectionEntryGroup" id="497d-ec2e-c35-edc" targetId="ec11-dabf-5c8-1a21"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="450"/>
@@ -740,6 +742,7 @@
         <entryLink id="7c9c-6e01-4443-f7a5" name="Battalions" hidden="false" collective="false" import="true" targetId="3f3e-293b-65ed-e3fa" type="selectionEntryGroup"/>
         <entryLink id="59b0-c483-8013-e8e9" name="Incarnate Bonding" hidden="false" collective="false" import="true" targetId="c890-acbd-0c80-55c9" type="selectionEntryGroup"/>
         <entryLink id="f3c0-4225-7cf4-6e00" name="Unique Enhancements" hidden="false" collective="false" import="true" targetId="62f4-174e-c529-75fe" type="selectionEntryGroup"/>
+        <entryLink import="true" name="Prayer Scriptures" hidden="false" type="selectionEntryGroup" id="cf04-fe08-249f-49f1" targetId="ec11-dabf-5c8-1a21"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="430"/>
@@ -2221,6 +2224,7 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
         <entryLink id="04e6-e7f1-368c-3ce3" name="Battalions" hidden="false" collective="false" import="true" targetId="3f3e-293b-65ed-e3fa" type="selectionEntryGroup"/>
         <entryLink id="f638-1285-e2cf-a7b9" name="Incarnate Bonding" hidden="false" collective="false" import="true" targetId="c890-acbd-0c80-55c9" type="selectionEntryGroup"/>
         <entryLink id="9036-511d-eb99-0d73" name="Unique Enhancements" hidden="false" collective="false" import="true" targetId="62f4-174e-c529-75fe" type="selectionEntryGroup"/>
+        <entryLink import="true" name="Prayer Scriptures" hidden="false" type="selectionEntryGroup" id="da4a-b318-46a4-3978" targetId="ec11-dabf-5c8-1a21"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="100"/>
@@ -2394,6 +2398,7 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
           </categoryLinks>
         </entryLink>
         <entryLink id="ffa4-db8a-934c-72c5" name="Unique Enhancements" hidden="false" collective="false" import="true" targetId="62f4-174e-c529-75fe" type="selectionEntryGroup"/>
+        <entryLink import="true" name="Prayer Scriptures" hidden="false" type="selectionEntryGroup" id="a575-4d43-fb47-68c9" targetId="ec11-dabf-5c8-1a21"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="140"/>
@@ -2650,6 +2655,7 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
           </categoryLinks>
         </entryLink>
         <entryLink id="ad60-81bd-9a14-b5be" name="Unique Enhancements" hidden="false" collective="false" import="true" targetId="62f4-174e-c529-75fe" type="selectionEntryGroup"/>
+        <entryLink import="true" name="Prayer Scriptures" hidden="false" type="selectionEntryGroup" id="2a63-43cf-9458-f421" targetId="ec11-dabf-5c8-1a21"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="145"/>
@@ -2756,6 +2762,7 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
         <entryLink id="85d5-4842-61f4-0c93" name="Battalions" hidden="false" collective="false" import="true" targetId="3f3e-293b-65ed-e3fa" type="selectionEntryGroup"/>
         <entryLink id="7a5b-9109-a233-f474" name="Incarnate Bonding" hidden="false" collective="false" import="true" targetId="c890-acbd-0c80-55c9" type="selectionEntryGroup"/>
         <entryLink id="0fac-e76a-3c63-d4c7" name="Unique Enhancements" hidden="false" collective="false" import="true" targetId="62f4-174e-c529-75fe" type="selectionEntryGroup"/>
+        <entryLink import="true" name="Prayer Scriptures" hidden="false" type="selectionEntryGroup" id="7893-6834-4f01-a08a" targetId="ec11-dabf-5c8-1a21"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="165"/>
@@ -3212,6 +3219,7 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
         <entryLink id="7e78-7fff-95a8-6cbd" name="Battalions" hidden="false" collective="false" import="true" targetId="3f3e-293b-65ed-e3fa" type="selectionEntryGroup"/>
         <entryLink id="1f6e-f190-7b3f-96b0" name="Incarnate Bonding" hidden="false" collective="false" import="true" targetId="c890-acbd-0c80-55c9" type="selectionEntryGroup"/>
         <entryLink id="4d6e-e40d-10fb-341b" name="Unique Enhancements" hidden="false" collective="false" import="true" targetId="62f4-174e-c529-75fe" type="selectionEntryGroup"/>
+        <entryLink import="true" name="Prayer Scriptures" hidden="false" type="selectionEntryGroup" id="2f05-5619-d37d-442c" targetId="ec11-dabf-5c8-1a21"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="240"/>
@@ -4039,12 +4047,12 @@ If it accepts, that enemy unit becomes infected. For the rest of the battle, rol
         <categoryLink id="58b0-9744-4ff2-7fee" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
         <categoryLink id="c875-3b49-dd6-261c" name="HERO" hidden="false" targetId="4e0e-664d-51ea-0929" primary="false"/>
         <categoryLink targetId="6b35-0508-c6cc-6592" id="b7ca-ecde-d896-f8de" primary="false" name="FLESH-EATER COURTS"/>
-        <categoryLink targetId="53f6-aa54-91a5-fcfb" id="9ccf-d432-d148-b18e" primary="false" name="MORDANT"/>
         <categoryLink targetId="6cdf-dd4f-0e91-e9c4" id="9c4d-21c4-7b94-fc05" primary="false" name="DEATH"/>
         <categoryLink targetId="aabf-1ee9-60e2-638" id="74d6-31c5-4d52-6e39" primary="false" name="COURTIER"/>
         <categoryLink targetId="5fca-46aa-3eee-233f" id="2f83-a19-d0dd-a11c" primary="false" name="MAROWSCROLL HERALD"/>
         <categoryLink targetId="e331-5936-7c92-f48b" id="6e17-e282-c341-4045" primary="false" name="MARROWSCROLL HERALD"/>
         <categoryLink targetId="94b9-7eb-a81a-b892" id="aa05-f026-db53-3eb9" primary="false" name="Champion"/>
+        <categoryLink targetId="53f6-aa54-91a5-fcfb" id="bdd6-9530-b560-f537" primary="false" name="MORDANT"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="3740-a4d4-d56-99a4" name="Artefacts" hidden="false" collective="false" import="true" targetId="c8cb-28b1-ffbb-2bbf" type="selectionEntryGroup"/>
@@ -4053,6 +4061,7 @@ If it accepts, that enemy unit becomes infected. For the rest of the battle, rol
         <entryLink id="9a2d-a37-b0e0-6df4" name="General" hidden="false" collective="false" import="true" targetId="8228-415a-66c3-dffe" type="selectionEntry"/>
         <entryLink id="d6cf-b204-8307-26c0" name="Incarnate Bonding" hidden="false" collective="false" import="true" targetId="c890-acbd-0c80-55c9" type="selectionEntryGroup"/>
         <entryLink id="bab9-9cc6-8b6f-41e2" name="Unique Enhancements" hidden="false" collective="false" import="true" targetId="62f4-174e-c529-75fe" type="selectionEntryGroup"/>
+        <entryLink import="true" name="Prayer Scriptures" hidden="false" type="selectionEntryGroup" id="a515-3caf-38ca-9f47" targetId="ec11-dabf-5c8-1a21"/>
       </entryLinks>
       <modifiers>
         <modifier type="add" field="category" value="89f7-d50b-0aa9-01ce">
@@ -4070,6 +4079,7 @@ If it accepts, that enemy unit becomes infected. For the rest of the battle, rol
         <entryLink id="e56b-33e2-2098-73d3" name="Battalions" hidden="false" collective="false" import="true" targetId="3f3e-293b-65ed-e3fa" type="selectionEntryGroup"/>
         <entryLink id="a193-47a-cc6a-d2ac" name="Spell Lores" hidden="false" collective="false" import="true" targetId="011c-b2d0-4781-ff07" type="selectionEntryGroup"/>
         <entryLink id="a50c-1bf1-fed8-2bf9" name="General" hidden="false" collective="false" import="true" targetId="8228-415a-66c3-dffe" type="selectionEntry"/>
+        <entryLink import="true" name="Prayer Scriptures" hidden="false" type="selectionEntryGroup" id="1b4e-b3a8-3cea-abb" targetId="ec11-dabf-5c8-1a21"/>
       </entryLinks>
       <categoryLinks>
         <categoryLink targetId="6cdf-dd4f-0e91-e9c4" id="38b1-82e1-34c5-d8ad" primary="false" name="DEATH"/>
@@ -4379,6 +4389,7 @@ At the end of your movement phase, you can set up this unit more than 9&quot; fr
         <entryLink id="74fa-781-60ea-3d8e" name="Battalions" hidden="false" collective="false" import="true" targetId="3f3e-293b-65ed-e3fa" type="selectionEntryGroup"/>
         <entryLink id="5270-fdab-6107-69bb" name="Incarnate Bonding" hidden="false" collective="false" import="true" targetId="c890-acbd-0c80-55c9" type="selectionEntryGroup"/>
         <entryLink id="3f56-dd8-8545-d11d" name="Unique Enhancements" hidden="false" collective="false" import="true" targetId="62f4-174e-c529-75fe" type="selectionEntryGroup"/>
+        <entryLink import="true" name="Prayer Scriptures" hidden="false" type="selectionEntryGroup" id="966a-5232-fd8b-d7cc" targetId="ec11-dabf-5c8-1a21"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="150"/>
@@ -4429,6 +4440,7 @@ Regicide: Pick 1 enemy unit that is visible to this unit and has slain a friendl
       <entryLinks>
         <entryLink id="f15c-57b2-4667-ceb5" name="General" hidden="false" collective="false" import="true" targetId="8228-415a-66c3-dffe" type="selectionEntry"/>
         <entryLink id="61d6-8ea6-b290-1a89" name="Battalions" hidden="false" collective="false" import="true" targetId="3f3e-293b-65ed-e3fa" type="selectionEntryGroup"/>
+        <entryLink import="true" name="Prayer Scriptures" hidden="false" type="selectionEntryGroup" id="65e8-fa6a-f31-ac8" targetId="ec11-dabf-5c8-1a21"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="140"/>
@@ -4487,6 +4499,7 @@ Regicide: Pick 1 enemy unit that is visible to this unit and has slain a friendl
         <entryLink id="23ee-5ba6-9b75-ba5b" name="General" hidden="false" collective="false" import="true" targetId="8228-415a-66c3-dffe" type="selectionEntry"/>
         <entryLink id="59ee-1006-7d7-9c1f" name="Incarnate Bonding" hidden="false" collective="false" import="true" targetId="c890-acbd-0c80-55c9" type="selectionEntryGroup"/>
         <entryLink id="af59-afc5-2f37-9786" name="Unique Enhancements" hidden="false" collective="false" import="true" targetId="62f4-174e-c529-75fe" type="selectionEntryGroup"/>
+        <entryLink import="true" name="Prayer Scriptures" hidden="false" type="selectionEntryGroup" id="340-c781-af74-b0ff" targetId="ec11-dabf-5c8-1a21"/>
       </entryLinks>
       <modifiers>
         <modifier type="add" field="category" value="89f7-d50b-0aa9-01ce">
@@ -4879,6 +4892,9 @@ Regicide: Pick 1 enemy unit that is visible to this unit and has slain a friendl
               </constraints>
             </selectionEntry>
           </selectionEntries>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3aa7-a417-c4b9-433c" type="max"/>
+          </constraints>
         </selectionEntryGroup>
         <selectionEntryGroup name="Royal Treasury" hidden="false" id="f639-605c-8f72-be3d">
           <selectionEntries>
@@ -4919,6 +4935,9 @@ Regicide: Pick 1 enemy unit that is visible to this unit and has slain a friendl
               </constraints>
             </selectionEntry>
           </selectionEntries>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="79cc-573f-e95-e3e0" type="max"/>
+          </constraints>
         </selectionEntryGroup>
       </selectionEntryGroups>
     </selectionEntryGroup>
@@ -5074,6 +5093,9 @@ Regicide: Pick 1 enemy unit that is visible to this unit and has slain a friendl
               </constraints>
             </selectionEntry>
           </selectionEntries>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c1c8-937b-a99b-a0d8" type="max"/>
+          </constraints>
         </selectionEntryGroup>
         <selectionEntryGroup name="Nobility" hidden="false" id="16d4-7b29-cf2a-ba05">
           <selectionEntries>
@@ -5114,6 +5136,9 @@ Regicide: Pick 1 enemy unit that is visible to this unit and has slain a friendl
               </constraints>
             </selectionEntry>
           </selectionEntries>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dce7-9143-ad93-9c16" type="max"/>
+          </constraints>
         </selectionEntryGroup>
       </selectionEntryGroups>
     </selectionEntryGroup>

--- a/Death - Flesh-eater Courts.cat
+++ b/Death - Flesh-eater Courts.cat
@@ -98,7 +98,7 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="f202-c960-472b-5361" name="Crypt Ghouls" hidden="false" collective="false" import="true" targetId="631c-0dae-5912-196d" type="selectionEntry"/>
-    <entryLink id="f8ec-6015-c1a7-2fd3" name="Duke Crakmarrow" hidden="false" collective="false" import="true" targetId="3659-35fc-ee8b-0f3e" type="selectionEntry"/>
+    <entryLink id="f8ec-6015-c1a7-2fd3" name="Duke Crakmarrow" hidden="true" collective="false" import="true" targetId="3659-35fc-ee8b-0f3e" type="selectionEntry"/>
     <entryLink id="6a82-64d0-618e-b46f" name="Abhorrant Ghoul King on Royal Terrorgheist" hidden="false" collective="false" import="true" targetId="25e3-54ae-82f5-152f" type="selectionEntry"/>
     <entryLink id="f4f9-ccff-07e9-813a" name="Abhorrant Ghoul King on Royal Zombie Dragon" hidden="false" collective="false" import="true" targetId="0e13-f2fc-7308-e23b" type="selectionEntry"/>
     <entryLink id="a374-bef2-cc39-d352" name="Crypt Ghast Courtier" hidden="false" collective="false" import="true" targetId="bb96-e300-f36b-2080" type="selectionEntry"/>
@@ -256,7 +256,7 @@
         </modifier>
       </modifiers>
     </entryLink>
-    <entryLink id="0b9e-131f-5420-c144" name="The Grymwatch" hidden="false" collective="false" import="true" targetId="29d5-0b2d-6b17-20ab" type="selectionEntry"/>
+    <entryLink id="0b9e-131f-5420-c144" name="The Grymwatch" hidden="true" collective="false" import="true" targetId="29d5-0b2d-6b17-20ab" type="selectionEntry"/>
     <entryLink id="e034-625e-02d2-737a" name="Grand Strategy" hidden="false" collective="false" import="true" targetId="296f-d30b-7ed5-408f" type="selectionEntry"/>
     <entryLink id="4764-6e7a-170f-40a8" name="Nagash, Supreme Lord of the Undead" hidden="false" collective="false" import="true" targetId="7c0c-91b9-f052-24af" type="selectionEntry">
       <infoLinks>
@@ -275,6 +275,12 @@
     <entryLink id="eddd-c7ab-f2c5-aac3" name="Regiment of Renown - Veremord&apos;s Shamblers" hidden="false" collective="false" import="true" targetId="fa3f-532f-9753-cd59" type="selectionEntry"/>
     <entryLink id="7745-d4c4-91be-339c" name="Royal Beastflayers" hidden="false" collective="false" import="true" targetId="1d12-6216-10d2-2f28" type="selectionEntry"/>
     <entryLink import="true" name="Marrowscroll Herald" hidden="false" type="selectionEntry" id="ac3a-6d27-4403-4a41" targetId="73b7-f1ea-97cf-9a50"/>
+    <entryLink import="true" name="Ushoran, Mortarch of Delusion" hidden="false" type="selectionEntry" id="b4ce-5741-63a4-e537" targetId="3d22-faad-f95d-173a"/>
+    <entryLink import="true" name="Grand Justice Gormayne" hidden="false" type="selectionEntry" id="c515-3cb7-5c6c-1130" targetId="6dba-937-c22b-bccf"/>
+    <entryLink import="true" name="Abhorrant Cardinal" hidden="false" type="selectionEntry" id="d6f-d076-daad-57ef" targetId="eff7-5485-4d69-64c7"/>
+    <entryLink import="true" name="Cryptguard" hidden="false" type="selectionEntry" id="5b73-6667-76b8-2a83" targetId="b689-54f9-5b9e-47cb"/>
+    <entryLink import="true" name="Abhorrant Gorewarden" hidden="false" type="selectionEntry" id="b11b-f71f-aa5-4f5f" targetId="a617-c031-1894-e81b"/>
+    <entryLink import="true" name="Royal Decapitator" hidden="false" type="selectionEntry" id="abb4-e512-678f-34be" targetId="698f-7fbf-7a84-59ff"/>
   </entryLinks>
   <rules>
     <rule id="1b49-484e-bc30-aa58" name="Muster Abilities" publicationId="6d29-cde4-pubN65555" page="75" hidden="false">

--- a/Death - Flesh-eater Courts.cat
+++ b/Death - Flesh-eater Courts.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="6d29-cde4-372b-08d3" name="Death - Flesh-eater Courts" revision="99" battleScribeVersion="2.03" authorName="https://discord.gg/4MSsD7" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="161" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="6d29-cde4-372b-08d3" name="Death - Flesh-eater Courts" revision="100" battleScribeVersion="2.03" authorName="https://discord.gg/4MSsD7" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="161" type="catalogue">
   <publications>
     <publication id="6d29-cde4-pubN65537" name="Battletome: Flesh-eater Courts 2019"/>
     <publication id="6d29-cde4-pubN65555" name="Battletome: Flesh-eater Courts"/>
@@ -24,7 +24,7 @@
       <characteristicTypes>
         <characteristicType id="2ad2-839b-d5ee-5770" name="Move"/>
         <characteristicType id="dfdc-a86c-e979-1eb7" name="Death Shriek"/>
-        <characteristicType id="5b09-7a6b-dd30-faf1" name="Skeletal Claws"/>
+        <characteristicType id="5b09-7a6b-dd30-faf1" name="Skeletal Talons"/>
       </characteristicTypes>
     </profileType>
     <profileType id="149a-6d26-c3e0-abdc" name="Delusion Table">
@@ -37,6 +37,12 @@
         <characteristicType id="a8cb-c0d2-5f4e-b001" name="The Nine Books of Nagash"/>
         <characteristicType id="dc13-513a-62da-5cc4" name="Zefet-nebtar"/>
         <characteristicType id="fc3e-569d-c347-0cdc" name="Alakanash"/>
+      </characteristicTypes>
+    </profileType>
+    <profileType name="Ushoran Wounds Suffered" hidden="false" id="47ed-4c74-6bd2-980f">
+      <characteristicTypes>
+        <characteristicType id="484c-b8de-f02e-75bb" name="Monstrous Claws and Fangs"/>
+        <characteristicType id="37c2-fa8b-ae93-152c" name="Epicentre of Delusion"/>
       </characteristicTypes>
     </profileType>
   </profileTypes>
@@ -69,6 +75,7 @@
     <categoryEntry id="e436-d1d7-652b-ab96" name="CRYPT HAUNTER COURTIER General" hidden="false"/>
     <categoryEntry id="52e4-3e6e-c3c9-58e0" name="ROYAL BEASTFLAYERS" hidden="false"/>
     <categoryEntry name="MARROWSCROLL HERALD" hidden="false" id="e331-5936-7c92-f48b"/>
+    <categoryEntry name="USHORAN" hidden="false" id="ec00-f808-c337-38f5"/>
   </categoryEntries>
   <entryLinks>
     <entryLink id="c7c9-5a8a-4868-57bc" name="Allegiance" hidden="false" collective="false" import="true" targetId="d563-f542-5dad-2b09" type="selectionEntry">
@@ -380,41 +387,6 @@
     </selectionEntry>
     <selectionEntry id="25e3-54ae-82f5-152f" name="Abhorrant Ghoul King on Royal Terrorgheist" publicationId="6afd-4f9a-0665-9b55" hidden="false" collective="false" import="true" type="unit">
       <profiles>
-        <profile id="21f5-0af7-68bb-37f3" name="00-03" hidden="false" typeId="cde6-89a6-4a4c-9d32" typeName="Terrorgheist Wound Table">
-          <characteristics>
-            <characteristic name="Move" typeId="2ad2-839b-d5ee-5770">14&quot;</characteristic>
-            <characteristic name="Death Shriek" typeId="dfdc-a86c-e979-1eb7">6</characteristic>
-            <characteristic name="Skeletal Claws" typeId="5b09-7a6b-dd30-faf1">4</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="42ea-94de-79eb-fdf7" name="04-06" hidden="false" typeId="cde6-89a6-4a4c-9d32" typeName="Terrorgheist Wound Table">
-          <characteristics>
-            <characteristic name="Move" typeId="2ad2-839b-d5ee-5770">12&quot;</characteristic>
-            <characteristic name="Death Shriek" typeId="dfdc-a86c-e979-1eb7">5</characteristic>
-            <characteristic name="Skeletal Claws" typeId="5b09-7a6b-dd30-faf1">4</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="9ed7-c9b2-49ba-a665" name="07-09" hidden="false" typeId="cde6-89a6-4a4c-9d32" typeName="Terrorgheist Wound Table">
-          <characteristics>
-            <characteristic name="Move" typeId="2ad2-839b-d5ee-5770">10&quot;</characteristic>
-            <characteristic name="Death Shriek" typeId="dfdc-a86c-e979-1eb7">4</characteristic>
-            <characteristic name="Skeletal Claws" typeId="5b09-7a6b-dd30-faf1">3</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="9611-efae-f29e-5a92" name="10-12" hidden="false" typeId="cde6-89a6-4a4c-9d32" typeName="Terrorgheist Wound Table">
-          <characteristics>
-            <characteristic name="Move" typeId="2ad2-839b-d5ee-5770">8&quot;</characteristic>
-            <characteristic name="Death Shriek" typeId="dfdc-a86c-e979-1eb7">3</characteristic>
-            <characteristic name="Skeletal Claws" typeId="5b09-7a6b-dd30-faf1">3</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="298d-d3b2-05a9-64b9" name="13+" hidden="false" typeId="cde6-89a6-4a4c-9d32" typeName="Terrorgheist Wound Table">
-          <characteristics>
-            <characteristic name="Move" typeId="2ad2-839b-d5ee-5770">6&quot;</characteristic>
-            <characteristic name="Death Shriek" typeId="dfdc-a86c-e979-1eb7">2</characteristic>
-            <characteristic name="Skeletal Claws" typeId="5b09-7a6b-dd30-faf1">2</characteristic>
-          </characteristics>
-        </profile>
         <profile id="37f6-2869-17eb-b9aa" name="Gaping Maw" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If the unmodified hit roll for an attack made with this model’s Fanged Maw is 6, that attack inflicts 6 mortal wounds on the target unit and the attack sequence ends (do not make a wound or save roll).</characteristic>
@@ -422,7 +394,7 @@
         </profile>
         <profile id="b1cd-c7f6-5b82-7403" name="Infested" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If this model is slain, before this model is removed from play each unit within 3&quot; of this model suffers D3 mortal wounds.</characteristic>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If this unit is destroyed, before it is removed from play, each enemy unit within 3” of this unit suffers D3 mortal wounds.</characteristic>
           </characteristics>
         </profile>
         <profile id="bab1-4ccf-a892-82ec" name="Abhorrant Ghoul King on Terrorgheist" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
@@ -435,7 +407,7 @@
         </profile>
         <profile id="830d-0083-244c-813c" name="Royal Blood" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">In your hero phase, you can heal up to D3 wounds allocated to this model.</characteristic>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">In your hero phase, you can heal up to D3 wounds allocated to this unit.</characteristic>
           </characteristics>
         </profile>
         <profile id="f3bb-c151-6ac5-f9df" name="Wizard" hidden="false" typeId="f55d-ee3a-1597-110f" typeName="Magic">
@@ -444,9 +416,11 @@
             <characteristic name="Spells Known" typeId="dc9c-47d3-6931-859c">Arcane Bolt, Mystic Shield and Unholy Vitality spells.</characteristic>
           </characteristics>
         </profile>
-        <profile id="0199-13aa-7780-9a11" name="Summon Royal Guard" hidden="false" typeId="f71f-b0a4-730e-ced3" typeName="Command Abilities">
+        <profile name="Ferocious Hunger" typeId="2e81-5e22-c6e1-73cb" typeName="Spell" hidden="false" id="6916-2d70-c3c7-a4c9">
           <characteristics>
-            <characteristic name="Command Ability Details" typeId="1b71-4c83-4e8c-093f">You can use this command ability at the end of your movement phase. If you do so, pick 1 friendly model that has this command ability and has not used it before in the battle. That model summons 1 unit of up to 3 Knights to the battlefield. The summoned unit is added to your army, and must be set up wholly within 6&quot; of the edge of the battlefield and more than 9&quot; from any enemy units.</characteristic>
+            <characteristic name="Casting Value" typeId="2508-b604-1258-a920">6</characteristic>
+            <characteristic name="Range" typeId="5b5c-1fd1-4c0f-5705">12&quot;</characteristic>
+            <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, pick 1 friendly ROYAL TERRORGHEIST wholly within range. You can re-roll hit rolls for attacks made with that unit’s Fanged Maw until your next hero phase.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -469,24 +443,6 @@
         <categoryLink id="1c4e-b0f7-c8e6-cbe0" name="Behemoth" hidden="false" targetId="fa0c-9044-2568-fa02" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="9ab0-3a0b-704b-0ae5" name="Unholy Vitality" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="baf8-8d1f-2bf6-8c40" type="min"/>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f86-1a41-042f-ed53" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="886d-4e03-edac-5280" name="Unholy Vitality" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
-              <characteristics>
-                <characteristic name="Casting Value" typeId="2508-b604-1258-a920">6</characteristic>
-                <characteristic name="Range" typeId="5b5c-1fd1-4c0f-5705">24&quot;</characteristic>
-                <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, pick 1 friendly Flesh‐eater Courts unit wholly within 24&quot; of the caster and visible to them. Until your next hero phase, roll a dice each time you allocate a wound or mortal wound to that unit. On a 5+ that wound or mortal wound is negated.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0"/>
-          </costs>
-        </selectionEntry>
         <selectionEntry id="b00c-3dcb-9898-625a" name="Death Shriek" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b3b0-3daf-7478-176c" type="max"/>
@@ -506,7 +462,7 @@
             </profile>
             <profile id="715a-07a9-235d-1227" name="Death Shriek" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
               <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Roll a dice and add the Death Shriek value shown on this model’s damage table. If the total is higher than the target unit’s Bravery characteristic, the target unit suffers a number of mortal wounds equal to the difference between its Bravery characteristic and the total.</characteristic>
+                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Do not use the attack sequence for an attack made with this unit’s Death Shriek. Instead, roll a dice and add the Death Shriek value shown on this unit’s damage table. If the total is higher than the target unit’s Bravery characteristic, the target unit suffers a number of mortal wounds equal to the difference between its Bravery characteristic and the total.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -524,11 +480,11 @@
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                 <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
-                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">5</characteristic>
+                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">4</characteristic>
                 <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">3+</characteristic>
                 <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
                 <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-1</characteristic>
-                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
+                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">2</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -558,13 +514,13 @@
             <cost name="pts" typeId="points" value="0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="3701-2d57-7232-1d09" name="Skeletal Claws" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="3701-2d57-7232-1d09" name="Skeletal Talons" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b971-7e33-0563-8dff" type="min"/>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="68fd-d72c-f997-4b2c" type="max"/>
           </constraints>
           <profiles>
-            <profile id="8fa2-63c7-50c3-37f7" name="Skeletal Claws" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
+            <profile id="8fa2-63c7-50c3-37f7" name="Skeletal Talons" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                 <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">2&quot;</characteristic>
@@ -572,7 +528,7 @@
                 <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">4+</characteristic>
                 <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
                 <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-1</characteristic>
-                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">D3</characteristic>
+                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">2</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -594,6 +550,40 @@
       <costs>
         <cost name="pts" typeId="points" value="450"/>
       </costs>
+      <infoGroups>
+        <infoGroup name="Damage Table" hidden="false" id="211f-f34a-c0d2-47bc">
+          <profiles>
+            <profile name="0-6" typeId="370f-9356-a89a-06b3" typeName="Terrorgheist Wounds Suffered" hidden="false" id="bcd9-bce0-9915-bce0">
+              <characteristics>
+                <characteristic name="Move" typeId="2ad2-839b-d5ee-5770">14&quot;</characteristic>
+                <characteristic name="Death Shriek" typeId="dfdc-a86c-e979-1eb7">6</characteristic>
+                <characteristic name="Skeletal Talons" typeId="5b09-7a6b-dd30-faf1">7</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="7-8" typeId="370f-9356-a89a-06b3" typeName="Terrorgheist Wounds Suffered" hidden="false" id="6a84-e4cd-ba52-b9a1">
+              <characteristics>
+                <characteristic name="Move" typeId="2ad2-839b-d5ee-5770">12&quot;</characteristic>
+                <characteristic name="Death Shriek" typeId="dfdc-a86c-e979-1eb7">5</characteristic>
+                <characteristic name="Skeletal Talons" typeId="5b09-7a6b-dd30-faf1">6</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="9-11" typeId="370f-9356-a89a-06b3" typeName="Terrorgheist Wounds Suffered" hidden="false" id="ecf4-4523-2707-efcd">
+              <characteristics>
+                <characteristic name="Move" typeId="2ad2-839b-d5ee-5770">10&quot;</characteristic>
+                <characteristic name="Death Shriek" typeId="dfdc-a86c-e979-1eb7">4</characteristic>
+                <characteristic name="Skeletal Talons" typeId="5b09-7a6b-dd30-faf1">5</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="12+" typeId="370f-9356-a89a-06b3" typeName="Terrorgheist Wounds Suffered" hidden="false" id="bcb0-546a-2ed5-99df">
+              <characteristics>
+                <characteristic name="Move" typeId="2ad2-839b-d5ee-5770">8&quot;</characteristic>
+                <characteristic name="Death Shriek" typeId="dfdc-a86c-e979-1eb7">3</characteristic>
+                <characteristic name="Skeletal Talons" typeId="5b09-7a6b-dd30-faf1">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+        </infoGroup>
+      </infoGroups>
     </selectionEntry>
     <selectionEntry id="0e13-f2fc-7308-e23b" name="Abhorrant Ghoul King on Royal Zombie Dragon" hidden="false" collective="false" import="true" type="unit">
       <profiles>
@@ -845,24 +835,37 @@
                 </profile>
                 <profile id="7b01-5b29-a8c6-99d2" name="Feeding Frenzy" publicationId="6d29-cde4-pubN71388" hidden="false" typeId="c137-4d1f-9d1a-524d" typeName="Battle Trait">
                   <characteristics>
-                    <characteristic name="Battle Trait Details" typeId="9fdd-b4b1-5f7a-0970">You can use this command ability in the combat phase after a friendly FLESH-EATER COURTS unit has fought for the first time in that phase and is wholly within 12&quot; of a friendly FLESH-EATER COURTS HERO or wholly within 18&quot; of a friendly FLESH-EATER COURTS HERO that is a general.  If you do so, that unit can immediately make a pile-in move and then attack with all of the melee weapons it is armed with for a second time.  You cannot pick the same unit to benefit from this ability more than once per phase.</characteristic>
+                    <characteristic name="Battle Trait Details" typeId="9fdd-b4b1-5f7a-0970">Add 1 to the Attacks characteristic of melee weapons used by friendly Flesh-eater Courts units while they are wholly within 12&quot; of any friendly Heroes that have 6 noble deeds points.</characteristic>
                   </characteristics>
                 </profile>
-                <profile id="2d74-bc24-c47b-6a6e" name="Grand Courts" page="FAQ 12/19" hidden="false" typeId="c137-4d1f-9d1a-524d" typeName="Battle Trait">
+                <profile id="2d74-bc24-c47b-6a6e" name="Noble Deeds" page="FAQ 12/19" hidden="false" typeId="c137-4d1f-9d1a-524d" typeName="Battle Trait">
                   <characteristics>
-                    <characteristic name="Battle Trait Details" typeId="9fdd-b4b1-5f7a-0970">After you have chosen the Flesh-eater Courts allegiance for you army, you can choose one of the Grand Court keywords: MORGAUNT, HOLLOWMOURNE, BLISTERSKIN or GRISTLEGORE.  All FLESH-EATER COURTS units in your army gain that keyword.  You cannot pick or roll a delusion for a Grand Court, but all units with that keyword benefit from the extra abilities defined for that Grand Court. If a model already has a Grand Court keyword on its warscroll, it cannot gain another one. This does not preclude you from including the unit in your army, but you cannot use the allegiance abilities for its Grand Court.</characteristic>
-                  </characteristics>
-                </profile>
-                <profile id="c1d0-c159-47c2-5b79" name="Courts of Delusion" hidden="false" typeId="c137-4d1f-9d1a-524d" typeName="Battle Trait">
-                  <characteristics>
-                    <characteristic name="Battle Trait Details" typeId="9fdd-b4b1-5f7a-0970">Before you select your general&apos;s command trait, pick one of the delusions for the army you have.  Alternatively, you can roll a dice to randomly determine the delusion the army has.  The delusion applies to all friendly FLESH-EATER COURTS unit for the duration of the battle, even if the general is slain (if you must select a new general during the battle, do not generate a new delusion for the army).</characteristic>
-                  </characteristics>
-                </profile>
-                <profile id="d0ed-d7c0-491a-bb8c" name="Muster Reinforcements" hidden="false" typeId="c137-4d1f-9d1a-524d" typeName="Battle Trait">
-                  <characteristics>
-                    <characteristic name="Battle Trait Details" typeId="9fdd-b4b1-5f7a-0970">At the start of your hero phase, you can carry out this heroic action with a friendly FLESH-EATER COURTS HERO instead of any other heroic action you can carry out with that HERO. 
+                    <characteristic name="Battle Trait Details" typeId="9fdd-b4b1-5f7a-0970">• Each time a friendly Flesh-eater Courts Hero successfully casts a spell that is not unbound, give 1 noble deeds point to that Hero.
+• Each time a prayer chanted by a friendly Flesheater Courts Hero is answered, give 1 noble deeds point to that Hero.
+• Each time a friendly Flesh-eater Courts Hero fights, after all of its attacks have been resolved, give that Hero a number of noble deeds points equal to the number of wounds and/or mortal wounds caused by that Hero in that phase that were allocated to enemy units. Do not count wounds and/or mortal wounds caused by that Hero’s mount.
 
-Muster Reinforcements: Pick 1 friendly FLESH-EATER COURTS HERO and roll 6 dice. For each 2+, you can return 1 slain model to a friendly SERFS unit within 10&quot; of that HERO. For each 5+, you can return 1 slain model to a friendly KNIGHTS unit within 10&quot; of that HERO instead. Slain models can be returned to more than 1 unit if you wish, but each successful dice roll can only be used to return 1 model to a single unit.</characteristic>
+
+Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any one time (it cannot be given any more until the number of noble deeds points it has is reduced to less than 6).</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="d0ed-d7c0-491a-bb8c" name="Muster Guard" hidden="false" typeId="c137-4d1f-9d1a-524d" typeName="Battle Trait">
+                  <characteristics>
+                    <characteristic name="Battle Trait Details" typeId="9fdd-b4b1-5f7a-0970">At the end of your movement phase, each friendly COURTIER can spend 1 of their noble deeds points to return 1 slain model to a friendly SERFS unit that is within 10&quot; of them, or 2 of their noble deeds points to return 1 slain model to a friendly KNIGHTS unit that is within 10&quot; of them. You can use this ability multiple times each turn as long as the required noble deeds points are available.</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="7721-4f66-303e-3d32" name="Summon Loyal Subjects" hidden="false" typeId="c137-4d1f-9d1a-524d" typeName="Battle Trait">
+                  <characteristics>
+                    <characteristic name="Battle Trait Details" typeId="9fdd-b4b1-5f7a-0970">At the end of your movement phase, each friendly ABHORRANT can spend 6 of their noble deeds points to summon loyal subjects. If they do so, pick 1 friendly SERFS or KNIGHTS unit that has been destroyed and add a new replacement unit identical to that unit to your army with half of the models from the unit that was destroyed (rounding up). Replacement units must be set up wholly within 6&quot; of the edge of the battlefield and more than 9&quot; from all enemy units. Each destroyed unit can only be replaced once - replacement units cannot themselves be replaced. Remaining models which are not set up as part of the replacement unit count as having been slain and can be returned to the replacement unit using the Muster Guard ability or Rally command ability.</characteristic>
+                  </characteristics>
+                </profile>
+                <profile name="Courts of Delusion" typeId="c137-4d1f-9d1a-524d" typeName="Battle Trait" hidden="false" id="1ba3-64f1-29ec-33cf">
+                  <characteristics>
+                    <characteristic name="Battle Trait Details" typeId="9fdd-b4b1-5f7a-0970">In the first battle round, after the players have received their starting command points but before the start of the first turn, you can pick 1 of the following delusions to apply during the battle:
+• The Royal Hunt: Add 1 to wound rolls for attacks made by friendly Flesh-eater Courts units that target a Monster.
+• Crusading Army: Add 1 to run rolls and charge rolls for friendly Flesh-eater Courts units.
+• Defenders of the Realm: Add 1 to save rolls for friendly Flesh-eater Courts units while they are contesting an objective that you control.
+• The Grand Tournament: Add 1 to hit rolls for attacks made by friendly Flesh-eater Courts Heroes that are not a general if they made a charge move in the same turn.
+• The Feast Day: The Feeding Frenzy ability applies to friendly Flesh-eater Courts units while they are wholly within 12&quot; of any friendly Heroes that have 4 or more noble deeds points instead of 6 noble deeds points.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -877,14 +880,9 @@ Muster Reinforcements: Pick 1 friendly FLESH-EATER COURTS HERO and roll 6 dice. 
                   <selectionEntries>
                     <selectionEntry id="dbb1-fd69-0ebc-97df" name="Morgaunt" hidden="false" collective="false" import="true" type="upgrade">
                       <profiles>
-                        <profile id="eb48-a123-2428-13f4" name="Bloody Loyalty" hidden="false" typeId="c137-4d1f-9d1a-524d" typeName="Battle Trait">
+                        <profile id="eb48-a123-2428-13f4" name="Morgaunt Kingdoms" hidden="false" typeId="c137-4d1f-9d1a-524d" typeName="Battle Trait">
                           <characteristics>
-                            <characteristic name="Battle Trait Details" typeId="9fdd-b4b1-5f7a-0970">You can re-roll hit rolls of 1 for friendly MORGAUNT COURTIER units that are wholly within 12&quot; of a friendly MORGAUNT SERFS unit.  In addition, while a friendly MORGAUNT SERFS unit is wholly within 12&quot; of a friendly MORGAUNT COURTIER, its Boundless Ferocity ability activates if the SERFS unit has 10 or more models.</characteristic>
-                          </characteristics>
-                        </profile>
-                        <profile id="5d16-33b1-ac08-dd81" name="Heaving Masses" publicationId="6afd-4f9a-0665-9b55" page="1" hidden="false" typeId="f71f-b0a4-730e-ced3" typeName="Command Abilities">
-                          <characteristics>
-                            <characteristic name="Command Ability Details" typeId="1b71-4c83-4e8c-093f">You can use this command ability when a friendly MORGAUNT SERFS unit is destroyed.  If you do so, roll a dice.  On a 4+ a new unit identical to the one that was destroyed is added to your army.  Set up the new unit wholly within 6&quot; of the edge of the battlefield and more than 9&quot; from any enemy models. You cannot use this command ability more than once per phase.</characteristic>
+                            <characteristic name="Battle Trait Details" typeId="9fdd-b4b1-5f7a-0970">Give 1 noble deeds point to each friendly MORGAUNT FLESH-EATER COURTS HERO at the end of the turn if that Hero is contesting an objective.</characteristic>
                           </characteristics>
                         </profile>
                       </profiles>
@@ -894,14 +892,9 @@ Muster Reinforcements: Pick 1 friendly FLESH-EATER COURTS HERO and roll 6 dice. 
                     </selectionEntry>
                     <selectionEntry id="c6db-68c4-dfd6-58c0" name="Hollowmourne" hidden="false" collective="false" import="true" type="upgrade">
                       <profiles>
-                        <profile id="7a8f-b5ea-d969-5458" name="Shattering Charge" hidden="false" typeId="c137-4d1f-9d1a-524d" typeName="Battle Trait">
+                        <profile id="7a8f-b5ea-d969-5458" name="Grisly Cavaliers" hidden="false" typeId="c137-4d1f-9d1a-524d" typeName="Battle Trait">
                           <characteristics>
-                            <characteristic name="Battle Trait Details" typeId="9fdd-b4b1-5f7a-0970">You can re-roll wound rolls of 1 for attacks made with melee weapons by friendly HOLLOWMOURNE COURTIER units and friendly HOLLOWMOURNE KNIGHTS units that have made a charge move in the same turn.</characteristic>
-                          </characteristics>
-                        </profile>
-                        <profile id="b4ba-43e4-6aa5-879d" name="Ravenous Crusaders" hidden="false" typeId="f71f-b0a4-730e-ced3" typeName="Command Abilities">
-                          <characteristics>
-                            <characteristic name="Command Ability Details" typeId="1b71-4c83-4e8c-093f">You can use this command ability at the start of your hero phase.  If you do so, pick 1 friendly HOLLOWMOURNE unit wholly within 9&quot; of a friendly HOLLOWMOURNE HERO, or wholly within 18&quot; of a friendly HOLLOWMOURNE HERO that is a general.  Add 1 to run and charge rolls for that unit until your next hero phase.  In addition, until your next hero phase, that unit can run and still charge later in the same turn.</characteristic>
+                            <characteristic name="Battle Trait Details" typeId="9fdd-b4b1-5f7a-0970">Add 1 to the Damage characteristic of melee weapons used by friendly HOLLOWMOURNE KNIGHTS units that have made a charge move in the same turn. This ability has no effect on attacks made by mounts.</characteristic>
                           </characteristics>
                         </profile>
                       </profiles>
@@ -911,14 +904,9 @@ Muster Reinforcements: Pick 1 friendly FLESH-EATER COURTS HERO and roll 6 dice. 
                     </selectionEntry>
                     <selectionEntry id="83a9-0464-b308-eef1" name="Blisterskin" hidden="false" collective="false" import="true" type="upgrade">
                       <profiles>
-                        <profile id="e81e-4750-3dae-30a6" name="Blistering Speed" hidden="false" typeId="c137-4d1f-9d1a-524d" typeName="Battle Trait">
+                        <profile id="e81e-4750-3dae-30a6" name="Pious Nobility" hidden="false" typeId="c137-4d1f-9d1a-524d" typeName="Battle Trait">
                           <characteristics>
-                            <characteristic name="Battle Trait Details" typeId="9fdd-b4b1-5f7a-0970">Add 2&quot; to the Move characteristic of BLISTERSKIN units.</characteristic>
-                          </characteristics>
-                        </profile>
-                        <profile id="1818-b616-433c-0728" name="Lords of the Burning Skies" hidden="false" typeId="f71f-b0a4-730e-ced3" typeName="Command Abilities">
-                          <characteristics>
-                            <characteristic name="Command Ability Details" typeId="1b71-4c83-4e8c-093f">You can use this command ability at the start of your movement phase.  If you do so, pick 1 friendly BLISTERSKIN unit that can fly and which is wholly within 12&quot; of a friendly BLISTERSKIN HERO, or wholly within 18&quot; of a friendly BLISTERSKIN HERO that is a general.  Remove that unit from the battle and then set it up again anywhere on the battlefield more than 9&quot; from any enemy units.  It may not move later in that movement phase.</characteristic>
+                            <characteristic name="Battle Trait Details" typeId="9fdd-b4b1-5f7a-0970">Friendly ABHORRENTS gain the PRIEST keyword but they cannot cast spells and chant prayers in the same hero phase.</characteristic>
                           </characteristics>
                         </profile>
                       </profiles>
@@ -928,14 +916,9 @@ Muster Reinforcements: Pick 1 friendly FLESH-EATER COURTS HERO and roll 6 dice. 
                     </selectionEntry>
                     <selectionEntry id="99b2-6989-d758-a4be" name="Gristlegore" hidden="false" collective="false" import="true" type="upgrade">
                       <profiles>
-                        <profile id="1312-c52c-1878-5393" name="Peerless Ferocity" hidden="false" typeId="c137-4d1f-9d1a-524d" typeName="Battle Trait">
+                        <profile id="1312-c52c-1878-5393" name="Savage Strike" hidden="false" typeId="c137-4d1f-9d1a-524d" typeName="Battle Trait">
                           <characteristics>
-                            <characteristic name="Battle Trait Details" typeId="9fdd-b4b1-5f7a-0970">If the unmodified hit roll for an attack made by a GRISTLEGORE HERO or GRISTLEGORE MONSTER is 6, that attack inflicts 2 hits on that target instead of 1.  Make a wound and save roll for each hit.</characteristic>
-                          </characteristics>
-                        </profile>
-                        <profile id="20fb-347c-741e-9ad7" name="Call to War" hidden="false" typeId="f71f-b0a4-730e-ced3" typeName="Command Abilities">
-                          <characteristics>
-                            <characteristic name="Command Ability Details" typeId="1b71-4c83-4e8c-093f">You can use this command ability in the combat phase if a friendly GRISTLEGORE HERO or GRISTLEGORE MONSTER that has not fought in that phase is slain while it is wholly within 12&quot; of a friendly GRISTLEGORE HERO, or wholly within 18&quot; of a friendly GRISTLEGORE HERO that is a general.  If you do so, before that model is removed from play, it can make a pile-in move and then attack with all of the melee weapons it is armed with.  You cannot pick the same unit to benefit from this ability more than once per phase.</characteristic>
+                            <characteristic name="Battle Trait Details" typeId="9fdd-b4b1-5f7a-0970">At the start of your combat phase, you can pick 1 friendly GRISTLEGORE MONSTER on the battlefield. The strike-first effect applies to that MONSTER until the end of the phase.</characteristic>
                           </characteristics>
                         </profile>
                       </profiles>
@@ -952,6 +935,46 @@ Muster Reinforcements: Pick 1 friendly FLESH-EATER COURTS HERO and roll 6 dice. 
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
               </costs>
+              <infoGroups>
+                <infoGroup name="Delusions of Grandeur" hidden="false" id="ce75-ec57-89d5-c8ec">
+                  <profiles>
+                    <profile name="Delusions of Grandeur" typeId="c137-4d1f-9d1a-524d" typeName="Battle Trait" hidden="false" id="cb2f-8347-5494-6148">
+                      <characteristics>
+                        <characteristic name="Battle Trait Details" typeId="9fdd-b4b1-5f7a-0970">At the start of the hero phase, you can carry out one of the following heroic actions with a friendly FLESH-EATER COURTS HERO instead of any other heroic action you can carry out with that HERO.</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="Rousing Oration" typeId="fff7-7178-1bdb-79d1" typeName="Heroic Action" hidden="false" id="f740-5c34-aa76-9064">
+                      <characteristics>
+                        <characteristic name="Description" typeId="ff08-d093-0b68-a4d6">Pick 1 friendly FLESH-EATER COURTS HERO and roll a dice for each other friendly FLESH-EATER COURTS unit wholly within 12&quot; of that Hero. For each 5+, give 1 noble deeds point to that HERO.</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="Scent of Blood" typeId="fff7-7178-1bdb-79d1" typeName="Heroic Action" hidden="false" id="85c4-aeec-268a-337b">
+                      <characteristics>
+                        <characteristic name="Description" typeId="ff08-d093-0b68-a4d6">Pick 1 friendly FLESH-EATER COURTS HERO and roll a dice. On a 3+, you can make a D6&quot; move with that HERO, but it must finish that move more than 3&quot; from all enemy units and closer to an enemy unit that has any wounds allocated to it.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </infoGroup>
+                <infoGroup name="Undead Monstrosities" hidden="false" id="b603-dea7-f6a5-1e31">
+                  <profiles>
+                    <profile name="Undead Monstrosities" typeId="c137-4d1f-9d1a-524d" typeName="Battle Trait" hidden="false" id="e15c-3078-469f-6f45">
+                      <characteristics>
+                        <characteristic name="Battle Trait Details" typeId="9fdd-b4b1-5f7a-0970">When you carry out a monstrous rampage with a ROYAL TERRORGHEIST or ROYAL ZOMBIE DRAGON, you can carry out 1 of the monstrous rampages below instead of any other monstrous rampage you can carry out with that unit.</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="Bloodcurdling Shriek" typeId="84d9-7a5a-fe76-b740" typeName="Monstrous Rampage" hidden="false" id="d790-e1b6-25b9-281">
+                      <characteristics>
+                        <characteristic name="Description" typeId="827b-962b-59a3-3b4d">Pick 1 enemy unit within 3&quot; of this unit and roll a dice. On a 3+, subtract 2 from the Bravery characteristic of that enemy unit until the end of the turn.</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="Delectable Appetisers" typeId="84d9-7a5a-fe76-b740" typeName="Monstrous Rampage" hidden="false" id="fd2c-9d34-a202-4c12">
+                      <characteristics>
+                        <characteristic name="Description" typeId="827b-962b-59a3-3b4d">Pick 1 enemy unit that has a Wounds characteristic of 2 or less and is within 3&quot; of this unit and roll a dice. On a 3+, that enemy unit suffers D3 mortal wounds. Then, for each mortal wound that was caused to that enemy unit and not negated, this unit heals 1 wound.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </infoGroup>
+              </infoGroups>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -3888,24 +3911,40 @@ Muster Reinforcements: Pick 1 friendly FLESH-EATER COURTS HERO and roll 6 dice. 
         <cost name="pts" typeId="points" value="0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="ae1d-e49b-1bda-8d2a" name="Flesh-eater Courts Battle Tactics" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="ae1d-e49b-1bda-8d2a" name="Battle Tactics: Duties to the Court" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3500-22ad-c629-d0a5" type="max"/>
       </constraints>
       <profiles>
-        <profile id="2764-fb8e-2b75-67eb" name="The Royal Hunt" hidden="false" typeId="eba0-4bf6-65fe-fdbc" typeName="Battle Tactic">
+        <profile id="0bc1-1741-e54d-0f64" name="Valiant Slaying" hidden="false" typeId="eba0-4bf6-65fe-fdbc" typeName="Battle Tactic">
           <characteristics>
-            <characteristic name="Description" typeId="f882-48d5-21a4-1787">When you reveal this battle tactic, pick 1 enemy MONSTER on the battlefield that has less than 5 wounds allocated to it. You complete this battle tactic if that MONSTER is slain during this turn. If that enemy MONSTER was slain by an attack made by a friendly ABHORRANT, score 1 additional victory point.</characteristic>
+            <characteristic name="Description" typeId="f882-48d5-21a4-1787">Pick 1 enemy MONSTER on the battlefield. You complete this battle tactic if that unit is destroyed during this turn by an attack made by a friendly ABHORRANT.</characteristic>
           </characteristics>
         </profile>
-        <profile id="c9a3-2319-8ef6-04a1" name="United Court" hidden="false" typeId="eba0-4bf6-65fe-fdbc" typeName="Battle Tactic">
+        <profile id="d93b-3f95-411b-3ee7" name="Overrun" hidden="false" typeId="eba0-4bf6-65fe-fdbc" typeName="Battle Tactic">
           <characteristics>
-            <characteristic name="Description" typeId="f882-48d5-21a4-1787">When you reveal this battle tactic, pick 1 objective on the battlefield that your opponent controls. You complete this battle tactic if you control that objective at the end of your turn and it is contested by at least 1 friendly SERFS mode, 1 friendly KNIGHTS model, and 1 friendly COURTIER model.</characteristic>
+            <characteristic name="Description" typeId="f882-48d5-21a4-1787">You complete this battle tactic if every enemy unit on the battlefield is within 3&quot; of a friendly FLESH-EATER COURTS unit at the end of the turn.</characteristic>
           </characteristics>
         </profile>
-        <profile id="0bc1-1741-e54d-0f64" name="Screamed to Death" hidden="false" typeId="eba0-4bf6-65fe-fdbc" typeName="Battle Tactic">
+        <profile id="65cb-678a-cac6-c46f" name="Glorious Feast" hidden="false" typeId="eba0-4bf6-65fe-fdbc" typeName="Battle Tactic">
           <characteristics>
-            <characteristic name="Description" typeId="f882-48d5-21a4-1787">Pick 1 enemy unit on the battlefield. You complete this battle tactic if that unit is destroyed this turn by attacks made with missile weapons by friendly Crypt Flayers units, Royal Terrorgheists, or Abhorrant Ghoul Kings on Royal Terrorgheists.</characteristic>
+            <characteristic name="Description" typeId="f882-48d5-21a4-1787">You complete this battle tactic if every friendly unit on the battlefield is wholly within 12&quot; of a friendly FLESH-EATER COURTS HERO that has 6 noble deeds points at the end of the turn.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="db21-e50d-1e3d-8e9f" name="Lance Formation" hidden="false" typeId="eba0-4bf6-65fe-fdbc" typeName="Battle Tactic">
+          <characteristics>
+            <characteristic name="Description" typeId="f882-48d5-21a4-1787">You complete this battle tactic if 2 or more friendly KNIGHTS units made a charge move this turn and the charge roll for each of those units was 7 or more.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="6804-7cda-10eb-123f" name="The Ties of Chivalry" hidden="false" typeId="eba0-4bf6-65fe-fdbc" typeName="Battle Tactic">
+          <characteristics>
+            <characteristic name="Description" typeId="f882-48d5-21a4-1787">Pick 1 objective on the battlefield that your opponent controls. You complete this battle tactic if you control that objective at the end of your turn and it is contested by at least 1 friendly SERFS model, 1 friendly KNIGHTS model and 1 friendly COURTIER model.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="62d9-92cd-dc2e-5d38" name="Screamed to Death" hidden="false" typeId="eba0-4bf6-65fe-fdbc" typeName="Battle Tactic">
+          <characteristics>
+            <characteristic name="Description" typeId="f882-48d5-21a4-1787">Pick 1 enemy unit on the battlefield. You complete this battle tactic if that unit is destroyed this turn by an attack made with a missile weapon used by a friendly CRYPT FLAYERS unit, CRYPT IFERNAL COURTIER or ROYAL TERRORGHEIST.
+</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -4139,6 +4178,130 @@ If it accepts, that enemy unit becomes infected. For the rest of the battle, rol
         </modifier>
       </modifiers>
     </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Ushoran, Mortarch of Delusion" hidden="false" id="3d22-faad-f95d-173a">
+      <entryLinks>
+        <entryLink id="e56b-33e2-2098-73d3" name="Battalions" hidden="false" collective="false" import="true" targetId="3f3e-293b-65ed-e3fa" type="selectionEntryGroup"/>
+        <entryLink id="a193-47a-cc6a-d2ac" name="Spell Lores" hidden="false" collective="false" import="true" targetId="011c-b2d0-4781-ff07" type="selectionEntryGroup"/>
+        <entryLink id="a50c-1bf1-fed8-2bf9" name="General" hidden="false" collective="false" import="true" targetId="8228-415a-66c3-dffe" type="selectionEntry"/>
+      </entryLinks>
+      <categoryLinks>
+        <categoryLink targetId="6cdf-dd4f-0e91-e9c4" id="38b1-82e1-34c5-d8ad" primary="false" name="DEATH"/>
+        <categoryLink targetId="6b35-0508-c6cc-6592" id="91d1-fc3e-3a86-d44f" primary="false" name="FLESH-EATER COURTS"/>
+        <categoryLink targetId="aaed-7228-c070-a251" id="80e5-b72e-6122-a79" primary="false" name="HOLLOWMOURNE"/>
+        <categoryLink targetId="d1e1-d80a-c667-b587" id="2a6a-115a-e8ce-88dd" primary="false" name="VAMPIRE"/>
+        <categoryLink targetId="5b04-42e4-33ef-10b1" id="6375-f8b-bd43-e112" primary="false" name="ABHORRANT"/>
+        <categoryLink targetId="4e0e-664d-51ea-0929" id="de5f-aef8-f1ac-1614" primary="false" name="HERO"/>
+        <categoryLink targetId="1959-9f6a-3056-913a" id="5c1-d13e-5e11-e436" primary="false" name="MONSTER"/>
+        <categoryLink targetId="4f53-8230-2f02-9639" id="c76f-c84b-d02d-2459" primary="false" name="WIZARD"/>
+        <categoryLink targetId="75f5-9da1-acc8-eb33" id="2d42-f28d-edd9-540b" primary="false" name="MORTARCH"/>
+        <categoryLink targetId="ec00-f808-c337-38f5" id="938-1871-10d6-72ed" primary="false" name="USHORAN"/>
+        <categoryLink targetId="6c6b-e787-f9b8-a510" id="c7d3-e352-bb95-f1a6" primary="true" name="Leader"/>
+        <categoryLink targetId="fa0c-9044-2568-fa02" id="6e2a-4b2a-2b0c-6f33" primary="false" name="Behemoth"/>
+        <categoryLink targetId="088b-3a27-03f7-8249" id="d496-7c75-d0e9-6b71" primary="false" name="Unique"/>
+      </categoryLinks>
+      <constraints>
+        <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="467e-de8-bb2a-5650" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="5ac8-47b6-d6fa-3e3b" name="Arcane Bolt" hidden="false" targetId="ae02-a84f-a903-1ff8" type="profile"/>
+        <infoLink id="112e-a3df-5a6f-95ee" name="Mystic Shield" hidden="false" targetId="b41f-f1ce-7aa5-4f81" type="profile"/>
+      </infoLinks>
+      <profiles>
+        <profile id="fd25-3269-6af0-5d2c" name="Wizard" hidden="false" typeId="f55d-ee3a-1597-110f" typeName="Magic">
+          <characteristics>
+            <characteristic name="Cast/Unbind" typeId="8294-f605-2c0f-8f92">2/2</characteristic>
+            <characteristic name="Spells Known" typeId="dc9c-47d3-6931-859c">Arcane Bolt, Mystic Shield and Glimpse of Delusion</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Epicentre of Delusion" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities" hidden="false" id="388f-2b8c-256f-f922">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If this unit is part of a FLESH-EATER COURTS army, in your hero phase, you can pick 1 delusion from the Courts of Delusion battle trait. Until your next hero phase, that delusion applies to friendly FLESH-EATER COURTS units while they are wholly within the Epicentre of Delusion range shown on this unit’s damage table, in addition to the delusion you picked before the start of the first turn.</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="The Carrion King" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities" hidden="false" id="3a93-67bc-fb2d-a6e0">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">While this unit has 6 noble deeds points, friendly FLESH-EATER COURTS units are affected by the Feeding Frenzy battle trait while they are wholly within 24&quot; of this unit instead of 12&quot;.</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Ushoran, Mortarch of Delusion" typeId="1960-ca8e-67ce-2014" typeName="Unit" hidden="false" id="cdc-b0ef-ba81-f238">
+          <characteristics>
+            <characteristic name="Move" typeId="8655-6213-2824-1752">10&quot;</characteristic>
+            <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">16</characteristic>
+            <characteristic name="Bravery" typeId="0c85-bf79-836b-759e">10</characteristic>
+            <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">4+</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Shroudcage Fragment" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities" hidden="false" id="aa1c-ad4a-a353-c339">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">At the start of the combat phase, subtract 1 from the Bravery characteristic of each enemy unit within 3&quot; of this unit until the end of the battle. Then, roll 2D6 for each enemy unit within 1” of this unit. If the result is higher than the Bravery characteristic of that unit, the strike-last effect applies to that unit until the end of the phase.</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="The King&apos;s Chalice" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities" hidden="false" id="ba40-5e6d-56f9-124b">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">This unit has a ward of 5+. In addition, in your hero phase, you can heal up to 2D3 wounds allocated to this unit.</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Glimpse of Delusion" typeId="2e81-5e22-c6e1-73cb" typeName="Spell" hidden="false" id="847d-5edb-f70a-caec">
+          <characteristics>
+            <characteristic name="Casting Value" typeId="2508-b604-1258-a920">7</characteristic>
+            <characteristic name="Range" typeId="5b5c-1fd1-4c0f-5705">18&quot;</characteristic>
+            <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, pick 1 enemy model within range and visible to the caster. Then, pick 1 melee weapon that enemy model is armed with and pick 1 other enemy unit within range of that weapon. That enemy model immediately makes combat attacks with that weapon targeting that other enemy unit.</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Monstrous Claws and Fangs" typeId="96df-ab28-5d72-bbb3" typeName="Weapon" hidden="false" id="ff26-b3c7-c3e7-b0c4">
+          <characteristics>
+            <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
+            <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">2&quot;</characteristic>
+            <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">3</characteristic>
+            <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">*</characteristic>
+            <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
+            <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-1</characteristic>
+            <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Sceptre of the Carrion King" typeId="96df-ab28-5d72-bbb3" typeName="Weapon" hidden="false" id="ef7b-18b5-b97f-d3a7">
+          <characteristics>
+            <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
+            <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">3&quot;</characteristic>
+            <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">3</characteristic>
+            <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">3+</characteristic>
+            <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">2+</characteristic>
+            <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-2</characteristic>
+            <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">D3+3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoGroups>
+        <infoGroup name="Damage Table" hidden="false" id="1b27-3290-c72b-cbd3">
+          <profiles>
+            <profile name="0-7" typeId="47ed-4c74-6bd2-980f" typeName="Ushoran Wounds Suffered" hidden="false" id="ec01-e27a-e7c9-ced8">
+              <characteristics>
+                <characteristic name="Monstrous Claws and Fangs" typeId="484c-b8de-f02e-75bb">10</characteristic>
+                <characteristic name="Epicentre of Delusion" typeId="37c2-fa8b-ae93-152c">30&quot;</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="8-9" typeId="47ed-4c74-6bd2-980f" typeName="Ushoran Wounds Suffered" hidden="false" id="f0f0-c076-866e-844">
+              <characteristics>
+                <characteristic name="Monstrous Claws and Fangs" typeId="484c-b8de-f02e-75bb">8</characteristic>
+                <characteristic name="Epicentre of Delusion" typeId="37c2-fa8b-ae93-152c">24&quot;</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="12+" typeId="47ed-4c74-6bd2-980f" typeName="Ushoran Wounds Suffered" hidden="false" id="1bb8-bebe-f552-3b22">
+              <characteristics>
+                <characteristic name="Monstrous Claws and Fangs" typeId="484c-b8de-f02e-75bb">4</characteristic>
+                <characteristic name="Epicentre of Delusion" typeId="37c2-fa8b-ae93-152c">12&quot;</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="10-11" typeId="47ed-4c74-6bd2-980f" typeName="Ushoran Wounds Suffered" hidden="false" id="e90b-ce02-1ea2-5e0c">
+              <characteristics>
+                <characteristic name="Monstrous Claws and Fangs" typeId="484c-b8de-f02e-75bb">6</characteristic>
+                <characteristic name="Epicentre of Delusion" typeId="37c2-fa8b-ae93-152c">18&quot;</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+        </infoGroup>
+      </infoGroups>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="c8cb-28b1-ffbb-2bbf" name="Artefacts" hidden="false" collective="false" import="true">
@@ -4160,203 +4323,92 @@ If it accepts, that enemy unit becomes infected. For the rest of the battle, rol
       <constraints>
         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="449c-8c4a-be77-4496" type="max"/>
       </constraints>
-      <selectionEntries>
-        <selectionEntry id="d598-c881-94e0-95fd" name="Decrepit Coronet" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="dbb1-fd69-0ebc-97df" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="e66a-270d-ea44-7f54" value="1">
-              <conditions>
-                <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="dbb1-fd69-0ebc-97df" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="23fa-1b92-066d-9683" value="1">
-              <conditions>
-                <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="dbb1-fd69-0ebc-97df" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="23fa-1b92-066d-9683" type="max"/>
-            <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="e66a-270d-ea44-7f54" type="min"/>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="46c5-83ed-06be-e877" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="17ae-5311-a3a1-838b" name="Decrepit Coronet" hidden="false" typeId="0ac4-aacb-2481-8e72" typeName="Artefact">
-              <characteristics>
-                <characteristic name="Artefact Details" typeId="0918-c47a-d84e-c0cf">Do not take battleshock tests for friendly MORGAUNT units while they are wholly within 12&quot; of the the bearer, or wholly within 18&quot; of the bearer if the bearer is your general.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <categoryLinks>
-            <categoryLink id="b57e-0ad4-ab55-962f" name="Artefact" hidden="false" targetId="3564-4c26-10b4-d953" primary="false"/>
-          </categoryLinks>
-          <costs>
-            <cost name="pts" typeId="points" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="63da-48ad-1dde-b4ef" name="Corpsefane Gauntlet" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="27db-a56d-c5fc-c616" value="1">
-              <conditions>
-                <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c6db-68c4-dfd6-58c0" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="fecd-c0a0-d337-885d" value="1">
-              <conditions>
-                <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c6db-68c4-dfd6-58c0" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c6db-68c4-dfd6-58c0" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="27db-a56d-c5fc-c616" type="min"/>
-            <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="fecd-c0a0-d337-885d" type="max"/>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="391b-91b9-9dc3-c76b" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="24f4-41b8-30ee-46cf" name="Corpsefane Gauntlet" hidden="false" typeId="0ac4-aacb-2481-8e72" typeName="Artefact">
-              <characteristics>
-                <characteristic name="Artefact Details" typeId="0918-c47a-d84e-c0cf">After this model makes a charge move, you can pick 1 enemy unit within 1&quot; of this model and roll a dice.  On a 2+ that enemy unit suffers D3 mortal wounds.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <categoryLinks>
-            <categoryLink id="2067-ee62-deef-91c5" name="Artefact" hidden="false" targetId="3564-4c26-10b4-d953" primary="false"/>
-          </categoryLinks>
-          <costs>
-            <cost name="pts" typeId="points" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="cb13-70b6-0f23-dc52" name="Eye of Hysh" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="c349-1bb0-fc74-39ee" value="1">
-              <conditions>
-                <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="83a9-0464-b308-eef1" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="7da3-4924-09b9-0d7f" value="1">
-              <conditions>
-                <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="83a9-0464-b308-eef1" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="83a9-0464-b308-eef1" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="c349-1bb0-fc74-39ee" type="min"/>
-            <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="7da3-4924-09b9-0d7f" type="max"/>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2856-fc21-c10a-97cc" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="cda1-3c7d-7e13-ea62" name="Eye of Hysh" hidden="false" typeId="0ac4-aacb-2481-8e72" typeName="Artefact">
-              <characteristics>
-                <characteristic name="Artefact Details" typeId="0918-c47a-d84e-c0cf">Subtract 1 from hit rolls for attacks made with missile weapons that target a friendly BLISTERSKIN unit wholly within 6&quot; of the bearer.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <categoryLinks>
-            <categoryLink id="ce55-eb6f-62a1-1789" name="Artefact" hidden="false" targetId="3564-4c26-10b4-d953" primary="false"/>
-          </categoryLinks>
-          <costs>
-            <cost name="pts" typeId="points" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="5620-3abe-0edb-1064" name="Ghurish Mawshard" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="1dd1-0f8f-f360-0a5f" value="1">
-              <conditions>
-                <condition field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="99b2-6989-d758-a4be" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="c6cc-4092-ed92-78e0" value="1">
-              <conditions>
-                <condition field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="99b2-6989-d758-a4be" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="99b2-6989-d758-a4be" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="1dd1-0f8f-f360-0a5f" type="max"/>
-            <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="c6cc-4092-ed92-78e0" type="min"/>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf6f-47b4-4e12-a91b" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="370d-bc95-f7eb-970f" name="Ghurish Mawshard" hidden="false" typeId="0ac4-aacb-2481-8e72" typeName="Artefact">
-              <characteristics>
-                <characteristic name="Artefact Details" typeId="0918-c47a-d84e-c0cf">Once per battle, at the start of the combat phase, you can pick 1 enemy model within 1&quot; of the bearer and roll a dice.  If the roll is greater than that model&apos;s Wounds characteristic, that model is slain.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <categoryLinks>
-            <categoryLink id="03e6-305a-14d8-f8f5" name="Artefact" hidden="false" targetId="3564-4c26-10b4-d953" primary="false"/>
-          </categoryLinks>
-          <costs>
-            <cost name="pts" typeId="points" value="0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
       <entryLinks>
-        <entryLink id="ed9c-f892-d90f-69df" name="Flesh-Eater Courts Artefacts" hidden="false" collective="false" import="true" targetId="2072-8001-6f68-7cbe" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="705f-02ae-f4f5-987a" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups>
-                    <conditionGroup type="and">
-                      <conditions>
-                        <condition field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="705f-02ae-f4f5-987a" type="equalTo"/>
-                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5b04-42e4-33ef-10b1" type="notInstanceOf"/>
-                      </conditions>
-                    </conditionGroup>
-                  </conditionGroups>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-        </entryLink>
         <entryLink id="a308-e618-2f02-37ee" name="Universal Artefacts of Power" hidden="false" collective="false" import="true" targetId="11c4-fd82-92a7-de8a" type="selectionEntryGroup"/>
-        <entryLink id="ce18-4e5d-7a51-4d3c" name="Realm Artefacts of Power" hidden="false" collective="false" import="true" targetId="37b0-af21-630c-d8af" type="selectionEntryGroup"/>
-        <entryLink id="097a-4ad8-a667-6cd9" name="Noble Heirlooms" hidden="false" collective="false" import="true" targetId="1ca0-51b1-7c91-2b54" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="705f-02ae-f4f5-987a" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups>
-                    <conditionGroup type="and">
-                      <conditions>
-                        <condition field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="705f-02ae-f4f5-987a" type="equalTo"/>
-                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3e2f-a545-bac2-1860" type="notInstanceOf"/>
-                      </conditions>
-                    </conditionGroup>
-                  </conditionGroups>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-        </entryLink>
         <entryLink id="c311-f7b5-6213-cda8" name="Relics of Gallet" hidden="false" collective="false" import="true" targetId="d27f-9ad5-990c-2915" type="selectionEntryGroup"/>
       </entryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup name="Noble Heirlooms" hidden="false" id="a570-d2c7-3fe7-1529">
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Medal of Madness" hidden="false" id="417a-45c1-7a1-aad2">
+              <profiles>
+                <profile name="Medal of Madness" typeId="0ac4-aacb-2481-8e72" typeName="Artefact" hidden="false" id="e020-f2c7-9b28-89c9">
+                  <characteristics>
+                    <characteristic name="Artefact Details" typeId="0918-c47a-d84e-c0cf">Once per battle round, the bearer can issue a command without a command point being spent, and they are treated as if they were a general when they do so.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b0da-37dd-7aeb-2888"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="The Flayed Pennant" hidden="false" id="83c-4e23-4495-3e9f">
+              <profiles>
+                <profile name="The Flayed Pennant" typeId="0ac4-aacb-2481-8e72" typeName="Artefact" hidden="false" id="d410-1d58-aeab-7abb">
+                  <characteristics>
+                    <characteristic name="Artefact Details" typeId="0918-c47a-d84e-c0cf">You can re-roll charge rolls for friendly Flesh-eater Courts units while they are wholly within 12&quot; of the bearer.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b7e0-bc8a-2c3c-5153"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Charnel Vestments" hidden="false" id="fe30-5f9e-3b8e-5fba">
+              <profiles>
+                <profile name="Charnel Vestments" typeId="0ac4-aacb-2481-8e72" typeName="Artefact" hidden="false" id="cf60-e068-2a94-63c0">
+                  <characteristics>
+                    <characteristic name="Artefact Details" typeId="0918-c47a-d84e-c0cf">The bearer gains the Priest keyword.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e0e2-e570-3001-3b88"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup name="Royal Treasury" hidden="false" id="f639-605c-8f72-be3d">
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Blood-river Chalice" hidden="false" id="a732-b6d9-4c5d-149a">
+              <profiles>
+                <profile name="Blood-river Chalice" typeId="0ac4-aacb-2481-8e72" typeName="Artefact" hidden="false" id="a6e2-34a8-4413-e16c">
+                  <characteristics>
+                    <characteristic name="Artefact Details" typeId="0918-c47a-d84e-c0cf">Once per battle, in the hero phase, the bearer can use this artefact. If they do so, heal up to 2D3 wounds allocated to the bearer.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3a6f-16d8-5697-14bb"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Heart of the Gargant" hidden="false" id="5b47-78a9-eeab-755c">
+              <profiles>
+                <profile name="Heart of the Gargant" typeId="0ac4-aacb-2481-8e72" typeName="Artefact" hidden="false" id="c16f-ea5f-e3cd-e432">
+                  <characteristics>
+                    <characteristic name="Artefact Details" typeId="0918-c47a-d84e-c0cf">Once per battle, at the start of the combat phase, the bearer can use this artefact. If they do so, add 1 to the Attacks characteristic of melee weapons used by the bearer and their mount in that phase.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a95f-8a2e-73e9-2417"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="The Grim Garland" hidden="false" id="903c-7ff4-3ca7-9c50">
+              <profiles>
+                <profile name="The Grim Garland" typeId="0ac4-aacb-2481-8e72" typeName="Artefact" hidden="false" id="b843-da6e-3e08-8533">
+                  <characteristics>
+                    <characteristic name="Artefact Details" typeId="0918-c47a-d84e-c0cf">Subtract 2 from the Bravery characteristic of enemy units while they are within 9&quot; of the bearer</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5945-5619-61d9-f712"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
     </selectionEntryGroup>
     <selectionEntryGroup id="ce7b-551c-20f3-f416" name="Courts of Delusion" hidden="false" collective="false" import="true">
       <constraints>
@@ -4466,310 +4518,92 @@ If it accepts, that enemy unit becomes infected. For the rest of the battle, rol
       <constraints>
         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e77-24a2-b606-64b8" type="max"/>
       </constraints>
-      <selectionEntries>
-        <selectionEntry id="6dc6-cfea-9822-55a2" name="Savage Chivalry" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="8afd-892a-0831-71ec" value="1">
-              <conditions>
-                <condition field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="dbb1-fd69-0ebc-97df" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="c277-584c-6868-a88f" value="1">
-              <conditionGroups>
-                <conditionGroup type="and">
-                  <conditions>
-                    <condition field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="dbb1-fd69-0ebc-97df" type="equalTo"/>
-                    <condition field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe3f-d230-7e2c-fba2" type="equalTo"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="dbb1-fd69-0ebc-97df" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="c277-584c-6868-a88f" type="min"/>
-            <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="8afd-892a-0831-71ec" type="max"/>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca41-7271-17d4-fdb2" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="f430-559e-4ce3-02c6" name="Savage Chivalry" hidden="false" typeId="c749-bae4-71a8-0c36" typeName="Command Trait">
-              <characteristics>
-                <characteristic name="Command Trait Details" typeId="ee96-6f3a-e5ca-2350">You can re-roll hit rolls of 1 for this general while this general is within 12&quot; of a friendly MORGAUNT SERFS unit.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="b406-b247-25be-a670" name="Grave Robber" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="bc85-a704-e91d-7b02" value="1">
-              <conditionGroups>
-                <conditionGroup type="and">
-                  <conditions>
-                    <condition field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe3f-d230-7e2c-fba2" type="equalTo"/>
-                    <condition field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c6db-68c4-dfd6-58c0" type="equalTo"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-            <modifier type="set" field="7f66-3211-a7ee-0555" value="1">
-              <conditions>
-                <condition field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c6db-68c4-dfd6-58c0" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c6db-68c4-dfd6-58c0" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="bc85-a704-e91d-7b02" type="min"/>
-            <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="7f66-3211-a7ee-0555" type="max"/>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b2f-f45d-fcd1-70f6" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="6517-7a5e-5c87-9a6d" name="Grave Robber" hidden="false" typeId="c749-bae4-71a8-0c36" typeName="Command Trait">
-              <characteristics>
-                <characteristic name="Command Trait Details" typeId="ee96-6f3a-e5ca-2350">Add 1 to the Attacks characteristic and Damage characteristic of this general&apos;s melee weapons while this general is within 3&quot; of any enemy HEROES with an artefact of power.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="2f95-e44a-5da8-a753" name="Hellish Orator" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="fea7-75d0-88cc-4482" value="1">
-              <conditionGroups>
-                <conditionGroup type="and">
-                  <conditions>
-                    <condition field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe3f-d230-7e2c-fba2" type="equalTo"/>
-                    <condition field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="83a9-0464-b308-eef1" type="equalTo"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-            <modifier type="set" field="12df-f79f-6d0f-275c" value="1">
-              <conditions>
-                <condition field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="83a9-0464-b308-eef1" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="83a9-0464-b308-eef1" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="fea7-75d0-88cc-4482" type="min"/>
-            <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="12df-f79f-6d0f-275c" type="max"/>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3d5-1f2d-28b4-6484" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="b678-ade1-cb30-3b0a" name="Hellish Orator" hidden="false" typeId="c749-bae4-71a8-0c36" typeName="Command Trait">
-              <characteristics>
-                <characteristic name="Command Trait Details" typeId="ee96-6f3a-e5ca-2350">If this general is on the battlefield at the start of your hero phase, roll a dice.  On a 4+ you receive 1 additional command point.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="8a4a-c805-bcc0-06b8" name="Savage Strike" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="f850-90ac-15a3-a1e6" value="1">
-              <conditionGroups>
-                <conditionGroup type="and">
-                  <conditions>
-                    <condition field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="99b2-6989-d758-a4be" type="equalTo"/>
-                    <condition field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe3f-d230-7e2c-fba2" type="equalTo"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-            <modifier type="set" field="908a-685e-3d17-ac4d" value="1">
-              <conditions>
-                <condition field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="99b2-6989-d758-a4be" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="99b2-6989-d758-a4be" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="f850-90ac-15a3-a1e6" type="min"/>
-            <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="908a-685e-3d17-ac4d" type="max"/>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="114a-114b-8443-a6b3" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="5eee-0521-0769-6e70" name="Savage Strike" publicationId="6afd-4f9a-0665-9b55" page="1" hidden="false" typeId="c749-bae4-71a8-0c36" typeName="Command Trait">
-              <characteristics>
-                <characteristic name="Command Trait Details" typeId="ee96-6f3a-e5ca-2350">The strike-first effect applies to this general and their mount if they made a charge move in the same turn.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
       <entryLinks>
-        <entryLink id="001d-605e-3718-ece5" name="Royalty Command Traits" hidden="false" collective="false" import="true" targetId="f944-ca97-7cdc-4616" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="705f-02ae-f4f5-987a" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups>
-                    <conditionGroup type="and">
-                      <conditions>
-                        <condition field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="705f-02ae-f4f5-987a" type="equalTo"/>
-                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5b04-42e4-33ef-10b1" type="notInstanceOf"/>
-                      </conditions>
-                    </conditionGroup>
-                  </conditionGroups>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-        </entryLink>
         <entryLink id="ad16-f717-fc6a-8224" name="Universal Command Traits" hidden="false" collective="false" import="true" targetId="b6b8-914a-dfca-18ee" type="selectionEntryGroup"/>
-        <entryLink id="cab6-8c0e-ae92-4b8a" name="Nobility Command Traits" hidden="false" collective="false" import="true" targetId="9e7d-6589-7d5a-7d7e" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="705f-02ae-f4f5-987a" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups>
-                    <conditionGroup type="and">
-                      <conditions>
-                        <condition field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="705f-02ae-f4f5-987a" type="equalTo"/>
-                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3e2f-a545-bac2-1860" type="notInstanceOf"/>
-                      </conditions>
-                    </conditionGroup>
-                  </conditionGroups>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-        </entryLink>
         <entryLink import="true" name="Universal Command Traits" hidden="false" type="selectionEntryGroup" id="96e9-4d14-e416-92d3" targetId="e372-6ace-3568-54e7"/>
       </entryLinks>
-    </selectionEntryGroup>
-    <selectionEntryGroup id="f944-ca97-7cdc-4616" name="Royalty Command Traits" hidden="false" collective="false" import="true">
-      <constraints>
-        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d79b-9eb1-1bc7-3349" type="max"/>
-      </constraints>
-      <selectionEntries>
-        <selectionEntry id="26a8-4ba1-f71b-bc79" name="1. Bringer of Death" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e23d-66d8-b5fe-ad9f" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="19c8-08c4-d21d-64c8" name="Bringer of Death" hidden="false" typeId="c749-bae4-71a8-0c36" typeName="Command Trait">
-              <characteristics>
-                <characteristic name="Command Trait Details" typeId="ee96-6f3a-e5ca-2350">You can re-roll wound rolls for attacks made by this general.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="564a-ea16-73d0-e36a" name="2. Frenzied Flesh-eater" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51a1-343e-c785-06a0" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="371c-da24-6622-bd6b" name="Frenzied Flesh-eater" hidden="false" typeId="c749-bae4-71a8-0c36" typeName="Command Trait">
-              <characteristics>
-                <characteristic name="Command Trait Details" typeId="ee96-6f3a-e5ca-2350">You can re-roll hit and wound rolls for attacks made by this general if there are any enemy models that have suffered any within 3&quot; of this general.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="00b4-d7a4-002e-bc42" name="4. Majestic Horror" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12a8-62f0-22fb-5d81" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="db85-200c-d00c-d3a4" name="Majestic Horror" hidden="false" typeId="c749-bae4-71a8-0c36" typeName="Command Trait">
-              <characteristics>
-                <characteristic name="Command Trait Details" typeId="ee96-6f3a-e5ca-2350">If the general is chosen as the model that uses a command ability that summons FLESH-EATER COURTS models to the battlefield, they can use it without a command point having to be spent.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="6dd1-2c20-da91-4dd9" name="3. Savage Beyond Reason" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44fb-09ee-3ac9-c312" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="d367-61b3-6d42-55ab" name="Savage Beyond Reason" hidden="false" typeId="c749-bae4-71a8-0c36" typeName="Command Trait">
-              <characteristics>
-                <characteristic name="Command Trait Details" typeId="ee96-6f3a-e5ca-2350">If the unmodified hit roll for an attack made with a melee weapon by this general is 6, that attack inflicts 2 hits on the target instead of 1.  Make a wound and save roll for each hit.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="bf5c-8d17-4aed-9551" name="5. Dark Wizardry" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f4f-fcb3-2c9e-fc3a" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="1e0b-6398-9368-f0dc" name="Dark Wizardry" hidden="false" typeId="c749-bae4-71a8-0c36" typeName="Command Trait">
-              <characteristics>
-                <characteristic name="Command Trait Details" typeId="ee96-6f3a-e5ca-2350">Add 1 to casting, dispelling and unbinding rolls for this general.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <categoryLinks>
-            <categoryLink id="a708-3f3f-d158-14b5" name="New CategoryLink" hidden="false" targetId="4f53-8230-2f02-9639" primary="false"/>
-          </categoryLinks>
-          <costs>
-            <cost name="pts" typeId="points" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="c328-bd9a-3114-455e" name="6. Completely Delusional" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb3b-7159-cb51-62e6" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="43a5-9a12-994b-00a9" name="Completely Delusional" hidden="false" typeId="c749-bae4-71a8-0c36" typeName="Command Trait">
-              <characteristics>
-                <characteristic name="Command Trait Details" typeId="ee96-6f3a-e5ca-2350">Once per battle, if this general has not been slain, you can pick a new delusion in your hero phase to replace the original delusion you chose for your army.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup name="Royalty" hidden="false" id="fc9e-cabe-deab-44e7">
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Stronger in Madness" hidden="false" id="c9b3-f608-8580-28bf">
+              <profiles>
+                <profile name="Stronger in Madness" typeId="c749-bae4-71a8-0c36" typeName="Command Trait" hidden="false" id="1922-6e9b-a790-a730">
+                  <characteristics>
+                    <characteristic name="Command Trait Details" typeId="ee96-6f3a-e5ca-2350">Add 2 to this general’s Wounds characteristic. While this general has 6 noble deeds points, they have a ward of 5+.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="974f-1c24-9b8f-f3da"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Savage Beyond Reason" hidden="false" id="8a21-bad-94dc-dee1">
+              <profiles>
+                <profile name="Savage Beyond Reason" typeId="c749-bae4-71a8-0c36" typeName="Command Trait" hidden="false" id="efd8-b284-11c1-4d31">
+                  <characteristics>
+                    <characteristic name="Command Trait Details" typeId="ee96-6f3a-e5ca-2350">If the unmodified hit roll for an attack made with a melee weapon by this general is 6, that attack scores 2 hits on the target instead of 1. If this general has 6 noble deeds points, that attack scores 3 hits on the target instead of 2.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3bfd-8a6-e661-ea4f"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Cruel Taskmaster" hidden="false" id="e03e-ca3f-fd17-fabc">
+              <profiles>
+                <profile name="Cruel Taskmaster" typeId="c749-bae4-71a8-0c36" typeName="Command Trait" hidden="false" id="7eba-807e-f6cc-93be">
+                  <characteristics>
+                    <characteristic name="Command Trait Details" typeId="ee96-6f3a-e5ca-2350">If this general uses the Muster Guard ability to return models to a unit, reduce the noble deeds cost of each returned model by 1, or if the cost was already 1, you can bring back 1 additional model instead.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="68c4-8153-5249-1849"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup name="Nobility" hidden="false" id="16d4-7b29-cf2a-ba05">
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Feverish Scholar" hidden="false" id="d88d-ffc-513-67d2">
+              <profiles>
+                <profile name="Feverish Scholar" typeId="c749-bae4-71a8-0c36" typeName="Command Trait" hidden="false" id="e6b0-e76d-dc16-5e21">
+                  <characteristics>
+                    <characteristic name="Command Trait Details" typeId="ee96-6f3a-e5ca-2350">Add 1 to casting rolls, dispelling rolls and unbinding rolls for this general. If this general has 6 noble deeds points, add 2 to casting rolls, dispelling rolls and unbinding rolls for this general instead of 1.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="287f-ac96-8dcf-c350"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Shadowy Obfuscation" hidden="false" id="2c44-3119-b414-60eb">
+              <profiles>
+                <profile name="Shadowy Obfuscation" typeId="c749-bae4-71a8-0c36" typeName="Command Trait" hidden="false" id="4afd-1cc2-e0cc-8e4">
+                  <characteristics>
+                    <characteristic name="Command Trait Details" typeId="ee96-6f3a-e5ca-2350">This general is not visible to enemy models that are more than 12&quot; away from them.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d2ca-133a-25be-c47a"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Master of the Menagerie" hidden="false" id="b8ec-e105-420-c21f">
+              <profiles>
+                <profile name="Master of the Menagerie" typeId="c749-bae4-71a8-0c36" typeName="Command Trait" hidden="false" id="7463-387e-9fa7-b18e">
+                  <characteristics>
+                    <characteristic name="Command Trait Details" typeId="ee96-6f3a-e5ca-2350">When using the Summon Loyal Subjects battle trait, you can pick 1 friendly FLESH-EATER COURTS MONSTER that is not a HERO and that has been destroyed, instead of a unit of SERFS or KNIGHTS. Set up a replacement unit as described in the battle trait and allocate 6 wounds to that replacement MONSTER that cannot be negated.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7107-3a65-8e3-2749"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
     </selectionEntryGroup>
     <selectionEntryGroup id="2072-8001-6f68-7cbe" name="Royal Treasury" hidden="false" collective="false" import="true">
       <constraints>
@@ -4880,103 +4714,6 @@ If it accepts, that enemy unit becomes infected. For the rest of the battle, rol
           <categoryLinks>
             <categoryLink id="8ca4-3852-6767-301c" name="Artefact" hidden="false" targetId="3564-4c26-10b4-d953" primary="false"/>
           </categoryLinks>
-          <costs>
-            <cost name="pts" typeId="points" value="0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-    </selectionEntryGroup>
-    <selectionEntryGroup id="9e7d-6589-7d5a-7d7e" name="Nobility Command Traits" hidden="false" collective="false" import="true">
-      <constraints>
-        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5858-63db-cb66-2e5e" type="max"/>
-      </constraints>
-      <selectionEntries>
-        <selectionEntry id="4536-3c4e-c4f6-d155" name="1. Bringer of Death" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1bfb-2e25-09cc-b805" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="72a1-0283-d36b-26d5" name="Bringer of Death" hidden="false" typeId="c749-bae4-71a8-0c36" typeName="Command Trait">
-              <characteristics>
-                <characteristic name="Command Trait Details" typeId="ee96-6f3a-e5ca-2350">You can re-roll wound rolls for attacks made by this general.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="5793-f3c4-3155-097c" name="2. Frenzied Flesh-eater" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d87-9b8e-5aa6-94b1" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="7ed6-b00f-f74c-272e" name="Frenzied Flesh-eater" hidden="false" typeId="c749-bae4-71a8-0c36" typeName="Command Trait">
-              <characteristics>
-                <characteristic name="Command Trait Details" typeId="ee96-6f3a-e5ca-2350">You can re-roll hit and wound rolls for attacks made by this general if there are any enemy models that have suffered any within 3&quot; of this general.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="8539-27e7-6df9-2895" name="3. Savage Beyond Reason" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="61b1-3e8b-26ca-38eb" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="f24b-20fb-5ba9-66a1" name="Savage Beyond Reason" hidden="false" typeId="c749-bae4-71a8-0c36" typeName="Command Trait">
-              <characteristics>
-                <characteristic name="Command Trait Details" typeId="ee96-6f3a-e5ca-2350">If the unmodified hit roll for an attack made with a melee weapon by this general is 6, that attack inflicts 2 hits on the target instead of 1.  Make a wound and save roll for each hit.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="cd23-af83-c210-8a02" name="4. Hulking Brute" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd7f-0285-d529-7980" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="6c58-aaf2-d83c-d22d" name="Hulking Brute" hidden="false" typeId="c749-bae4-71a8-0c36" typeName="Command Trait">
-              <characteristics>
-                <characteristic name="Command Trait Details" typeId="ee96-6f3a-e5ca-2350">Add 1 to this general&apos;s Wounds characteristic.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="0b73-204c-a55c-263e" name="5. Cruel Taskmaster" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abde-9b98-4d71-7cf6" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="1aa2-f87c-b9a6-f028" name="Cruel Taskmaster" hidden="false" typeId="c749-bae4-71a8-0c36" typeName="Command Trait">
-              <characteristics>
-                <characteristic name="Command Trait Details" typeId="ee96-6f3a-e5ca-2350">If this general uses a Muster ability you can re-roll the dice for this general that determine if slain models are returned to units (you must re-roll all of the dice).</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="c072-8804-feb2-d9ef" name="6. Dark Acolyte" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3ef-39ab-178a-b687" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="af67-1d9e-70f9-2a58" name="Dark Acolyte" hidden="false" typeId="c749-bae4-71a8-0c36" typeName="Command Trait">
-              <characteristics>
-                <characteristic name="Command Trait Details" typeId="ee96-6f3a-e5ca-2350">This general gains the WIZARD keyword and can cast and unbind spells in the same manner as an ABHORRANT GHOUL KING from the Abhorrant Ghoul King warscroll.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
           </costs>
@@ -5107,71 +4844,59 @@ If it accepts, that enemy unit becomes infected. For the rest of the battle, rol
         </modifier>
       </modifiers>
       <selectionEntries>
-        <selectionEntry id="039c-abbb-103d-8d49" name="1. Bonestorm" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c5e-efc6-4ed0-7878" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="e115-0b36-9e42-c519" name="Bonestorm" hidden="false" targetId="aa99-687a-7d70-4313" type="profile"/>
-          </infoLinks>
-          <costs>
-            <cost name="pts" typeId="points" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="d2b5-69c5-c2b0-3c93" name="2. Spectral Host" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ed0-c188-ea27-db18" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="f4ca-940f-a28c-343b" name="Spectral Host" hidden="false" targetId="a94b-797e-56da-3b8f" type="profile"/>
-          </infoLinks>
-          <costs>
-            <cost name="pts" typeId="points" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="d139-3c4c-c41e-5046" name="3. Monstrous Vigour" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be6f-d6f5-cc90-2b87" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="3e71-7fdb-5ad1-8cf3" name="Monstrous Vigour" hidden="false" targetId="ca44-d98d-931a-eaba" type="profile"/>
-          </infoLinks>
-          <costs>
-            <cost name="pts" typeId="points" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="ae92-be39-19f7-591f" name="4. Miasmal Shroud" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="ae92-be39-19f7-591f" name="Deranged Transformation" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d4f3-3e07-80c8-f255" type="max"/>
           </constraints>
-          <infoLinks>
-            <infoLink id="77e8-0336-5a70-3710" name="Miasmal Shroud" hidden="false" targetId="a9e3-c72b-a285-1208" type="profile"/>
-          </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
           </costs>
+          <profiles>
+            <profile name="Deranged Transformation" typeId="2e81-5e22-c6e1-73cb" typeName="Spell" hidden="false" id="349e-2b09-6adb-cace">
+              <characteristics>
+                <characteristic name="Casting Value" typeId="2508-b604-1258-a920">6</characteristic>
+                <characteristic name="Range" typeId="5b5c-1fd1-4c0f-5705">24&quot;</characteristic>
+                <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, pick 1 friendly FLESH-EATER COURTS unit wholly within range and visible to the caster that has a Wounds characteristic of 7 or less. Until your next hero phase, add 2&quot; to that unit’s Move characteristic and add 1 to wound rolls for attacks made by that unit.
+If the casting roll was 10 or more, you can pick up to 3 different friendly units to be affected by the spell instead of 1.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
         </selectionEntry>
-        <selectionEntry id="d676-e1b0-5619-7804" name="5. Deranged Transformation" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="4d31-283b-dbef-f995" name="Crimson Victuals" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a609-fc7b-df0f-d1fe" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30a9-7038-5c88-2137" type="max"/>
           </constraints>
-          <infoLinks>
-            <infoLink id="5963-c1d7-35e0-4c24" name="Deranged Transformation" hidden="false" targetId="e03f-f5ef-9494-379b" type="profile"/>
-          </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
           </costs>
+          <profiles>
+            <profile name="Crimson Victuals" typeId="2e81-5e22-c6e1-73cb" typeName="Spell" hidden="false" id="3796-881e-f778-636c">
+              <characteristics>
+                <characteristic name="Casting Value" typeId="2508-b604-1258-a920">6</characteristic>
+                <characteristic name="Range" typeId="5b5c-1fd1-4c0f-5705">18&quot;</characteristic>
+                <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, pick 1 enemy unit within range of the caster, and a friendly FLESH-EATER COURTS unit that has a Wounds characteristic of 1 and is within 6&quot; of that enemy unit. The enemy unit suffers D3 mortal wounds. Then, for each mortal wound that was caused to the enemy unit and not negated, you can return 1 slain model to the friendly unit.
+If the casting roll was 10 or more, the enemy unit suffers 2D3 mortal wounds instead of D3 mortal wounds.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
         </selectionEntry>
-        <selectionEntry id="12eb-79ad-66b7-3a1a" name="6. Blood Feast" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="fe4f-689a-d2de-ddff" name="Miasmal Shroud" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d26-666d-2c1b-4e9c" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="810e-7099-eb44-930b" type="max"/>
           </constraints>
-          <infoLinks>
-            <infoLink id="e9f9-c17c-b106-3ec0" name="Blood Feast" hidden="false" targetId="8236-8d28-defc-5987" type="profile"/>
-          </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
           </costs>
+          <profiles>
+            <profile name="Miasmal Shroud" typeId="2e81-5e22-c6e1-73cb" typeName="Spell" hidden="false" id="70dd-7bb-d494-5e76">
+              <characteristics>
+                <characteristic name="Casting Value" typeId="2508-b604-1258-a920">6</characteristic>
+                <characteristic name="Range" typeId="5b5c-1fd1-4c0f-5705">18&quot;</characteristic>
+                <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, pick 1 enemy unit within range and visible to the caster, and roll 6 dice. If 2 or more dice share the same value, that unit suffers 1 mortal wound. If 3 or more dice share the same value, subtract 1 from hit rolls for attacks made by that unit until your next hero phase (in addition to the previous effect). If 4 or more dice share the same value, subtract 1 from wound rolls for attacks made by that unit until your next hero phase (in addition to the previous effects).
+If the casting roll was 10 or more, roll 8 dice instead of 6. Each effect can only be triggered once, even if there is more than one set of dice with the same value.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
@@ -5229,11 +4954,11 @@ If it accepts, that enemy unit becomes infected. For the rest of the battle, rol
         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="67ea-d5c5-a294-f2b9" type="max"/>
       </constraints>
       <selectionEntries>
-        <selectionEntry id="e516-718b-53ca-3f7e" name="1. Deathly Fast" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="6d87-b2af-5d89-6827" name="Gruesome Bite" hidden="false" collective="false" import="true" type="upgrade">
           <profiles>
-            <profile id="35a8-9bf2-78c1-5611" name="Deathly Fast" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+            <profile id="cdd2-ee76-4e40-9e6b" name="Gruesome Bite" hidden="false" typeId="e6fe-61ec-3973-ad03" typeName="Mount Trait">
               <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">This model can run and still shoot in the same turn.</characteristic>
+                <characteristic name="Mount Trait Details" typeId="0603-faf4-fada-3cbf">Add 1 to the Attacks characteristic of this unit’s Fanged Maw.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -5241,11 +4966,11 @@ If it accepts, that enemy unit becomes infected. For the rest of the battle, rol
             <cost name="pts" typeId="points" value="0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="bb2e-035c-edbf-4b53" name="2. Razor-clawed" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="4c3-49ea-5515-ced5" name="Morbheg’s Swiftness" hidden="false" collective="false" import="true" type="upgrade">
           <profiles>
-            <profile id="d618-fd65-8f6a-f148" name="Razor-clawed" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+            <profile id="bcb7-ebf4-5c23-b24f" name="Morbheg’s Swiftness" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
               <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Improve the Rend characteristic of this mount&apos;s melee weapon by 1.</characteristic>
+                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">This unit can retreat and still charge later in the turn.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -5253,47 +4978,11 @@ If it accepts, that enemy unit becomes infected. For the rest of the battle, rol
             <cost name="pts" typeId="points" value="0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="2f08-94c6-0ea0-f2ea" name="3. Horribly Infested" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="7348-a01-fe27-9ab1" name="Horribly Resilient" hidden="false" collective="false" import="true" type="upgrade">
           <profiles>
-            <profile id="9e03-a169-3429-9c75" name="Horribly Infested" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+            <profile id="2571-9df3-bab3-6938" name="Horribly Resilient" hidden="false" typeId="e6fe-61ec-3973-ad03" typeName="Mount Trait">
               <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">This model&apos;s Infested ability inflicts 3 mortal wounds instead of D3 mortal wounds.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="9e2d-bf38-84f1-ba9f" name="4. Horribly Resilient" hidden="false" collective="false" import="true" type="upgrade">
-          <profiles>
-            <profile id="c1e4-499e-d74f-b7a7" name="Horribly Resilient" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">This model&apos;s Royal Blood ability heals up to 3 wounds instead of up to D3 wounds.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="1704-8ff9-c5cd-f37b" name="5. Gruesome Bite" hidden="false" collective="false" import="true" type="upgrade">
-          <profiles>
-            <profile id="7c92-8414-8b21-e23d" name="Gruesome Bite" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">You can re-roll failed hit rolls for attacks made with mount&apos;s Fanged Maw.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="d102-fdf3-de53-e590" name="6. Devastating Scream" hidden="false" collective="false" import="true" type="upgrade">
-          <profiles>
-            <profile id="0346-1c92-36af-0b7a" name="Devastating Scream" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Add 1 to each of the Death Shriek values on this model&apos;s damage table.</characteristic>
+                <characteristic name="Mount Trait Details" typeId="0603-faf4-fada-3cbf">This unit’s Royal Blood ability heals up to 2D3 wounds instead of up to D3 wounds.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -5327,11 +5016,11 @@ If it accepts, that enemy unit becomes infected. For the rest of the battle, rol
         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dea2-2478-453e-1f20" type="max"/>
       </constraints>
       <selectionEntries>
-        <selectionEntry id="08f9-a4cd-b839-580f" name="1. Deathly Fast" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="08f9-a4cd-b839-580f" name="Venerated Zombie Dragon" hidden="false" collective="false" import="true" type="upgrade">
           <profiles>
-            <profile id="0c6b-333f-e473-8752" name="Deathly Fast" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+            <profile id="0c6b-333f-e473-8752" name="Venerated Zombie Dragon" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
               <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">This model can run and still shoot in the same turn.</characteristic>
+                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Add 1 to hit rolls for friendly FLESH-EATER COURTS MONSTERS while they are wholly within 12&quot; of this unit.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -5339,11 +5028,11 @@ If it accepts, that enemy unit becomes infected. For the rest of the battle, rol
             <cost name="pts" typeId="points" value="0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="96fc-e5b6-5911-fc23" name="2. Razor-clawed" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="0f63-99c2-6ae0-b6f7" name="Baneful Breath" hidden="false" collective="false" import="true" type="upgrade">
           <profiles>
-            <profile id="76d9-7ad4-d558-2bbf" name="Razor-clawed" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+            <profile id="cfe9-5fc6-5ec4-a70c" name="Baneful Breath" hidden="false" typeId="e6fe-61ec-3973-ad03" typeName="Mount Trait">
               <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Improve the Rend characteristic of this mount&apos;s melee weapon by 1.</characteristic>
+                <characteristic name="Mount Trait Details" typeId="0603-faf4-fada-3cbf">Improve the Rend characteristic of this unit’s Pestilential Breath by 1.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -5351,47 +5040,11 @@ If it accepts, that enemy unit becomes infected. For the rest of the battle, rol
             <cost name="pts" typeId="points" value="0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="0f63-99c2-6ae0-b6f7" name="3. Baneful Breath" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="e18b-3f59-8d8b-d750" name="Death From the Skies" hidden="false" collective="false" import="true" type="upgrade">
           <profiles>
-            <profile id="cfe9-5fc6-5ec4-a70c" name="Baneful Breath" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+            <profile id="7c80-9692-6e64-81cf" name="Death From the Skies" hidden="false" typeId="e6fe-61ec-3973-ad03" typeName="Mount Trait">
               <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">You can re-roll wound rolls for attacks made with this model&apos;s Pestilential Breath.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="f4b0-6ebf-1326-2acc" name="4. Horribly Resilient" hidden="false" collective="false" import="true" type="upgrade">
-          <profiles>
-            <profile id="a4b2-ff7c-c606-7dbc" name="Horribly Resilient" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">This model&apos;s Royal Blood ability heals up to 3 wounds instead of up to D3 wounds.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="f95a-09ee-8e62-d21a" name="5. Necrotic Fangs" hidden="false" collective="false" import="true" type="upgrade">
-          <profiles>
-            <profile id="3b64-2742-b54b-9d4c" name="Necrotic Fangs" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">You can re-roll the Damage characteristic roll for this model&apos;s Snapping Maw.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="e18b-3f59-8d8b-d750" name="6. Death From the Skies" hidden="false" collective="false" import="true" type="upgrade">
-          <profiles>
-            <profile id="7c80-9692-6e64-81cf" name="Death From the Skies" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Instead of setting up this model on the battlefield, you can place it to one side and say that it is soaring in the skies in reserve.  If you do so, at the end of your first movement phase, you must set up this unit on the battlefield more than 9&quot; from any enemy units.</characteristic>
+                <characteristic name="Mount Trait Details" typeId="0603-faf4-fada-3cbf">Instead of setting up this unit on the battlefield, you can place it to one side and say that it is soaring in the skies in reserve. If you do so, at the end of your first movement phase, you must set up this unit on the battlefield more than 9&quot; from all enemy units.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -5461,6 +5114,107 @@ If it accepts, that enemy unit becomes infected. For the rest of the battle, rol
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
+    <selectionEntryGroup name="Prayer Scriptures" hidden="false" id="ec11-dabf-5c8-1a21">
+      <modifiers>
+        <modifier type="set" field="f879-c4b8-2d35-a4f" value="1">
+          <repeats>
+            <repeat field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="24e6-c9b0-8d0d-02a2" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8af4-649e-9ee2-22ee" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="78f3-8a59-699a-61e8" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="24d6-500b-7e3f-1470" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1e36-e511-437b-5de8" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="524e-8001-63ee-cdf7" type="instanceOf"/>
+              </conditions>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition type="notInstanceOf" value="1" field="selections" scope="parent" childId="e8a5-e4c1-3d11-e7dd" shared="true"/>
+                    <condition type="notEqualTo" value="1" field="selections" scope="parent" childId="fe30-5f9e-3b8e-5fba" shared="true"/>
+                  </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition type="lessThan" value="1" field="selections" scope="roster" childId="83a9-0464-b308-eef1" shared="true" includeChildSelections="true" includeChildForces="true"/>
+                        <condition type="notInstanceOf" value="1" field="selections" scope="parent" childId="5b04-42e4-33ef-10b1" shared="true"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f879-c4b8-2d35-a4f" type="max"/>
+      </constraints>
+      <selectionEntryGroups>
+        <selectionEntryGroup name="Rites of Delusion" hidden="false" id="eb90-b742-6b0b-f41c">
+          <selectionEntries>
+            <selectionEntry id="18ad-6eae-f322-d4eb" name="Charnel Conviction" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="920c-cbec-a964-f3d7" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="0"/>
+              </costs>
+              <profiles>
+                <profile name="Charnel Conviction" typeId="eed7-4131-0a52-0668" typeName="Prayer" hidden="false" id="380f-42ee-821f-c833">
+                  <characteristics>
+                    <characteristic name="Answer Value" typeId="276a-ab7e-145d-3ffc">3</characteristic>
+                    <characteristic name="Range" typeId="fd81-4e98-28ac-092a">18&quot;</characteristic>
+                    <characteristic name="Description" typeId="0746-6cfb-5e15-53cb">If answered, pick 1 friendly FLESH-EATER COURTS unit wholly within range and visible to the chanter. That unit has a ward of 5+ until your next hero phase.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry id="1814-1d04-9361-3e83" name="The Summerking’s Favour" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="391e-a22b-86f1-ba72" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="0"/>
+              </costs>
+              <profiles>
+                <profile name="The Summerking’s Favour" typeId="eed7-4131-0a52-0668" typeName="Prayer" hidden="false" id="2ad4-a0d9-4308-9f9e">
+                  <characteristics>
+                    <characteristic name="Answer Value" typeId="276a-ab7e-145d-3ffc">3</characteristic>
+                    <characteristic name="Range" typeId="fd81-4e98-28ac-092a">18&quot;</characteristic>
+                    <characteristic name="Description" typeId="0746-6cfb-5e15-53cb">If answered, pick 1 friendly FLESH-EATER COURTS HERO wholly within range and visible to the chanter. Until your next hero phase, that Hero gains 1 additional noble deeds point each time they slay an enemy model.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry id="8e35-a49f-903f-9ec5" name="Bless This Meal" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4fa9-a9dd-3ac-27d7" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="0"/>
+              </costs>
+              <profiles>
+                <profile name="Bless This Meal" typeId="eed7-4131-0a52-0668" typeName="Prayer" hidden="false" id="c7c1-c45e-144-d424">
+                  <characteristics>
+                    <characteristic name="Answer Value" typeId="276a-ab7e-145d-3ffc">3</characteristic>
+                    <characteristic name="Range" typeId="fd81-4e98-28ac-092a">18&quot;</characteristic>
+                    <characteristic name="Description" typeId="0746-6cfb-5e15-53cb">If answered, pick 1 enemy unit within range that is visible to the chanter. Each time a model from that enemy unit is slain, you can heal 1 wound allocated to 1 friendly FLESH-EATER COURTS unit within 6&quot; of that enemy unit.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink import="true" name="Universal Prayer Scripture" hidden="false" type="selectionEntryGroup" id="7dd3-a5b-66c2-c435" targetId="3674-103c-35c9-85a6"/>
+      </entryLinks>
+    </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedProfiles>
     <profile id="aa99-687a-7d70-4313" name="Bonestorm" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
@@ -5512,5 +5266,4 @@ If it accepts, that enemy unit becomes infected. For the rest of the battle, rol
     <catalogueLink id="6293-b5b7-5166-6bee" name="Endless Spells" targetId="f0db-356d-9f9f-662d" type="catalogue" importRootEntries="true"/>
     <catalogueLink id="ecd3-786c-7f00-9fac" name="Regiments of Renown" targetId="33cf-d309-6df3-50d6" type="catalogue" importRootEntries="true"/>
   </catalogueLinks>
-  <xmlns>http://www.battlescribe.net/schema/catalogueSchema</xmlns>
 </catalogue>

--- a/Death - Flesh-eater Courts.cat
+++ b/Death - Flesh-eater Courts.cat
@@ -76,6 +76,13 @@
     <categoryEntry id="52e4-3e6e-c3c9-58e0" name="ROYAL BEASTFLAYERS" hidden="false"/>
     <categoryEntry name="MARROWSCROLL HERALD" hidden="false" id="e331-5936-7c92-f48b"/>
     <categoryEntry name="USHORAN" hidden="false" id="ec00-f808-c337-38f5"/>
+    <categoryEntry name="ABHORRANT CARDINAL" hidden="false" id="9aa6-4e02-cf3-aa5b"/>
+    <categoryEntry name="ABHORRANT GOREWARDEN" hidden="false" id="fe0a-2400-fd27-1447"/>
+    <categoryEntry name="GRAND JUSTICE GORMAYNE" hidden="false" id="bb13-e01f-8d98-c68c"/>
+    <categoryEntry name="ROYAL DECAPITATOR" hidden="false" id="6aaf-34b3-15d0-400d"/>
+    <categoryEntry name="CRYPTGUARD" hidden="false" id="9527-1e4c-6681-2aa5"/>
+    <categoryEntry name="MORBHEG KNIGHTS" hidden="false" id="28ac-1b27-ef5e-33be"/>
+    <categoryEntry name="Gorewarden general" hidden="true" id="c89f-a721-882d-41b9"/>
   </categoryEntries>
   <entryLinks>
     <entryLink id="c7c9-5a8a-4868-57bc" name="Allegiance" hidden="false" collective="false" import="true" targetId="d563-f542-5dad-2b09" type="selectionEntry">
@@ -289,11 +296,6 @@
         </modifier>
       </modifiers>
       <profiles>
-        <profile id="ee85-ecbb-396d-2387" name="Royal Blood" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-          <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">In your hero phase, you can heal up to D3 wounds allocated to this model.</characteristic>
-          </characteristics>
-        </profile>
         <profile id="9087-1bc2-d242-968d" name="Wizard" hidden="false" typeId="f55d-ee3a-1597-110f" typeName="Magic">
           <characteristics>
             <characteristic name="Cast/Unbind" typeId="8294-f605-2c0f-8f92">1/1</characteristic>
@@ -308,9 +310,23 @@
             <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">4+</characteristic>
           </characteristics>
         </profile>
-        <profile id="e836-17c7-0674-8a88" name="Summon Men-at-arms" hidden="false" typeId="f71f-b0a4-730e-ced3" typeName="Command Abilities">
+        <profile id="e836-17c7-0674-8a88" name="Code of Honour" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Command Ability Details" typeId="1b71-4c83-4e8c-093f">You can use this command ability at the end of your movement phase. If you do so, pick 1 friendly model that has this command ability and has not used it before in the battle. That model summons 1 unit of up to 10 SERFS to the battlefield. The summoned unit is added to your army, and must be set up wholly within 6&quot; of the edge of the battlefield and more than 9&quot; from any enemy units.</characteristic>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">At the start of the combat phase, you can pick an enemy HERO within 1&quot; of this unit and say that this unit will duel that enemy HERO. If you do so, add 1 to the Damage characteristic of this unit’s melee weapons until the end of the phase, but it can only target that enemy HERO.
+
+</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="544c-2f8f-39d0-fffe" name="Royal Blood" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">In your hero phase, you can heal up to D3 wounds allocated to this unit.</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Unnatural Speed" typeId="2e81-5e22-c6e1-73cb" typeName="Spell" hidden="false" id="884c-88cf-c581-3d05">
+          <characteristics>
+            <characteristic name="Casting Value" typeId="2508-b604-1258-a920">6</characteristic>
+            <characteristic name="Range" typeId="5b5c-1fd1-4c0f-5705"/>
+            <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, this unit can immediately attempt a charge and you can roll 3D6 for the charge roll. If the charge is successful, the strike-first effect applies to this unit in the following combat phase.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -341,29 +357,11 @@
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                 <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
-                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">6</characteristic>
+                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">5</characteristic>
                 <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">3+</characteristic>
                 <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
                 <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-1</characteristic>
-                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="401c-96bf-e614-aa65" name="Black Hunger" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b7d2-f7f8-921f-34ab" type="min"/>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba01-f029-7356-2450" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="d25d-27ca-3ea2-09d1" name="Black Hunger" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
-              <characteristics>
-                <characteristic name="Casting Value" typeId="2508-b604-1258-a920">5</characteristic>
-                <characteristic name="Range" typeId="5b5c-1fd1-4c0f-5705">24&quot;</characteristic>
-                <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, pick 1 friendly FLESH-EATER COURTS unit wholly within 24&quot; of the caster and visible to them. Add 1 to the Attacks characteristic of melee weapons used by that unit until your next hero phase.</characteristic>
+                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">2</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -382,7 +380,7 @@
         <entryLink id="7586-8f34-3277-64b1" name="Unique Enhancements" hidden="false" collective="false" import="true" targetId="62f4-174e-c529-75fe" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="170"/>
+        <cost name="pts" typeId="points" value="130"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="25e3-54ae-82f5-152f" name="Abhorrant Ghoul King on Royal Terrorgheist" publicationId="6afd-4f9a-0665-9b55" hidden="false" collective="false" import="true" type="unit">
@@ -590,60 +588,32 @@
         <profile id="d3cb-acad-a59b-e8ba" name="Wizard" hidden="false" typeId="f55d-ee3a-1597-110f" typeName="Magic">
           <characteristics>
             <characteristic name="Cast/Unbind" typeId="8294-f605-2c0f-8f92">1/1</characteristic>
-            <characteristic name="Spells Known" typeId="dc9c-47d3-6931-859c">Arcane Bolt, Mystic Shield and Malefic Hunger spells.</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="44b3-6879-4336-6077" name="00-03" hidden="false" typeId="b1c1-c8b1-016e-4235" typeName="Zombie Dragon&apos;s Wound Table">
-          <characteristics>
-            <characteristic name="Move" typeId="1712-425e-7e40-a5b1">14&quot;</characteristic>
-            <characteristic name="Pestilential Breath" typeId="b17b-97f7-9c40-21e5">2+</characteristic>
-            <characteristic name="Sword-like Claws" typeId="e309-9fb0-c644-47ee">7</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="ed8d-976f-fc8a-5cbd" name="04-06" hidden="false" typeId="b1c1-c8b1-016e-4235" typeName="Zombie Dragon&apos;s Wound Table">
-          <characteristics>
-            <characteristic name="Move" typeId="1712-425e-7e40-a5b1">12&quot;</characteristic>
-            <characteristic name="Pestilential Breath" typeId="b17b-97f7-9c40-21e5">3+</characteristic>
-            <characteristic name="Sword-like Claws" typeId="e309-9fb0-c644-47ee">6</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="2f95-57cd-a600-4f24" name="07-09" hidden="false" typeId="b1c1-c8b1-016e-4235" typeName="Zombie Dragon&apos;s Wound Table">
-          <characteristics>
-            <characteristic name="Move" typeId="1712-425e-7e40-a5b1">10&quot;</characteristic>
-            <characteristic name="Pestilential Breath" typeId="b17b-97f7-9c40-21e5">4+</characteristic>
-            <characteristic name="Sword-like Claws" typeId="e309-9fb0-c644-47ee">5</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="3a66-5d5b-06b6-6295" name="10-12" hidden="false" typeId="b1c1-c8b1-016e-4235" typeName="Zombie Dragon&apos;s Wound Table">
-          <characteristics>
-            <characteristic name="Move" typeId="1712-425e-7e40-a5b1">8&quot;</characteristic>
-            <characteristic name="Pestilential Breath" typeId="b17b-97f7-9c40-21e5">5+</characteristic>
-            <characteristic name="Sword-like Claws" typeId="e309-9fb0-c644-47ee">4</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="a445-c165-01b7-0391" name="13+" hidden="false" typeId="b1c1-c8b1-016e-4235" typeName="Zombie Dragon&apos;s Wound Table">
-          <characteristics>
-            <characteristic name="Move" typeId="1712-425e-7e40-a5b1">6&quot;</characteristic>
-            <characteristic name="Pestilential Breath" typeId="b17b-97f7-9c40-21e5">6+</characteristic>
-            <characteristic name="Sword-like Claws" typeId="e309-9fb0-c644-47ee">3</characteristic>
+            <characteristic name="Spells Known" typeId="dc9c-47d3-6931-859c">Arcane Bolt, Mystic Shield and Monstrous Hunger spells.</characteristic>
           </characteristics>
         </profile>
         <profile id="353c-cd25-8bcd-cf3f" name="Abhorrant Ghoul King on Royal Zombie Dragon" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>
             <characteristic name="Move" typeId="8655-6213-2824-1752">*</characteristic>
-            <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">14</characteristic>
+            <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">16</characteristic>
             <characteristic name="Bravery" typeId="0c85-bf79-836b-759e">10</characteristic>
             <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">4+</characteristic>
           </characteristics>
         </profile>
-        <profile id="963d-3a48-1b7d-2936" name="Royal Blood" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+        <profile id="621c-a17b-3a1f-cc7e" name="Draconic Terror" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">In your hero phase, you can heal up to D3 wounds allocated to this model.</characteristic>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Enemy units cannot receive the Inspiring Presence command while they are within 3&quot; of any friendly units with this ability.</characteristic>
           </characteristics>
         </profile>
-        <profile id="dd33-f077-7952-fc7a" name="Summon Royal Courtier" hidden="false" typeId="f71f-b0a4-730e-ced3" typeName="Command Abilities">
+        <profile id="d9c9-be60-8d1c-e721" name="Royal Blood" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Command Ability Details" typeId="1b71-4c83-4e8c-093f">You can use this command ability at the end of your movement phase. If you do so, pick 1 friendly model that has this command ability and has not used it before in the battle. That model summons 1 Courtier unit to the battlefield. The summoned unit is added to your army, and must be set up wholly within 6&quot; of the edge of the battlefield and more than 9&quot; from any enemy units.</characteristic>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">In your hero phase, you can heal up to D3 wounds allocated to this unit.</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Monstrous Hunger" typeId="2e81-5e22-c6e1-73cb" typeName="Spell" hidden="false" id="8ee9-bbe7-82e-2a64">
+          <characteristics>
+            <characteristic name="Casting Value" typeId="2508-b604-1258-a920">6</characteristic>
+            <characteristic name="Range" typeId="5b5c-1fd1-4c0f-5705">18&quot;</characteristic>
+            <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, friendly FLESH-EATER COURTS MONSTERS wholly within range of the caster are filled with monstrous hunger until your next hero phase. A unit filled with monstrous hunger can run and still charge later in the turn.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -701,8 +671,8 @@
                 <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">3</characteristic>
                 <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">4+</characteristic>
                 <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
-                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-2</characteristic>
-                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">D6</characteristic>
+                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-3</characteristic>
+                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">3</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -716,38 +686,15 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58ff-ad69-36dd-0f6b" type="max"/>
           </constraints>
           <profiles>
-            <profile id="563f-e2a7-1dcc-f820" name="Pestilential Breath" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">When you attack with this model’s Pestilential Breath, roll a dice before making the hit roll for the attack. If the roll is less than or equal to the number of models in the target unit, the attack scores a hit without needing to make a hit roll.</characteristic>
-              </characteristics>
-            </profile>
             <profile id="e03a-7430-bd0e-d976" name="Pestilential Breath" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Missile</characteristic>
-                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">9&quot;</characteristic>
-                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">1</characteristic>
+                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">12&quot;</characteristic>
+                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">D6</characteristic>
                 <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">3+</characteristic>
-                <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">*</characteristic>
-                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-3</characteristic>
-                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">D6</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="5295-f692-14d0-bae7" name="Malefic Hunger" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b2f-2705-cc1b-ef6c" type="min"/>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dcaf-423d-c63b-c714" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="e5cb-b4f2-e5de-ecb4" name="Malefic Hunger" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
-              <characteristics>
-                <characteristic name="Casting Value" typeId="2508-b604-1258-a920">6</characteristic>
-                <characteristic name="Range" typeId="5b5c-1fd1-4c0f-5705">-</characteristic>
-                <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, until your next hero phase you can re-roll wound rolls for attacks made with melee weapons by friendly Flesh‐eater Courts units wholly within 16&quot; of the caster.</characteristic>
+                <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
+                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-1</characteristic>
+                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">3</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -765,11 +712,11 @@
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                 <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
-                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">5</characteristic>
+                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">4</characteristic>
                 <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">3+</characteristic>
                 <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
                 <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-1</characteristic>
-                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
+                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">2</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -791,6 +738,36 @@
       <costs>
         <cost name="pts" typeId="points" value="430"/>
       </costs>
+      <infoGroups>
+        <infoGroup name="Damage Table" hidden="false" id="79f6-7731-b373-ba41">
+          <profiles>
+            <profile name="0-6" typeId="1fc7-f451-3937-0a17" typeName="Zombie Dragon&apos;s Wounds Suffered" hidden="false" id="6b42-9de3-3b09-7e13">
+              <characteristics>
+                <characteristic name="Move" typeId="1712-425e-7e40-a5b1">14&quot;</characteristic>
+                <characteristic name="Sword-like Claws" typeId="e309-9fb0-c644-47ee">7</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="7-8" typeId="1fc7-f451-3937-0a17" typeName="Zombie Dragon&apos;s Wounds Suffered" hidden="false" id="be9e-939a-67c2-e39a">
+              <characteristics>
+                <characteristic name="Move" typeId="1712-425e-7e40-a5b1">12&quot;</characteristic>
+                <characteristic name="Sword-like Claws" typeId="e309-9fb0-c644-47ee">6</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="9-11" typeId="1fc7-f451-3937-0a17" typeName="Zombie Dragon&apos;s Wounds Suffered" hidden="false" id="dcbc-5d2b-3870-2a4b">
+              <characteristics>
+                <characteristic name="Move" typeId="1712-425e-7e40-a5b1">10&quot;</characteristic>
+                <characteristic name="Sword-like Claws" typeId="e309-9fb0-c644-47ee">5</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="12+" typeId="1fc7-f451-3937-0a17" typeName="Zombie Dragon&apos;s Wounds Suffered" hidden="false" id="3c89-1ee9-b953-869a">
+              <characteristics>
+                <characteristic name="Move" typeId="1712-425e-7e40-a5b1">8&quot;</characteristic>
+                <characteristic name="Sword-like Claws" typeId="e309-9fb0-c644-47ee">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+        </infoGroup>
+      </infoGroups>
     </selectionEntry>
     <selectionEntry id="d563-f542-5dad-2b09" name="Allegiance" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
@@ -2036,7 +2013,6 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af5a-c2ed-b1df-7760" type="equalTo"/>
                     <condition field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="83a9-0464-b308-eef1" type="equalTo"/>
                   </conditions>
                 </conditionGroup>
@@ -2061,7 +2037,7 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
         </profile>
         <profile id="e471-2ee7-af1c-9fd2" name="Crypt Infernal" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">The leader of this unit is a Crypt Infernal. Add 1 to the Attacks characteristic of a Crypt Infernal’s Piercing Talons.</characteristic>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">1 model in this unit can be a Crypt Infernal. Add 1 to the Attacks characteristic of that model’s Piercing Talons.</characteristic>
           </characteristics>
         </profile>
         <profile name="Escort Courtier" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities" hidden="false" id="bb13-6aff-df80-f43a">
@@ -2101,7 +2077,7 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <costs>
-            <cost name="pts" typeId="points" value="180"/>
+            <cost name="pts" typeId="points" value="160"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0208-ad2e-d4e9-620d" name="Piercing Talons" hidden="false" collective="false" import="true" type="upgrade">
@@ -2176,7 +2152,7 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
             </modifier>
           </modifiers>
           <costs>
-            <cost name="pts" typeId="points" value="180"/>
+            <cost name="pts" typeId="points" value="160"/>
           </costs>
         </entryLink>
         <entryLink id="fd5b-3bd3-4970-6129" name="Battalions" hidden="false" collective="false" import="true" targetId="3f3e-293b-65ed-e3fa" type="selectionEntryGroup"/>
@@ -2194,14 +2170,11 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
         </modifier>
       </modifiers>
       <profiles>
-        <profile id="4a48-5042-e157-f1a6" name="Muster Serfs" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+        <profile id="4a48-5042-e157-f1a6" name="Marshal of the Peasantry" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">In your hero phase, roll 6 dice for each friendly CRYPT GHAST COURTIER on the battlefield. For each 2+ you can return 1 slain model to a friendly SERFS unit that is within 10&quot; of that CRYPT GHAST COURTIER. Slain models can be returned to more than one unit if you wish, but each successful dice roll can only be used to return a model to a single unit.</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="6ae5-0935-aaf9-1cc7" name="Trophy Hunter" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-          <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If any enemy models are slain by wounds inflicted by this model’s attacks, until the end of the phase in which the attacks were made add 1 to the Attacks characteristic of melee weapons used by friendly SERFS units while they are wholly within 16&quot; of this model.</characteristic>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">In the combat phase, after this unit has fought for the first time in that phase, you can pick 1 friendly SERFS unit that has not yet fought in that phase, is within 3&quot; of an enemy unit and is wholly within 9&quot; of this unit. That unit can fight immediately.
+
+</characteristic>
           </characteristics>
         </profile>
         <profile id="e884-a5cb-5d7c-2f00" name="Crypt Ghast Courtier" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
@@ -2210,6 +2183,17 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
             <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">4</characteristic>
             <characteristic name="Bravery" typeId="0c85-bf79-836b-759e">10</characteristic>
             <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">5+</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Bone Club and Filthy Claws" typeId="96df-ab28-5d72-bbb3" typeName="Weapon" hidden="false" id="9c61-3c4e-2b24-f5df">
+          <characteristics>
+            <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
+            <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
+            <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">5</characteristic>
+            <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">4+</characteristic>
+            <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
+            <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-1</characteristic>
+            <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">D3</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -2224,52 +2208,6 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
         <categoryLink id="3784-728c-ad9d-f665" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
         <categoryLink targetId="94b9-7eb-a81a-b892" id="da2e-c86-57a6-ecd3" primary="false" name="Champion"/>
       </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="e5af-89c5-5341-f0a8" name="Bone Club" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e43-364f-4915-85bc" type="min"/>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e23c-83f6-4b4f-2f56" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="56c4-ec70-703c-92d8" name="Bone Club" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
-              <characteristics>
-                <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
-                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
-                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">3</characteristic>
-                <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">3+</characteristic>
-                <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
-                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-</characteristic>
-                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="fec9-db2c-83be-d15c" name="Filthy Claws" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6406-223b-b90b-538b" type="min"/>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23fb-9b34-50cc-f1bd" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="3874-7b64-b0e7-3a5b" name="Filthy Claws" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
-              <characteristics>
-                <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
-                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
-                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">2</characteristic>
-                <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">4+</characteristic>
-                <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
-                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-</characteristic>
-                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
       <entryLinks>
         <entryLink id="3b99-af1e-01f2-ffe9" name="Artefacts" hidden="false" collective="false" import="true" targetId="c8cb-28b1-ffbb-2bbf" type="selectionEntryGroup"/>
         <entryLink id="ce4e-2370-acec-9876" name="General" hidden="false" collective="false" import="true" targetId="8228-415a-66c3-dffe" type="selectionEntry"/>
@@ -2279,7 +2217,7 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
         <entryLink id="9036-511d-eb99-0d73" name="Unique Enhancements" hidden="false" collective="false" import="true" targetId="62f4-174e-c529-75fe" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="70"/>
+        <cost name="pts" typeId="points" value="100"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="631c-0dae-5912-196d" name="Crypt Ghouls" page="135" hidden="false" collective="false" import="true" type="unit">
@@ -2330,14 +2268,14 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
         <categoryLink targetId="7f45-c5b3-c698-138d" id="ef1-efad-5b2f-85f1" primary="false" name="Infantry"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="3ce1-fdde-09b6-cbe7" name="10 Crypt Ghouls" hidden="false" collective="false" import="true" type="model">
+        <selectionEntry id="3ce1-fdde-09b6-cbe7" name="20 Crypt Ghouls" hidden="false" collective="false" import="true" type="model">
           <modifiers>
-            <modifier type="set" field="name" value="20 Crypt Ghouls">
+            <modifier type="set" field="name" value="40 Crypt Ghouls">
               <conditions>
                 <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a8d-cde8-fba1-6c0d" type="equalTo"/>
               </conditions>
             </modifier>
-            <modifier type="set" field="name" value="30 Crypt Ghouls">
+            <modifier type="set" field="name" value="60 Crypt Ghouls">
               <conditions>
                 <condition field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a8d-cde8-fba1-6c0d" type="equalTo"/>
               </conditions>
@@ -2348,7 +2286,7 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <costs>
-            <cost name="pts" typeId="points" value="80"/>
+            <cost name="pts" typeId="points" value="160"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6cf7-ce8a-1a10-189f" name="Sharpened Teeth and Filthy Claws" hidden="false" collective="false" import="true" type="upgrade">
@@ -2380,7 +2318,7 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
             <modifier type="set" field="95f2-6885-756f-9ea5" value="2"/>
           </modifiers>
           <costs>
-            <cost name="pts" typeId="points" value="80"/>
+            <cost name="pts" typeId="points" value="160"/>
           </costs>
         </entryLink>
         <entryLink id="25be-6131-0679-2425" name="Battalions" hidden="false" collective="false" import="true" targetId="3f3e-293b-65ed-e3fa" type="selectionEntryGroup"/>
@@ -2398,19 +2336,14 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
         </modifier>
       </modifiers>
       <profiles>
-        <profile id="d96a-bd18-ce25-4e35" name="Muster King&apos;s Chosen" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+        <profile id="d96a-bd18-ce25-4e35" name="Knightly Retinue" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">In your hero phase, roll 6 dice for each friendly CRYPT HAUNTER COURTIER on the battlefield. For each 5+ you can return 1 slain model to a friendly CRYPT HORRORS unit that is within 10&quot; of that CRYPT HAUNTER COURTIER. Slain models can be returned to more than one unit if you wish, but each successful dice roll can only be used to return a model to a single unit.</characteristic>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">In the combat phase, after this unit has fought for the first time in that phase, you can pick 1 friendly CRYPT HORRORS unit that has not yet fought in that phase, is within 3&quot; of an enemy unit and is wholly within 9&quot; of this unit. That unit can fight immediately.</characteristic>
           </characteristics>
         </profile>
         <profile id="1360-c6d0-d6f7-8767" name="Noble Blood" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">In your hero phase, you can heal 1 wound allocated to this model.</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="8ff0-b144-d920-c7e8" name="Chosen of the King" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-          <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">You can re-roll hit rolls for attacks made by this model while it is within 18&quot; of any friendly ABHORRANTS.</characteristic>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">In your hero phase, you can heal up to D3 wounds allocated to this unit.</characteristic>
           </characteristics>
         </profile>
         <profile id="6235-0287-78dc-1bf4" name="Crypt Haunter Courtier" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
@@ -2419,6 +2352,17 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
             <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">6</characteristic>
             <characteristic name="Bravery" typeId="0c85-bf79-836b-759e">10</characteristic>
             <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">4+</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Massive Bone Club and Rancid Talons" typeId="96df-ab28-5d72-bbb3" typeName="Weapon" hidden="false" id="9ae5-b5b8-3b49-85f2">
+          <characteristics>
+            <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
+            <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">2&quot;</characteristic>
+            <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">5</characteristic>
+            <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">4+</characteristic>
+            <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
+            <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-2</characteristic>
+            <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">3</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -2433,52 +2377,6 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
         <categoryLink id="07bd-c2ca-b7d1-9e00" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
         <categoryLink targetId="94b9-7eb-a81a-b892" id="fda-e796-a255-8ad0" primary="false" name="Champion"/>
       </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="ab65-03de-a1c1-1a23" name="Massive Bone Club" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7639-9976-f8f7-06a3" type="min"/>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1abe-d19c-ff07-707e" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="428e-ca00-b99a-6b15" name="Massive Bone Club" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
-              <characteristics>
-                <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
-                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
-                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">3</characteristic>
-                <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">4+</characteristic>
-                <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
-                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-</characteristic>
-                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">3</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="97ba-4f42-1547-400d" name="Rancid Talons" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cca6-9403-bc73-2d71" type="min"/>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e0d8-e3b6-87b9-e743" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="47d6-4161-c5b9-3d45" name="Rancid Talons" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
-              <characteristics>
-                <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
-                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
-                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">2</characteristic>
-                <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">4+</characteristic>
-                <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
-                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-</characteristic>
-                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
       <entryLinks>
         <entryLink id="07a2-14a4-cccf-9c4e" name="Command Traits" hidden="false" collective="false" import="true" targetId="2b46-6a34-bba4-a7a2" type="selectionEntryGroup"/>
         <entryLink id="dca0-933b-2b68-2248" name="Artefacts" hidden="false" collective="false" import="true" targetId="c8cb-28b1-ffbb-2bbf" type="selectionEntryGroup"/>
@@ -2492,7 +2390,7 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
         <entryLink id="ffa4-db8a-934c-72c5" name="Unique Enhancements" hidden="false" collective="false" import="true" targetId="62f4-174e-c529-75fe" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="110"/>
+        <cost name="pts" typeId="points" value="140"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="69e7-2a2c-7334-f453" name="Crypt Horrors" page="135" hidden="false" collective="false" import="true" type="unit">
@@ -2524,7 +2422,6 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e436-d1d7-652b-ab96" type="equalTo"/>
                     <condition field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c6db-68c4-dfd6-58c0" type="equalTo"/>
                   </conditions>
                 </conditionGroup>
@@ -2541,7 +2438,7 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
       <profiles>
         <profile id="d016-cca4-6a93-0349" name="Noble Blood" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">In your hero phase, you can heal up to D3 wounda allocated to this unit.</characteristic>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">In your hero phase, you can heal up to D3 wounds allocated to this unit.</characteristic>
           </characteristics>
         </profile>
         <profile id="1bb1-c343-db65-261f" name="Chosen of the King" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
@@ -2662,9 +2559,9 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
         </modifier>
       </modifiers>
       <profiles>
-        <profile id="de60-35dd-57eb-215a" name="Muster Royal Guard" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+        <profile id="de60-35dd-57eb-215a" name="Mind-shattering Cacophony" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">In your hero phase, roll 6 dice for each friendly CRYPT INFERNAL COURTIER on the battlefield. For each 5+ you can return 1 slain model to a friendly CRYPT FLAYERS unit that is within 10&quot; of that CRYPT INFERNAL COURTIER. Slain models can be returned to more than one unit if you wish, but each successful dice roll can only be used to return a model to a single unit.</characteristic>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If any enemy models are slain by wounds caused by this unit’s Foetid Breath, until the end of the phase, add 1 to the Damage characteristic of missile weapons used by friendly CRYPT FLAYERS units while they are wholly within 9&quot; of this unit. The same CRYPT FLAYERS unit cannot benefit from this ability more than once per phase.</characteristic>
           </characteristics>
         </profile>
         <profile id="b244-cef4-38e4-157b" name="Crypt Infernal Courtier" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
@@ -2700,17 +2597,12 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
             <profile id="2d0a-9d98-a25d-68bc" name="Skewering Talons" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
-                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
+                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">2&quot;</characteristic>
                 <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">5</characteristic>
                 <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">4+</characteristic>
                 <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
                 <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-1</characteristic>
                 <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">2</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="51b0-0058-41d6-18c7" name="Skewering Strike" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If the unmodified hit roll for an attack made with Skewering Talons is 6, that attack inflicts 1 mortal wound on the target in addition to any normal damage.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -2727,11 +2619,11 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
             <profile id="72a5-61c4-20bb-6b2c" name="Foetid Breath" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Missile</characteristic>
-                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">9&quot;</characteristic>
-                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">1</characteristic>
+                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">10&quot;</characteristic>
+                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">4</characteristic>
                 <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">4+</characteristic>
                 <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
-                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-1</characteristic>
+                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-2</characteristic>
                 <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">D3</characteristic>
               </characteristics>
             </profile>
@@ -2754,7 +2646,7 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
         <entryLink id="ad60-81bd-9a14-b5be" name="Unique Enhancements" hidden="false" collective="false" import="true" targetId="62f4-174e-c529-75fe" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="130"/>
+        <cost name="pts" typeId="points" value="145"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f124-2ae2-055e-c865" name="Varghulf Courtier" page="80" hidden="false" collective="false" import="true" type="unit">
@@ -2771,33 +2663,29 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
             <characteristic name="Move" typeId="8655-6213-2824-1752">10&quot;</characteristic>
             <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">8</characteristic>
             <characteristic name="Bravery" typeId="0c85-bf79-836b-759e">10</characteristic>
-            <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">5+</characteristic>
+            <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">4+</characteristic>
           </characteristics>
         </profile>
-        <profile id="e5a8-5d9f-2ba3-ed36" name="Muster Royal Household" page="80" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+        <profile id="e5a8-5d9f-2ba3-ed36" name="Bounding Strides" page="80" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">In your here phase, roll 6 dice for each friendly VARGHULF COURTIER on the battlefield.  For each 2+ you can return 1 slain model to a friendly SERFS unit within 10&quot; of that VARGHULF COURTIER.  For each 5+ you can return 1 slain model to a friendly KNIGHTS unit within 10&quot; of that VARGHULF COURTIER instead.  Slain models can be returned to more than one unit if you wish, but each successful dice roll can only be used to return a model to a single unit.</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="bd0e-fd55-92b5-75f4" name="Feed on Dark Magic" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-          <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If a friendly ABHORRANT within 18&quot; of this model successfully casts a spell, and it is not unbound, you can re-roll hit rolls for this model until the start of your next hero phase.</characteristic>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">When this unit makes a move, it can pass across terrain features in the same manner as a model that can fly.
+
+</characteristic>
           </characteristics>
         </profile>
         <profile id="f01b-396c-d7c8-ed31" name="King&apos;s Champion" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Add 2 the Attacks characteristic of this model&apos;s Immense Claws if it is within 3&quot; of 10 or more enemy models when you pick the target unit(s) for its attacks.</characteristic>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">At the start of the combat phase, you can say that this unit will use this ability. If you do so, in that phase, you can add 2 to the Attacks characteristic of this unit’s melee weapons, but it can only target units that have a Wounds characteristic of 1 or 2 and do not have a mount.
+
+</characteristic>
           </characteristics>
         </profile>
         <profile id="ed9f-43e2-d254-da0f" name="Victory Feast" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">At the end of the combat phase, if any enemy models were slain by wounds inflicted by this model&apos;s attacks in that combat phase, you can heal up to D3 wounds allocated to this model.</characteristic>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">At the end of the combat phase, if any enemy models were slain by wounds caused by this unit’s attacks in that phase, you can heal up to D6 wounds allocated to this unit. In addition, at the end of the combat phase, this unit can immediately retreat.</characteristic>
           </characteristics>
         </profile>
       </profiles>
-      <infoLinks>
-        <infoLink id="6900-ec1b-51e6-5504" name="Fly" hidden="false" targetId="8e0c-cbe4-27be-8a30" type="profile"/>
-      </infoLinks>
       <categoryLinks>
         <categoryLink id="c70a-0f9b-4fc9-89d3" name="New CategoryLink" hidden="false" targetId="6cdf-dd4f-0e91-e9c4" primary="false"/>
         <categoryLink id="cd52-a3b4-e4c0-ab5a" name="New CategoryLink" hidden="false" targetId="53f6-aa54-91a5-fcfb" primary="false"/>
@@ -2820,7 +2708,7 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                 <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">2&quot;</characteristic>
-                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">4</characteristic>
+                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">5</characteristic>
                 <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">3+</characteristic>
                 <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
                 <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-1</characteristic>
@@ -2841,12 +2729,12 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
             <profile id="bd3e-888c-848c-f951" name="Dagger-like Fangs" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
-                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
+                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">2&quot;</characteristic>
                 <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">1</characteristic>
                 <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">3+</characteristic>
                 <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">2+</characteristic>
                 <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-2</characteristic>
-                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">D3</characteristic>
+                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">3</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -2864,7 +2752,7 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
         <entryLink id="0fac-e76a-3c63-d4c7" name="Unique Enhancements" hidden="false" collective="false" import="true" targetId="62f4-174e-c529-75fe" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="160"/>
+        <cost name="pts" typeId="points" value="165"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8228-415a-66c3-dffe" name="General" hidden="false" collective="false" import="true" type="upgrade">
@@ -2903,7 +2791,6 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="705f-02ae-f4f5-987a" type="equalTo"/>
                 <condition field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="99b2-6989-d758-a4be" type="equalTo"/>
               </conditions>
             </conditionGroup>
@@ -2913,7 +2800,6 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="705f-02ae-f4f5-987a" type="equalTo"/>
                 <condition field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="99b2-6989-d758-a4be" type="equalTo"/>
               </conditions>
             </conditionGroup>
@@ -2931,52 +2817,12 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
         </profile>
         <profile id="ac80-ae58-725a-b89f" name="Gaping Maw" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If the unmodified hit roll for an attack made with this model’s Fanged Maw is 6, that attack inflicts 6 mortal wounds on the target unit and the attack sequence ends (do not make a wound or save roll).</characteristic>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If the unmodified hit roll for an attack made with this unit’s Fanged Maw is 6, the target suffers 6 mortal wounds and the attack sequence ends (do not make a wound roll or save roll).</characteristic>
           </characteristics>
         </profile>
         <profile id="c42b-b79a-b2d2-a62c" name="Infested" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If this model is slain, before this model is removed from play each unit within 3&quot; of this model suffers D3 mortal wounds.</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="ce4e-4f85-b9e2-45a6" name="Royal Menagerie" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-          <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">In your hero phase, you can heal up to D3 wounds allocated to this model if this model is within 6&quot; of a friendly ABHORRANT.</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="5c94-07cf-7941-ac90" name="00-03" hidden="false" typeId="cde6-89a6-4a4c-9d32" typeName="Terrorgheist Wound Table">
-          <characteristics>
-            <characteristic name="Move" typeId="2ad2-839b-d5ee-5770">14&quot;</characteristic>
-            <characteristic name="Death Shriek" typeId="dfdc-a86c-e979-1eb7">6</characteristic>
-            <characteristic name="Skeletal Claws" typeId="5b09-7a6b-dd30-faf1">4</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="d220-5b9d-07a1-2388" name="04-06" hidden="false" typeId="cde6-89a6-4a4c-9d32" typeName="Terrorgheist Wound Table">
-          <characteristics>
-            <characteristic name="Move" typeId="2ad2-839b-d5ee-5770">12&quot;</characteristic>
-            <characteristic name="Death Shriek" typeId="dfdc-a86c-e979-1eb7">5</characteristic>
-            <characteristic name="Skeletal Claws" typeId="5b09-7a6b-dd30-faf1">4</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="896f-946b-1fba-2cc3" name="07-09" hidden="false" typeId="cde6-89a6-4a4c-9d32" typeName="Terrorgheist Wound Table">
-          <characteristics>
-            <characteristic name="Move" typeId="2ad2-839b-d5ee-5770">10&quot;</characteristic>
-            <characteristic name="Death Shriek" typeId="dfdc-a86c-e979-1eb7">4</characteristic>
-            <characteristic name="Skeletal Claws" typeId="5b09-7a6b-dd30-faf1">3</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="d5aa-59db-8232-18ca" name="10-12" hidden="false" typeId="cde6-89a6-4a4c-9d32" typeName="Terrorgheist Wound Table">
-          <characteristics>
-            <characteristic name="Move" typeId="2ad2-839b-d5ee-5770">8&quot;</characteristic>
-            <characteristic name="Death Shriek" typeId="dfdc-a86c-e979-1eb7">3</characteristic>
-            <characteristic name="Skeletal Claws" typeId="5b09-7a6b-dd30-faf1">3</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="ed4e-a944-d348-5287" name="13+" hidden="false" typeId="cde6-89a6-4a4c-9d32" typeName="Terrorgheist Wound Table">
-          <characteristics>
-            <characteristic name="Move" typeId="2ad2-839b-d5ee-5770">6&quot;</characteristic>
-            <characteristic name="Death Shriek" typeId="dfdc-a86c-e979-1eb7">2</characteristic>
-            <characteristic name="Skeletal Claws" typeId="5b09-7a6b-dd30-faf1">2</characteristic>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If this unit is destroyed, before it is removed from play, each enemy unit within 3&quot; of this unit suffers D3 mortal wounds.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -3011,7 +2857,9 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
             </profile>
             <profile id="f62c-7ea6-62c0-c1e1" name="Death Shriek" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
               <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Do not use the attack sequence for an attack made with this model’s Death Shriek. Instead roll a dice and add the Death Shriek value shown on this model’s damage table. If the total is higher than the target unit’s Bravery characteristic, the target unit suffers a number of mortal wounds equal to the difference between its Bravery characteristic and the total.</characteristic>
+                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Do not use the attack sequence for an attack made with this unit’s Death Shriek. Instead, roll a dice and add the Death Shriek value shown on this unit’s damage table. If the total is higher than the target unit’s Bravery characteristic, the target unit suffers a number of mortal wounds equal to the difference between its Bravery characteristic and the total.
+
+</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -3041,13 +2889,13 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
             <cost name="pts" typeId="points" value="0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="8290-2e2c-4d2e-f6ad" name="Skeletal Claws" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="8290-2e2c-4d2e-f6ad" name="Skeletal Talons" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f2d-e3fe-d947-a03d" type="min"/>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2270-7958-8350-7456" type="max"/>
           </constraints>
           <profiles>
-            <profile id="fd03-9006-54bf-fc0e" name="Skeletal Claws" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
+            <profile id="fd03-9006-54bf-fc0e" name="Skeletal Talons" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                 <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">2&quot;</characteristic>
@@ -3055,7 +2903,7 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
                 <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">4+</characteristic>
                 <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
                 <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-1</characteristic>
-                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">D3</characteristic>
+                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">2</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -3070,6 +2918,40 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
       <costs>
         <cost name="pts" typeId="points" value="260"/>
       </costs>
+      <infoGroups>
+        <infoGroup name="Damage Table" hidden="false" id="af58-d31a-a444-8e1a">
+          <profiles>
+            <profile name="0-6" typeId="370f-9356-a89a-06b3" typeName="Terrorgheist Wounds Suffered" hidden="false" id="3fa9-8bfd-fcb7-67f0">
+              <characteristics>
+                <characteristic name="Move" typeId="2ad2-839b-d5ee-5770">14&quot;</characteristic>
+                <characteristic name="Death Shriek" typeId="dfdc-a86c-e979-1eb7">6</characteristic>
+                <characteristic name="Skeletal Talons" typeId="5b09-7a6b-dd30-faf1">7</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="7-8" typeId="370f-9356-a89a-06b3" typeName="Terrorgheist Wounds Suffered" hidden="false" id="1b17-569e-abe-3a58">
+              <characteristics>
+                <characteristic name="Move" typeId="2ad2-839b-d5ee-5770">12&quot;</characteristic>
+                <characteristic name="Death Shriek" typeId="dfdc-a86c-e979-1eb7">5</characteristic>
+                <characteristic name="Skeletal Talons" typeId="5b09-7a6b-dd30-faf1">6</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="9-11" typeId="370f-9356-a89a-06b3" typeName="Terrorgheist Wounds Suffered" hidden="false" id="2dac-f6bf-338b-4a8b">
+              <characteristics>
+                <characteristic name="Move" typeId="2ad2-839b-d5ee-5770">10&quot;</characteristic>
+                <characteristic name="Death Shriek" typeId="dfdc-a86c-e979-1eb7">4</characteristic>
+                <characteristic name="Skeletal Talons" typeId="5b09-7a6b-dd30-faf1">5</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="12+" typeId="370f-9356-a89a-06b3" typeName="Terrorgheist Wounds Suffered" hidden="false" id="1ad8-d833-4967-8436">
+              <characteristics>
+                <characteristic name="Move" typeId="2ad2-839b-d5ee-5770">8&quot;</characteristic>
+                <characteristic name="Death Shriek" typeId="dfdc-a86c-e979-1eb7">3</characteristic>
+                <characteristic name="Skeletal Talons" typeId="5b09-7a6b-dd30-faf1">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+        </infoGroup>
+      </infoGroups>
     </selectionEntry>
     <selectionEntry id="a0a1-5316-0121-e73d" name="Royal Zombie Dragon" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
@@ -3103,39 +2985,14 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
             <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">4+</characteristic>
           </characteristics>
         </profile>
-        <profile id="de30-4d0d-5a8e-0d00" name="00-03" hidden="false" typeId="b1c1-c8b1-016e-4235" typeName="Zombie Dragon&apos;s Wound Table">
+        <profile id="eed4-8812-fa28-df9e" name="Terror" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Move" typeId="1712-425e-7e40-a5b1">14&quot;</characteristic>
-            <characteristic name="Pestilential Breath" typeId="b17b-97f7-9c40-21e5">2+</characteristic>
-            <characteristic name="Sword-like Claws" typeId="e309-9fb0-c644-47ee">7</characteristic>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Enemy units cannot receive the Inspiring Presence command while they are within 3&quot; of any friendly units with this ability.</characteristic>
           </characteristics>
         </profile>
-        <profile id="5740-a1fd-8334-e04d" name="04-06" hidden="false" typeId="b1c1-c8b1-016e-4235" typeName="Zombie Dragon&apos;s Wound Table">
+        <profile name="Loathsome Descent" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities" hidden="false" id="a32-18ec-a831-580a">
           <characteristics>
-            <characteristic name="Move" typeId="1712-425e-7e40-a5b1">12&quot;</characteristic>
-            <characteristic name="Pestilential Breath" typeId="b17b-97f7-9c40-21e5">3+</characteristic>
-            <characteristic name="Sword-like Claws" typeId="e309-9fb0-c644-47ee">6</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="7d09-e9d8-8681-6c2a" name="07-09" hidden="false" typeId="b1c1-c8b1-016e-4235" typeName="Zombie Dragon&apos;s Wound Table">
-          <characteristics>
-            <characteristic name="Move" typeId="1712-425e-7e40-a5b1">10&quot;</characteristic>
-            <characteristic name="Pestilential Breath" typeId="b17b-97f7-9c40-21e5">4+</characteristic>
-            <characteristic name="Sword-like Claws" typeId="e309-9fb0-c644-47ee">5</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="2527-6fdb-5025-8ced" name="10-12" hidden="false" typeId="b1c1-c8b1-016e-4235" typeName="Zombie Dragon&apos;s Wound Table">
-          <characteristics>
-            <characteristic name="Move" typeId="1712-425e-7e40-a5b1">8&quot;</characteristic>
-            <characteristic name="Pestilential Breath" typeId="b17b-97f7-9c40-21e5">5+</characteristic>
-            <characteristic name="Sword-like Claws" typeId="e309-9fb0-c644-47ee">4</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="a487-b8cf-00cd-a24c" name="13+" hidden="false" typeId="b1c1-c8b1-016e-4235" typeName="Zombie Dragon&apos;s Wound Table">
-          <characteristics>
-            <characteristic name="Move" typeId="1712-425e-7e40-a5b1">6&quot;</characteristic>
-            <characteristic name="Pestilential Breath" typeId="b17b-97f7-9c40-21e5">6+</characteristic>
-            <characteristic name="Sword-like Claws" typeId="e309-9fb0-c644-47ee">3</characteristic>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Instead of setting up this unit on the battlefield, you can place it to one side and say that it is circling high above as a reserve unit. If you do so, at the end of your movement phase, you can set up this unit on the battlefield more than 9&quot; from all enemy units.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -3179,20 +3036,15 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3644-919d-3e3d-0258" type="max"/>
           </constraints>
           <profiles>
-            <profile id="da9c-7c80-cc9b-6d8f" name="Pestilential Breath" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">When you attack with this model’s Pestilential Breath, roll a dice before making the hit roll for the attack. If the roll is less than or equal to the number of models in the target unit, the attack scores a hit without needing to make a hit roll.</characteristic>
-              </characteristics>
-            </profile>
             <profile id="7713-9878-8575-e9ba" name="Pestilential Breath" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Missile</characteristic>
-                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">9&quot;</characteristic>
-                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">1</characteristic>
+                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">12&quot;</characteristic>
+                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">D6</characteristic>
                 <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">3+</characteristic>
-                <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">*</characteristic>
+                <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
                 <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-3</characteristic>
-                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">D6</characteristic>
+                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">3</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -3213,7 +3065,7 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
                 <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">3</characteristic>
                 <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">4+</characteristic>
                 <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
-                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-2</characteristic>
+                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-3</characteristic>
                 <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">D6</characteristic>
               </characteristics>
             </profile>
@@ -3229,6 +3081,36 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
       <costs>
         <cost name="pts" typeId="points" value="240"/>
       </costs>
+      <infoGroups>
+        <infoGroup name="Damage Table" hidden="false" id="9a85-38a3-d47e-1917">
+          <profiles>
+            <profile name="0-6" typeId="1fc7-f451-3937-0a17" typeName="Zombie Dragon&apos;s Wounds Suffered" hidden="false" id="f6b7-ae42-fc09-fbfd">
+              <characteristics>
+                <characteristic name="Move" typeId="1712-425e-7e40-a5b1">14&quot;</characteristic>
+                <characteristic name="Sword-like Claws" typeId="e309-9fb0-c644-47ee">7</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="7-8" typeId="1fc7-f451-3937-0a17" typeName="Zombie Dragon&apos;s Wounds Suffered" hidden="false" id="6817-dd08-49b8-4d2e">
+              <characteristics>
+                <characteristic name="Move" typeId="1712-425e-7e40-a5b1">12&quot;</characteristic>
+                <characteristic name="Sword-like Claws" typeId="e309-9fb0-c644-47ee">6</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="9-11" typeId="1fc7-f451-3937-0a17" typeName="Zombie Dragon&apos;s Wounds Suffered" hidden="false" id="86e9-7b6-3f27-12dd">
+              <characteristics>
+                <characteristic name="Move" typeId="1712-425e-7e40-a5b1">10&quot;</characteristic>
+                <characteristic name="Sword-like Claws" typeId="e309-9fb0-c644-47ee">5</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="12+" typeId="1fc7-f451-3937-0a17" typeName="Zombie Dragon&apos;s Wounds Suffered" hidden="false" id="d84a-8cac-b55c-7c9c">
+              <characteristics>
+                <characteristic name="Move" typeId="1712-425e-7e40-a5b1">8&quot;</characteristic>
+                <characteristic name="Sword-like Claws" typeId="e309-9fb0-c644-47ee">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+        </infoGroup>
+      </infoGroups>
     </selectionEntry>
     <selectionEntry id="e7cb-d62d-6411-53fd" name="Abhorrant Archregent" publicationId="6afd-4f9a-0665-9b55" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
@@ -3249,30 +3131,30 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
             <characteristic name="Move" typeId="8655-6213-2824-1752">6</characteristic>
             <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">7</characteristic>
             <characteristic name="Bravery" typeId="0c85-bf79-836b-759e">10</characteristic>
-            <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">4</characteristic>
+            <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">4+</characteristic>
           </characteristics>
         </profile>
         <profile id="7e90-b3ff-a0a0-c637" name="Wizard" hidden="false" typeId="f55d-ee3a-1597-110f" typeName="Magic">
           <characteristics>
             <characteristic name="Cast/Unbind" typeId="8294-f605-2c0f-8f92">2/2</characteristic>
-            <characteristic name="Spells Known" typeId="dc9c-47d3-6931-859c">Arcane Bolt, Mystic Shield and Ferocious Hunger</characteristic>
+            <characteristic name="Spells Known" typeId="dc9c-47d3-6931-859c">Arcane Bolt, Mystic Shield and Carrion Call</characteristic>
           </characteristics>
         </profile>
-        <profile id="681e-93c7-6053-1226" name="Ferocious Hunger" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
+        <profile id="fbcc-1a65-33f4-d1a7" name="Royal Blood" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">In your hero phase, you can heal up to D3 wounds allocated to this unit.</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Countless Servants" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities" hidden="false" id="1e15-35d6-1ff5-a5cc">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">At the start of your hero phase, you can return up to 3 slain models to 1 friendly SERFS unit that is within 18&quot; of this unit, or you can return 1 slain model to 1 friendly KNIGHTS unit that is within 18&quot; of this unit.</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Carrion Call" typeId="2e81-5e22-c6e1-73cb" typeName="Spell" hidden="false" id="f804-5542-241e-6b25">
           <characteristics>
             <characteristic name="Casting Value" typeId="2508-b604-1258-a920">6</characteristic>
-            <characteristic name="Range" typeId="5b5c-1fd1-4c0f-5705">24&quot;</characteristic>
-            <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, pick 1 friendly FLESH‐EATER COURTS unit wholly within 24&quot; of the caster and visible to them, and roll a D3. Add the roll to the Attacks characteristic of melee weapons used by that unit until your next hero phase.</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="207b-99e6-7314-927a" name="Summon Imperial Guard" hidden="false" typeId="f71f-b0a4-730e-ced3" typeName="Command Abilities">
-          <characteristics>
-            <characteristic name="Command Ability Details" typeId="1b71-4c83-4e8c-093f">You can use this command ability at the end of your movement phase. If you do so, pick 1 friendly model that has this command ability and has not used it before in the battle. That model summons 1 of the following units to the battlefield: 1 COURTIER; or 1 unit of up to 3 KNIGHTS; or 1 unit of up to 20 SERFS. The summoned unit is added to your army, and must be set up wholly within 6&quot; of the edge of the battlefield and more than 9&quot; from any enemy units.</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="fbcc-1a65-33f4-d1a7" name="Imperial Blood" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-          <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">In your hero phase, you can heal up to 3 wounds allocated to this model</characteristic>
+            <characteristic name="Range" typeId="5b5c-1fd1-4c0f-5705"/>
+            <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, in the following movement phase, friendly FLESH-EATER COURTS units that are set up at the end of the movement phase can immediately move D6&quot;.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -3302,11 +3184,11 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
                 <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
-                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">7</characteristic>
+                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">5</characteristic>
                 <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">3+</characteristic>
                 <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
                 <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-1</characteristic>
-                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
+                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">2</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -3333,12 +3215,14 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
       <profiles>
         <profile id="2621-1cdd-1bbb-0df8" name="Ghoulish Landmark" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">While an enemy unit is within 12&quot; of any terrain features with this scenery rule, it cannot be affected by any abilities that allow units to ignore battleshock tests.</characteristic>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">While an enemy unit is within 12&quot; of this terrain feature, it cannot be affected by any abilities that allow units to ignore battleshock tests.</characteristic>
           </characteristics>
         </profile>
-        <profile id="c6eb-b81f-0ca9-91fd" name="Ruler of All He Surveys" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+        <profile id="c6eb-b81f-0ca9-91fd" name="Ruler of All They Survey" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">While a friendly FLESH-EATER COURTS HERO is garrisoning a terrain feature with this scenery rule, friendly FLESH-EATER COURTS HEROES wholly within 12&quot; of this terrain feature can issue the Summon Men-at-arms, Summon Courtier, Summon Royal Guard, and Summon Imperial Guard commands without a command point being spent.</characteristic>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">At the start of your hero phase, add D3 noble deeds points to any friendly FLESH-EATER COURTS HERO that is garrisoning this terrain feature.
+
+</characteristic>
           </characteristics>
         </profile>
         <profile id="2659-991f-ea21-dc99" name="Set-Up" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
@@ -3348,7 +3232,7 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
         </profile>
         <profile id="4f5c-6d55-4833-5bce" name="Defensible" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">This terrain feature is a defensible terrain feature that can be garrisoned by 1 FLESH-EATER COURTS HERO with a Wounds characteristic of 8 or less.</characteristic>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">This terrain feature is a defensible terrain feature that can be garrisoned by 1 FLESH-EATER COURTS HERO that has a Wounds characteristic of up to 7.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -3697,7 +3581,7 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
         <cost name="pts" typeId="points" value="100"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="3659-35fc-ee8b-0f3e" name="Duke Crakmarrow" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="3659-35fc-ee8b-0f3e" name="Duke Crakmarrow" hidden="true" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="6531-19c3-a5c8-ebb0" value="1">
           <conditions>
@@ -3773,7 +3657,7 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
         <cost name="pts" typeId="points" value="120"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="29d5-0b2d-6b17-20ab" name="The Grymwatch" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="29d5-0b2d-6b17-20ab" name="The Grymwatch" hidden="true" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="d90e-de72-b8d2-ec3a" value="1">
           <conditions>
@@ -3943,8 +3827,7 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
         </profile>
         <profile id="62d9-92cd-dc2e-5d38" name="Screamed to Death" hidden="false" typeId="eba0-4bf6-65fe-fdbc" typeName="Battle Tactic">
           <characteristics>
-            <characteristic name="Description" typeId="f882-48d5-21a4-1787">Pick 1 enemy unit on the battlefield. You complete this battle tactic if that unit is destroyed this turn by an attack made with a missile weapon used by a friendly CRYPT FLAYERS unit, CRYPT IFERNAL COURTIER or ROYAL TERRORGHEIST.
-</characteristic>
+            <characteristic name="Description" typeId="f882-48d5-21a4-1787">Pick 1 enemy unit on the battlefield. You complete this battle tactic if that unit is destroyed this turn by an attack made with a missile weapon used by a friendly CRYPT FLAYERS unit, CRYPT IFERNAL COURTIER or ROYAL TERRORGHEIST.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -3966,8 +3849,7 @@ Each Flesh-eater Courts Hero can have a maximum of 6 noble deeds points at any o
       <profiles>
         <profile id="80b9-c2df-133c-c711" name="Hunter&apos;s Instincts" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Enemy MONSTERS within 3&quot; of this unit cannot carry out monstrous rampages. In addition, reduce the Damage
-characteristic of weapons used by enemy MONSTERS by 1 while they are within 3&quot; of this unit, to a minimum of 1.</characteristic>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Enemy MONSTERS within 3&quot; of this unit cannot carry out monstrous rampages. In addition, reduce the Damage characteristic of weapons used by enemy MONSTERS by 1 while they are within 3&quot; of any friendly units with this ability, to a minimum of 1.</characteristic>
           </characteristics>
         </profile>
         <profile id="ce79-aaee-e7e7-933a" name="Royal Beastflayers" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
@@ -4122,12 +4004,8 @@ characteristic of weapons used by enemy MONSTERS by 1 while they are within 3&qu
         <profile id="1df7-eb91-bb6a-4d28" name="The King&apos;s Entreaty" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
             <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">At the end of the charge phase, you can pick 1 enemy unit within 3&quot; of this unit and say that this unit will offer it an infected bone. If you do so, your opponent must choose whether that enemy unit accepts or refuses the bone.
-
-
 If it refuses, the strike-first effect applies to friendly FLESH-EATER COURTS units within 3&quot; of this unit until the end of the following combat phase.
-
-
-If it accepts, that enemy unit becomes infected. For the rest of the battle, roll 2D6 before an infected unit issues or receives a command, attempts to cast a spell, or chants a prayer. Make the roll before the action is carried out. If the roll is greater than that unit&apos;s Bravery characteristic, that unit cannot perform that action in that phase.</characteristic>
+If it accepts, that enemy unit becomes infected. For the rest of the battle, roll 2D6 before an infected unit issues or receives a command, attempts to cast a spell, or chants a prayer. Make the roll before the action is carried out. If the roll is greater than that unit’s Bravery characteristic, that unit cannot perform that action in that phase.</characteristic>
           </characteristics>
         </profile>
         <profile id="a817-5b9d-d49e-695" name="Marrowscroll Herald" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
@@ -4177,6 +4055,9 @@ If it accepts, that enemy unit becomes infected. For the rest of the battle, rol
           </conditions>
         </modifier>
       </modifiers>
+      <costs>
+        <cost name="pts" typeId="points" value="100"/>
+      </costs>
     </selectionEntry>
     <selectionEntry type="upgrade" import="true" name="Ushoran, Mortarch of Delusion" hidden="false" id="3d22-faad-f95d-173a">
       <entryLinks>
@@ -4301,6 +4182,631 @@ If it accepts, that enemy unit becomes infected. For the rest of the battle, rol
           </profiles>
         </infoGroup>
       </infoGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="460"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="eff7-5485-4d69-64c7" name="Abhorrant Cardinal" publicationId="6afd-4f9a-0665-9b55" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="89f7-d50b-0aa9-01ce">
+          <conditions>
+            <condition field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9f18-9ffb-0267-3e08" type="greaterThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <profiles>
+        <profile id="5cfb-499e-ca4e-ab2b" name="Abhorrant Cardinal" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
+          <characteristics>
+            <characteristic name="Move" typeId="8655-6213-2824-1752">6&quot;</characteristic>
+            <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">5</characteristic>
+            <characteristic name="Bravery" typeId="0c85-bf79-836b-759e">10</characteristic>
+            <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">5+</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Speak in Tongues" typeId="eed7-4131-0a52-0668" typeName="Prayer" hidden="false" id="e870-734a-c577-41a">
+          <characteristics>
+            <characteristic name="Answer Value" typeId="276a-ab7e-145d-3ffc">3</characteristic>
+            <characteristic name="Range" typeId="fd81-4e98-28ac-092a">18&quot;</characteristic>
+            <characteristic name="Description" typeId="0746-6cfb-5e15-53cb">If answered, pick 1 enemy unit within range and visible to the chanter. Until your next hero phase, roll a dice each time that enemy unit receives a command. On a 4+, that command has no effect.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="be20-c31b-d0f-1d4a" name="Royal Blood" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">In your hero phase, you can heal up to D3 wounds allocated to this unit.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink id="6aa0-6a3b-f744-193a" name="ABHORRANT" hidden="false" targetId="5b04-42e4-33ef-10b1" primary="false"/>
+        <categoryLink id="c6c0-53be-4520-1667" name="DEATH" hidden="false" targetId="6cdf-dd4f-0e91-e9c4" primary="false"/>
+        <categoryLink id="9d25-7186-3cb6-5997" name="FLESH-EATER COURTS" hidden="false" targetId="6b35-0508-c6cc-6592" primary="false"/>
+        <categoryLink id="b446-f8a3-558a-d318" name="HERO" hidden="false" targetId="4e0e-664d-51ea-0929" primary="false"/>
+        <categoryLink id="41e4-d61b-f5de-a629" name="9 or less wounds Leader" hidden="false" targetId="a8ed-ca35-24e0-cf2e" primary="false"/>
+        <categoryLink id="bf6c-7c1f-1b00-f648" name="VAMPIRE" hidden="false" targetId="d1e1-d80a-c667-b587" primary="false"/>
+        <categoryLink id="7089-47ba-263e-227b" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
+        <categoryLink targetId="94b9-7eb-a81a-b892" id="4e9f-70d2-4409-314d" primary="false" name="Champion"/>
+        <categoryLink targetId="e8a5-e4c1-3d11-e7dd" id="fb31-40be-9a0d-56f7" primary="false" name="PRIEST"/>
+        <categoryLink targetId="9aa6-4e02-cf3-aa5b" id="940-9079-8dc-c22a" primary="false" name="ABHORRANT CARDINAL"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="877d-c7bd-d69d-f40" name="Gory Talons and Fangs" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c785-4935-75b7-abfc" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b0b-766d-db73-d600" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="1890-5c94-1bca-bb5b" name="Gory Talons and Fangs" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
+                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
+                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">5</characteristic>
+                <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">3+</characteristic>
+                <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
+                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-1</characteristic>
+                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="651d-9234-3c3c-e45" name="General" hidden="false" collective="false" import="true" targetId="8228-415a-66c3-dffe" type="selectionEntry"/>
+        <entryLink id="c757-19a4-cd45-cd83" name="Artefacts" hidden="false" collective="false" import="true" targetId="c8cb-28b1-ffbb-2bbf" type="selectionEntryGroup"/>
+        <entryLink id="c13c-dc-3b29-c83c" name="Command Traits" hidden="false" collective="false" import="true" targetId="2b46-6a34-bba4-a7a2" type="selectionEntryGroup"/>
+        <entryLink id="fb21-4f84-373b-f432" name="Battalions" hidden="false" collective="false" import="true" targetId="3f3e-293b-65ed-e3fa" type="selectionEntryGroup"/>
+        <entryLink id="7dbb-3877-a31b-f926" name="Incarnate Bonding" hidden="false" collective="false" import="true" targetId="c890-acbd-0c80-55c9" type="selectionEntryGroup"/>
+        <entryLink id="e2d-198f-5b54-515d" name="Unique Enhancements" hidden="false" collective="false" import="true" targetId="62f4-174e-c529-75fe" type="selectionEntryGroup"/>
+        <entryLink import="true" name="Prayer Scriptures" hidden="false" type="selectionEntryGroup" id="dc0e-2935-6676-bd3b" targetId="ec11-dabf-5c8-1a21"/>
+        <entryLink import="true" name="Smite" hidden="false" type="selectionEntry" id="598-2761-9802-6f86" targetId="be59-6ab9-bf9f-9434"/>
+        <entryLink import="true" name="Bless" hidden="false" type="selectionEntry" id="2b3e-67c1-23b5-e10e" targetId="c064-0ddb-52cf-5fb9"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="120"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a617-c031-1894-e81b" name="Abhorrant Gorewarden" publicationId="6afd-4f9a-0665-9b55" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="89f7-d50b-0aa9-01ce">
+          <conditions>
+            <condition field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9f18-9ffb-0267-3e08" type="greaterThan"/>
+          </conditions>
+        </modifier>
+        <modifier type="add" field="category" value="8f5e-e464-221b-4f06">
+          <conditions>
+            <condition field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9f95-f6dc-e866-90a0" type="greaterThan"/>
+          </conditions>
+        </modifier>
+        <modifier type="add" value="c89f-a721-882d-41b9" field="category">
+          <conditions>
+            <condition type="atLeast" value="1" field="selections" scope="parent" childId="b297-cecc-d8-c9d8" shared="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <profiles>
+        <profile id="75fe-dca7-6506-bda4" name="Wizard" hidden="false" typeId="f55d-ee3a-1597-110f" typeName="Magic">
+          <characteristics>
+            <characteristic name="Cast/Unbind" typeId="8294-f605-2c0f-8f92">1/1</characteristic>
+            <characteristic name="Spells Known" typeId="dc9c-47d3-6931-859c">Arcane Bolt, Mystic Shield and Winds of Shyish spells.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="91e7-8d43-2b98-2680" name="Abhorrant Gorewarden" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
+          <characteristics>
+            <characteristic name="Move" typeId="8655-6213-2824-1752">12&quot;</characteristic>
+            <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">7</characteristic>
+            <characteristic name="Bravery" typeId="0c85-bf79-836b-759e">10</characteristic>
+            <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">4+</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="839d-c458-d955-e230" name="Royal Hunting Party" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Instead of setting up this unit on the battlefield, you can place it to one side and say that it is circling in the skies as a reserve unit. If you do so, when you would set up a friendly CRYPT FLAYERS or MORBHEG KNIGHTS unit during deployment, that unit can join this unit circling in the skies as a reserve unit. A maximum of 1 unit can join this unit.
+
+
+At the end of your movement phase, you can set up this unit more than 9&quot; from all enemy units. If you do so, set up the unit that joined this unit wholly within 9&quot; of this unit and more than 9&quot; from all enemy units.
+
+</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="276b-6c93-edda-1e9a" name="Royal Blood" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">In your hero phase, you can heal up to D3 wounds allocated to this unit.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="717e-e8e9-41f2-123" name="Winds of Shyish" hidden="false" typeId="2e81-5e22-c6e1-73cb" typeName="Spell">
+          <characteristics>
+            <characteristic name="Casting Value" typeId="2508-b604-1258-a920">6</characteristic>
+            <characteristic name="Range" typeId="5b5c-1fd1-4c0f-5705">9&quot;</characteristic>
+            <characteristic name="Description" typeId="76ff-781d-b8e6-5f27">If successfully cast, pick 1 friendly FLESH-EATER COURTS unit that can fly and is wholly within range and visible to the caster. Remove this unit and the unit you picked from the battlefield and set them up again more than 9&quot; from all enemy units and wholly within 9&quot; of each other. Neither unit can move in the following movement phase.
+
+</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="c26e-6257-229f-b721" name="Arcane Bolt" hidden="false" targetId="ae02-a84f-a903-1ff8" type="profile"/>
+        <infoLink id="b5c8-9083-ce5c-a427" name="Mystic Shield" hidden="false" targetId="b41f-f1ce-7aa5-4f81" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="d59-e9ee-6845-4b74" name="New CategoryLink" hidden="false" targetId="4e0e-664d-51ea-0929" primary="false"/>
+        <categoryLink id="c09c-bf4b-199d-8fb3" name="New CategoryLink" hidden="false" targetId="4f53-8230-2f02-9639" primary="false"/>
+        <categoryLink id="f1fd-f907-a8b7-40a2" name="New CategoryLink" hidden="false" targetId="6cdf-dd4f-0e91-e9c4" primary="false"/>
+        <categoryLink id="62d5-f45-59e9-84f3" name="New CategoryLink" hidden="false" targetId="6b35-0508-c6cc-6592" primary="false"/>
+        <categoryLink id="e430-b915-c83b-daa7" name="ABHORRANT" hidden="false" targetId="5b04-42e4-33ef-10b1" primary="false"/>
+        <categoryLink id="8ee4-e2db-c226-7b26" name="9 or less wounds Leader" hidden="false" targetId="a8ed-ca35-24e0-cf2e" primary="false"/>
+        <categoryLink id="11c3-6ad4-e360-b498" name="VAMPIRE" hidden="false" targetId="d1e1-d80a-c667-b587" primary="false"/>
+        <categoryLink id="cb4f-6e83-1ff3-7f99" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
+        <categoryLink targetId="94b9-7eb-a81a-b892" id="bdb6-7a38-6bc0-b6a9" primary="false" name="Champion"/>
+        <categoryLink targetId="fe0a-2400-fd27-1447" id="650e-1b76-864c-aee6" primary="false" name="ABHORRANT GOREWARDEN"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="b29d-acde-98a5-ab8e" name="Gory Talons and Fangs" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c1dd-a635-52d6-df3b" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6332-4782-daee-17af" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="a315-9e66-476-14a7" name="Gory Talons and Fangs" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
+                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
+                <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">5</characteristic>
+                <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">3+</characteristic>
+                <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
+                <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-1</characteristic>
+                <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="b297-cecc-d8-c9d8" name="General" hidden="false" collective="false" import="true" targetId="8228-415a-66c3-dffe" type="selectionEntry"/>
+        <entryLink id="f058-a377-1094-43c7" name="Artefacts" hidden="false" collective="false" import="true" targetId="c8cb-28b1-ffbb-2bbf" type="selectionEntryGroup"/>
+        <entryLink id="f355-2bee-8148-94a2" name="Command Traits" hidden="false" collective="false" import="true" targetId="2b46-6a34-bba4-a7a2" type="selectionEntryGroup"/>
+        <entryLink id="cfaa-ab6c-4a1b-757c" name="Spell Lores" hidden="false" collective="false" import="true" targetId="011c-b2d0-4781-ff07" type="selectionEntryGroup"/>
+        <entryLink id="74fa-781-60ea-3d8e" name="Battalions" hidden="false" collective="false" import="true" targetId="3f3e-293b-65ed-e3fa" type="selectionEntryGroup"/>
+        <entryLink id="5270-fdab-6107-69bb" name="Incarnate Bonding" hidden="false" collective="false" import="true" targetId="c890-acbd-0c80-55c9" type="selectionEntryGroup"/>
+        <entryLink id="3f56-dd8-8545-d11d" name="Unique Enhancements" hidden="false" collective="false" import="true" targetId="62f4-174e-c529-75fe" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="150"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6dba-937-c22b-bccf" name="Grand Justice Gormayne" publicationId="6afd-4f9a-0665-9b55" hidden="false" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="e2b4-9369-e0c-3977" name="Grand Justice Gormayne" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
+          <characteristics>
+            <characteristic name="Move" typeId="8655-6213-2824-1752">6&quot;</characteristic>
+            <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">6</characteristic>
+            <characteristic name="Bravery" typeId="0c85-bf79-836b-759e">10</characteristic>
+            <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">4+</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="2e94-3df-78c4-2b94" name="Pronounce Judgement" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">In your hero phase, pick 1 of the following judgements to pronounce. The same unit cannot be affected by more than 1 judgement at the same time.
+
+
+Petty Transgression: Pick 1 enemy unit that is visible to this unit and roll a dice. On a 3+, add 1 to wound rolls for attacks made by friendly FLESH-EATER COURTS units that target that unit until the end of the turn.
+
+
+Dishonourable Conduct in Battle: Pick 1 enemy unit that is visible to this unit and more than 3&quot; from all friendly units. Roll a dice. On a 3+, friendly FLESH-EATER COURTS units can charge even if they ran earlier in the turn, as long as they finish the charge move within 1/2 of the enemy unit you picked.
+
+
+Grievous Insult to the Court: Pick 1 enemy unit that is visible to this unit and within 3&quot; of a friendly ABHORRANT. Roll a dice. On a 3+, add 1 to hit rolls for attacks made by friendly FLESH-EATER COURTS units that target that enemy unit until the end of the turn.
+
+
+Regicide: Pick 1 enemy unit that is visible to this unit and has slain a friendly ABHORRANT. Roll a dice. On a 3+, until the end of the turn, add 1 to the Damage characteristic of weapons used by friendly FLESH-EATER COURTS units for attacks that target that unit.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="2106-bcea-5e84-6e13" name="Royal Blood" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">In your hero phase, you can heal up to D3 wounds allocated to this unit.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink id="3375-f497-1948-b0fa" name="New CategoryLink" hidden="false" targetId="4e0e-664d-51ea-0929" primary="false"/>
+        <categoryLink id="2879-8932-d831-5b16" name="New CategoryLink" hidden="false" targetId="6cdf-dd4f-0e91-e9c4" primary="false"/>
+        <categoryLink id="854c-c339-f28e-e487" name="New CategoryLink" hidden="false" targetId="6b35-0508-c6cc-6592" primary="false"/>
+        <categoryLink id="4d5b-48d8-9a55-e195" name="ABHORRANT" hidden="false" targetId="5b04-42e4-33ef-10b1" primary="false"/>
+        <categoryLink id="fe7-46bf-37a3-5e4c" name="9 or less wounds Leader" hidden="false" targetId="a8ed-ca35-24e0-cf2e" primary="false"/>
+        <categoryLink id="8879-e79a-e2fc-674a" name="VAMPIRE" hidden="false" targetId="d1e1-d80a-c667-b587" primary="false"/>
+        <categoryLink id="7e86-8085-40dc-78e0" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="f15c-57b2-4667-ceb5" name="General" hidden="false" collective="false" import="true" targetId="8228-415a-66c3-dffe" type="selectionEntry"/>
+        <entryLink id="61d6-8ea6-b290-1a89" name="Battalions" hidden="false" collective="false" import="true" targetId="3f3e-293b-65ed-e3fa" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="140"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="698f-7fbf-7a84-59ff" name="Royal Decapitator" hidden="false" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="3e72-cc90-1e7d-5a26" name="Executioner’s Entourage" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">In the combat phase, after this unit has fought for the first time in that phase, you can pick 1 friendly SERFS unit that has not yet fought in that phase, is within 3&quot; of an enemy unit and is wholly within 9&quot; of this unit. That unit can fight immediately.
+
+</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="eff2-a805-f42f-2b6" name="Off with their Head!" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">At the end of the combat phase, if any wounds caused by this unit’s Headsman’s Axe in that phase were allocated to an enemy HERO and that enemy HERO has not been slain, roll a dice. On a 5+, that enemy HERO is slain.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="95eb-bfa3-2e5e-166a" name="Royal Decapitator" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
+          <characteristics>
+            <characteristic name="Move" typeId="8655-6213-2824-1752">6&quot;</characteristic>
+            <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">5</characteristic>
+            <characteristic name="Bravery" typeId="0c85-bf79-836b-759e">10</characteristic>
+            <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">5+</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Headsman’s Axe" typeId="96df-ab28-5d72-bbb3" typeName="Weapon" hidden="false" id="4b0a-d029-c672-e955">
+          <characteristics>
+            <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
+            <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
+            <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">3</characteristic>
+            <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">4+</characteristic>
+            <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
+            <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-2</characteristic>
+            <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink id="7190-ad04-7ed-b592" name="9 or less wounds Leader" hidden="false" targetId="a8ed-ca35-24e0-cf2e" primary="false"/>
+        <categoryLink id="fa54-1ced-7d08-3f2a" name="New CategoryLink" hidden="false" targetId="6c6b-e787-f9b8-a510" primary="true"/>
+        <categoryLink id="5340-248e-24bf-76a1" name="HERO" hidden="false" targetId="4e0e-664d-51ea-0929" primary="false"/>
+        <categoryLink targetId="6b35-0508-c6cc-6592" id="b702-b2e9-4fd5-239" primary="false" name="FLESH-EATER COURTS"/>
+        <categoryLink targetId="53f6-aa54-91a5-fcfb" id="fff4-d50-fe05-a164" primary="false" name="MORDANT"/>
+        <categoryLink targetId="6cdf-dd4f-0e91-e9c4" id="4544-e89e-1d-d0ab" primary="false" name="DEATH"/>
+        <categoryLink targetId="aabf-1ee9-60e2-638" id="2966-eeaa-4478-a544" primary="false" name="COURTIER"/>
+        <categoryLink targetId="5fca-46aa-3eee-233f" id="3d12-5ff9-b224-999f" primary="false" name="MAROWSCROLL HERALD"/>
+        <categoryLink targetId="94b9-7eb-a81a-b892" id="66c4-753e-6008-1817" primary="false" name="Champion"/>
+        <categoryLink targetId="6aaf-34b3-15d0-400d" id="e900-3c44-3227-3653" primary="false" name="ROYAL DECAPITATOR"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="9a26-6003-4126-9569" name="Artefacts" hidden="false" collective="false" import="true" targetId="c8cb-28b1-ffbb-2bbf" type="selectionEntryGroup"/>
+        <entryLink id="cde7-21b6-7f8f-71fb" name="Battalions" hidden="false" collective="false" import="true" targetId="3f3e-293b-65ed-e3fa" type="selectionEntryGroup"/>
+        <entryLink id="66d-6d76-ebc3-6229" name="Command Traits" hidden="false" collective="false" import="true" targetId="2b46-6a34-bba4-a7a2" type="selectionEntryGroup"/>
+        <entryLink id="23ee-5ba6-9b75-ba5b" name="General" hidden="false" collective="false" import="true" targetId="8228-415a-66c3-dffe" type="selectionEntry"/>
+        <entryLink id="59ee-1006-7d7-9c1f" name="Incarnate Bonding" hidden="false" collective="false" import="true" targetId="c890-acbd-0c80-55c9" type="selectionEntryGroup"/>
+        <entryLink id="af59-afc5-2f37-9786" name="Unique Enhancements" hidden="false" collective="false" import="true" targetId="62f4-174e-c529-75fe" type="selectionEntryGroup"/>
+      </entryLinks>
+      <modifiers>
+        <modifier type="add" field="category" value="89f7-d50b-0aa9-01ce">
+          <conditions>
+            <condition field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9f18-9ffb-0267-3e08" type="greaterThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <costs>
+        <cost name="pts" typeId="points" value="100"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b689-54f9-5b9e-47cb" name="Cryptguard" page="135" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="7ede-19c1-7261-f88b">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1411-460f-c135-a667" type="greaterThan"/>
+                <condition type="atLeast" value="1" field="selections" scope="roster" childId="dbb1-fd69-0ebc-97df" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="add" field="category" value="7f45-c5b3-c698-138d">
+          <conditions>
+            <condition field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9f18-9ffb-0267-3e08" type="greaterThan"/>
+          </conditions>
+        </modifier>
+        <modifier type="set-primary" value="e9f2-765a-b7b8-ce8e" field="category">
+          <conditions>
+            <condition type="atLeast" value="1" field="selections" scope="roster" childId="dbb1-fd69-0ebc-97df" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <profiles>
+        <profile id="eeb3-768a-b05e-5fa0" name="Armoury of Madness" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If any wounds caused by this unit’s attacks are allocated to an enemy unit, that enemy unit cannot issue or receive commands until the end of the turn.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="712-56d-16b-95c2" name="Cryptguard" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
+          <characteristics>
+            <characteristic name="Move" typeId="8655-6213-2824-1752">6&quot;</characteristic>
+            <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">1</characteristic>
+            <characteristic name="Bravery" typeId="0c85-bf79-836b-759e">10</characteristic>
+            <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">5+</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="2b33-3ab0-8180-617c" name="Royal Bodyguard" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">This unit has a ward of 5+. In addition, add 1 to ward rolls for friendly FLESH-EATER COURTS HEROES wholly within 3&quot; of this unit.
+
+</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Cursed Weapon" typeId="96df-ab28-5d72-bbb3" typeName="Weapon" hidden="false" id="b95-85dc-a729-ee9a">
+          <characteristics>
+            <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
+            <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">2&quot;</characteristic>
+            <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">2</characteristic>
+            <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">3+</characteristic>
+            <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
+            <characteristic name="Rend" typeId="f578-d2a5-f0d3-b707">-1</characteristic>
+            <characteristic name="Damage" typeId="b5b6-4cbd-661d-1b70">1</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink id="7e3e-a909-9764-2fc5" name="New CategoryLink" hidden="false" targetId="53f6-aa54-91a5-fcfb" primary="false"/>
+        <categoryLink id="1c95-618e-e59a-2c25" name="New CategoryLink" hidden="false" targetId="6cdf-dd4f-0e91-e9c4" primary="false"/>
+        <categoryLink id="a5cc-2fe5-b1f2-cbbf" name="New CategoryLink" hidden="false" targetId="6b35-0508-c6cc-6592" primary="false"/>
+        <categoryLink id="a128-7fbc-8023-b150" name="SERFS" hidden="false" targetId="ee79-e29c-b47c-f2db" primary="false"/>
+        <categoryLink targetId="7f45-c5b3-c698-138d" id="d464-6948-8ccb-4d38" primary="false" name="Infantry"/>
+        <categoryLink targetId="065e-fda7-fd27-1f40" id="c5ae-702e-7510-ccd0" primary="true" name="Other"/>
+        <categoryLink targetId="9527-1e4c-6681-2aa5" id="aa02-e149-12da-9541" primary="false" name="CRYPTGUARD"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="d886-405d-fdee-27b9" name="10 Cryptguard" hidden="false" collective="false" import="true" type="model">
+          <modifiers>
+            <modifier type="set" field="name" value="20 Cryptguard">
+              <conditions>
+                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a8d-cde8-fba1-6c0d" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="name" value="30 Cryptguard">
+              <conditions>
+                <condition field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a8d-cde8-fba1-6c0d" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e7fa-467f-c2c6-3d14" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="54b1-3b0a-b63f-d0c5" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="points" value="140"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="f7af-de61-e90c-71b5" name="Reinforced" hidden="false" collective="false" import="true" targetId="0a8d-cde8-fba1-6c0d" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="95f2-6885-756f-9ea5" value="2"/>
+          </modifiers>
+          <costs>
+            <cost name="pts" typeId="points" value="140"/>
+          </costs>
+        </entryLink>
+        <entryLink id="bd54-c42b-d951-b918" name="Battalions" hidden="false" collective="false" import="true" targetId="3f3e-293b-65ed-e3fa" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0"/>
+      </costs>
+      <selectionEntryGroups>
+        <selectionEntryGroup name="Command Models" hidden="false" id="d4bc-42d0-1f45-fe2d">
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Champion" hidden="false" id="87fb-ce0-189b-8596">
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="86d8-d7b2-dce2-b3c4"/>
+              </constraints>
+              <profiles>
+                <profile name="Champion" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities" hidden="false" id="d54c-bce4-37fc-7de2">
+                  <characteristics>
+                    <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">1 model in this unit can be a Crypt Captain. Add 1 to the Attacks characteristic of that model’s melee weapon.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Standard Bearer" hidden="false" id="5ef-3e7-fc2c-935e">
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4e9b-e423-718-d7e6"/>
+              </constraints>
+              <modifiers>
+                <modifier type="increment" value="1" field="4e9b-e423-718-d7e6">
+                  <repeats>
+                    <repeat value="1" repeats="1" field="selections" scope="parent" childId="f7af-de61-e90c-71b5" shared="true" roundUp="false" id="4bb3-607e-351a-c9c6"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <profiles>
+                <profile name="Standard Bearer" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities" hidden="false" id="d6bb-1474-b8bf-b484">
+                  <characteristics>
+                    <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">1 in every 10 models in this unit can be a Drummer. Add 1 to run rolls and charge rolls for this unit while it includes any Drummers.
+
+</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Musician" hidden="false" id="96f7-6797-17de-431">
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a645-5c31-2a8e-d9a9"/>
+              </constraints>
+              <modifiers>
+                <modifier type="increment" value="1" field="a645-5c31-2a8e-d9a9">
+                  <repeats>
+                    <repeat value="1" repeats="1" field="selections" scope="parent" childId="f7af-de61-e90c-71b5" shared="true" roundUp="false" id="f3cc-2c74-95a4-772c"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <profiles>
+                <profile name="Musician" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities" hidden="false" id="8cfa-1092-ba2a-7906">
+                  <characteristics>
+                    <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">1 in every 10 models in this unit can be a Standard Bearer. While this unit includes a Standard Bearer, if this unit fails a battleshock test, halve the number of models that flee (rounding down).</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntry>
+    <selectionEntry id="97d9-cba9-52a4-1b00" name="Morbheg Knights" page="135" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set-primary" field="category" value="e9f2-765a-b7b8-ce8e">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="705f-02ae-f4f5-987a" type="equalTo"/>
+              </conditions>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="atLeast" value="1" field="selections" scope="parent" childId="c89f-a721-882d-41b9" shared="true" includeChildSelections="true" includeChildForces="true"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <profiles>
+        <profile id="7c48-c23-af4d-4ae7" name="Morbheg Knights" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
+          <characteristics>
+            <characteristic name="Move" typeId="8655-6213-2824-1752">12&quot;</characteristic>
+            <characteristic name="Wounds" typeId="cd0e-fea6-411f-904d">3</characteristic>
+            <characteristic name="Bravery" typeId="0c85-bf79-836b-759e">10</characteristic>
+            <characteristic name="Save" typeId="f8dd-4f2a-8543-4f36">4+</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Shrieking Charge" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities" hidden="false" id="2c9-b966-75e6-9294">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">After this unit makes a charge move, you can pick 1 enemy unit within 1&quot; of this unit. That enemy unit cannot receive the Unleash Hell command in this phase. In addition, roll 1 dice for each model in this unit that is within 1&quot; of that enemy unit. For each 4+, that enemy unit suffers D3 mortal wounds.
+
+</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Predator’s Pounce" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities" hidden="false" id="cbd7-ca5c-63dc-dd36">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">This unit can retreat and still charge later in the turn.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="f66-cf82-2c8e-46e1" name="Fly" hidden="false" targetId="8e0c-cbe4-27be-8a30" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="29f4-df84-b27f-4d05" name="New CategoryLink" hidden="false" targetId="53f6-aa54-91a5-fcfb" primary="false"/>
+        <categoryLink id="be70-75c1-ad07-a95b" name="New CategoryLink" hidden="false" targetId="6cdf-dd4f-0e91-e9c4" primary="false"/>
+        <categoryLink id="6cbe-e77b-aeee-c20a" name="New CategoryLink" hidden="false" targetId="6b35-0508-c6cc-6592" primary="false"/>
+        <categoryLink id="8e01-a005-970b-4c4e" name="KNIGHTS" hidden="false" targetId="3246-ccec-12af-67af" primary="false"/>
+        <categoryLink id="ccff-9510-aaf8-78d1" name="New CategoryLink" hidden="false" targetId="065e-fda7-fd27-1f40" primary="true"/>
+        <categoryLink targetId="28ac-1b27-ef5e-33be" id="f559-1e92-5e5a-6ea6" primary="false" name="MORBHEG KNIGHTS"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="5c46-39a-2fc3-13c1" name="3 Morbheg Knights" hidden="false" collective="false" import="true" type="model">
+          <modifiers>
+            <modifier type="set" field="name" value="6 Morbheg Knights">
+              <conditions>
+                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a8d-cde8-fba1-6c0d" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="name" value="9 Morbheg Knights">
+              <conditions>
+                <condition field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a8d-cde8-fba1-6c0d" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7c7a-787b-63f3-402" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="acd-43ac-b7c7-3771" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="points" value="150"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="dfe-1c95-872b-7749" name="Reinforced" hidden="false" collective="false" import="true" targetId="0a8d-cde8-fba1-6c0d" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="95f2-6885-756f-9ea5" value="2">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition type="atLeast" value="1" field="selections" scope="parent" childId="c89f-a721-882d-41b9" shared="true" includeChildSelections="true" includeChildForces="true"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <costs>
+            <cost name="pts" typeId="points" value="150"/>
+          </costs>
+        </entryLink>
+        <entryLink id="98e3-b994-9b94-c10c" name="Battalions" hidden="false" collective="false" import="true" targetId="3f3e-293b-65ed-e3fa" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0"/>
+      </costs>
+      <selectionEntryGroups>
+        <selectionEntryGroup name="Command Models" hidden="false" id="d0a6-1f01-a3c6-62bc">
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Champion" hidden="false" id="d01c-c7a6-c3a5-5b5c">
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d97e-d828-8557-de65"/>
+              </constraints>
+              <profiles>
+                <profile name="Champion" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities" hidden="false" id="3493-26a8-5e77-61f1">
+                  <characteristics>
+                    <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">1 model in this unit can be a Champion of Morbheg. Add 1 to the Attacks characteristic of that model’s Grisly Lance.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Standard Bearer" hidden="false" id="cbbf-ac2f-8dee-af27">
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7e2f-7a77-8e31-7654"/>
+              </constraints>
+              <modifiers>
+                <modifier type="increment" value="1" field="7e2f-7a77-8e31-7654">
+                  <repeats>
+                    <repeat value="1" repeats="1" field="selections" scope="parent" childId="f7af-de61-e90c-71b5" shared="true" roundUp="false" id="d2ac-3374-eed2-a7ec"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <profiles>
+                <profile name="Standard Bearer" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities" hidden="false" id="7fdd-8bf0-1759-697b">
+                  <characteristics>
+                    <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">1 in every 3 models in this unit can be a Standard Bearer. While this unit includes any Standard Bearers, if it made a charge move in the same turn, each model in this unit counts as 3 models for the purposes of contesting objectives.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Musician" hidden="false" id="5a-d7e0-f89a-d837">
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8d75-69e4-c065-e85f"/>
+              </constraints>
+              <modifiers>
+                <modifier type="increment" value="1" field="8d75-69e4-c065-e85f">
+                  <repeats>
+                    <repeat value="1" repeats="1" field="selections" scope="parent" childId="f7af-de61-e90c-71b5" shared="true" roundUp="false" id="7e00-6883-bb59-97d2"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <profiles>
+                <profile name="Musician" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities" hidden="false" id="e2a0-17ca-9226-c4c1">
+                  <characteristics>
+                    <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">1 in every 3 models in this unit can be a Hornblower. Add 1 to run rolls and charge rolls for this unit while it includes any Hornblowers.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>

--- a/Endless Spells.cat
+++ b/Endless Spells.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="f0db-356d-9f9f-662d" name="Endless Spells" revision="34" battleScribeVersion="2.03" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="true" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="161" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="f0db-356d-9f9f-662d" name="Endless Spells" revision="35" battleScribeVersion="2.03" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="true" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="161" type="catalogue">
   <publications>
     <publication id="d1d1-5917-4fcf-8b1e" name="General&apos;s Handbook Pitched Battles 2022-23 - Season 1 September 2022 FAQ"/>
     <publication id="afcd-7621-7abc-1ba5" name="General&apos;s Handbook Pitched Battles 2022-23 - Season 2, Errata January 2023"/>
@@ -1083,12 +1083,12 @@ A WIZARD in a garrison cannot attempt to summon this endless spell, and if this 
         </profile>
         <profile id="3aef-55b1-6967-58f9" name="Grasping Hands" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">If a model starts a move within 3&quot; of this terrain feature, halve the distance that model can move when it makes that move. DEATH models are not affected by this scenery rule.</characteristic>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Enemy units within 3&quot; of this terrain feature cannot run or retreat. In addition, if an enemy model starts a move within 3&quot; of this terrain feature, halve the distance that model can move when it makes that move.</characteristic>
           </characteristics>
         </profile>
         <profile id="cfa5-51a1-d33f-c9d6" name="Terrain Feature" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">After it is set up, this endless spell is treated as a terrain feature that has the Grasping Hands scenery rule opposite, except that it can still be dispelled as if it were an endless spell.</characteristic>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">After it is set up, this endless spell is treated as a terrain feature that has the Grasping Hands scenery rule, except that it can still be dispelled as if it were an endless spell.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -1114,7 +1114,12 @@ A WIZARD in a garrison cannot attempt to summon this endless spell, and if this 
         </profile>
         <profile id="da11-8f47-0e90-4c7e" name="Soul Stealer" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Keep track of the number of models that are slain within 12&quot; of this endless spell each turn. At the end of each turn, roll a dice for each model that was slain within 12&quot; of this endless spell during that turn. For each 4+, the commanding player can heal 1 wound allocated to 1 FLESH-EATER COURTS model within 12&quot; of this endless spell or return 1 slain model to 1 FLESH-EATER COURTS unit with a Wounds characteristic of 1 that is wholly within 12&quot; of this endless spell.</characteristic>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">Keep track of the number of models that are slain within 12&quot; of this endless spell each turn. At the end of each turn, roll a dice for each model that was slain within 12&quot; of this endless spell during that turn. For each 4+, the commanding player can heal 1 wound allocated to 1 FLESH-EATER COURTS model within 12&quot; of this endless spell or return 1 slain model to 1 FLESH-EATER COURTS unit that has a Wounds characteristic of 1 that is wholly within 12&quot; of this endless spell.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="93b3-bf66-204c-69bb" name="Predatory" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
+          <characteristics>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">This endless spell is a predatory endless spell. It can be moved up to 8&quot; and can fly.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -1125,6 +1130,9 @@ A WIZARD in a garrison cannot attempt to summon this endless spell, and if this 
       <costs>
         <cost name="pts" typeId="points" value="50"/>
       </costs>
+      <infoLinks>
+        <infoLink id="a849-f08d-bb6b-7533" name="Fly" hidden="false" targetId="8e0c-cbe4-27be-8a30" type="profile"/>
+      </infoLinks>
     </selectionEntry>
     <selectionEntry id="67e9-09b1-bc11-a859" name="Endless Spell: Corpsemare Stampede" hidden="false" collective="false" import="true" type="unit">
       <constraints>
@@ -1145,7 +1153,7 @@ A WIZARD in a garrison cannot attempt to summon this endless spell, and if this 
         </profile>
         <profile id="7d3c-bf9d-0bca-30e6" name="Trampled Underfoot" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>
-            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">After this endless spell has moved, roll 5 dice for each unit that has any models it passed across. For each roll that is more than that unit’s Wounds characteristic, that unit suffers 1 mortal wound. For each 6, that unit instead suffers 1 mortal wound regardless of its Wounds characteristic.</characteristic>
+            <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">After this endless spell has moved, roll 6 dice for each unit that has any models it passes across. For each roll that is greater than that unit’s Wounds characteristic, that unit suffers 1 mortal wound. For each 6, that unit instead suffers 1 mortal wound regardless of its Wounds characteristic.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -1157,7 +1165,7 @@ A WIZARD in a garrison cannot attempt to summon this endless spell, and if this 
         <categoryLink id="3861-78d7-1b88-67ee" name="New CategoryLink" hidden="false" targetId="eecb-ed66-d474-9ddd" primary="true"/>
       </categoryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="50"/>
+        <cost name="pts" typeId="points" value="60"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="189e-27eb-c948-aa33" name="Endless Spell: Mortalis Terminexus" hidden="false" collective="false" import="true" type="upgrade">


### PR DESCRIPTION
New FEC book. While not tournament legal yet, it's in popular demand and no other listbuilders support. To downgrade in New Recruit, go to List Options > Select Book Version and change the date to 2024-01-10. To downgrade in Battlescribe, manually check out [this release](https://github.com/BSData/warhammer-age-of-sigmar/releases/tag/v3.3.29).