### PR TITLE
New Recruit multi-unit patch

### DIFF
--- a/Chaos - Beasts of Chaos - Data.cat
+++ b/Chaos - Beasts of Chaos - Data.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="a990-882b-7e62-27e9" name="Chaos - Beasts of Chaos - Data" revision="111" battleScribeVersion="2.03" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="true" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="161" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="a990-882b-7e62-27e9" name="Chaos - Beasts of Chaos - Data" revision="112" battleScribeVersion="2.03" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="true" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="161" type="catalogue">
   <publications>
     <publication id="c9b2-1fe6-pubN65537" name="Battletome: Beasts of Chaos"/>
     <publication id="ec9c-1f93-d9ca-18c7" name="White Dwarf 473" publisher="White Dwarf 473"/>
@@ -4862,7 +4862,7 @@ From the start of the fourth battle round, improve the Rend characteristic of me
         <cost name="pts" typeId="points" value="0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2e20-099d-99a7-666a" name="Morghurite Chaos Spawn" hidden="false" collective="false" import="true" type="model">
+    <selectionEntry id="2e20-099d-99a7-666a" name="Morghurite Chaos Spawn" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="a417-7545-385d-7e6b" name="Aura of Insanity" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
           <characteristics>

--- a/Chaos - Nurgle.cat
+++ b/Chaos - Nurgle.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="6894-a70d-7327-b3c3" name="Chaos - Nurgle" revision="129" battleScribeVersion="2.03" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="159" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="6894-a70d-7327-b3c3" name="Chaos - Nurgle" revision="130" battleScribeVersion="2.03" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="159" type="catalogue">
   <publications>
     <publication id="6894-a70d-pubN65537" name="Chaos Battletome: Maggotkin of Nurgle"/>
     <publication id="6894-a70d-pubN85775" name="Chaos Battletome: Maggotkin of Nurgle"/>
@@ -2610,7 +2610,7 @@ Before attempting to cast this spell, you can say that the caster will project t
         <cost name="pts" typeId="points" value="0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="a0fc-1a6d-64a9-f326" name="Rot Coven" hidden="true" collective="false" import="true" type="upgrade">
+    <selectionEntry id="a0fc-1a6d-64a9-f326" name="Rot Coven" hidden="true" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>

--- a/Chaos Data.cat
+++ b/Chaos Data.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="0339-0157-6910-d29c" name="Chaos Data" revision="236" battleScribeVersion="2.03" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="true" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="161" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="0339-0157-6910-d29c" name="Chaos Data" revision="237" battleScribeVersion="2.03" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="true" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="161" type="catalogue">
   <publications>
     <publication id="c9b2-1fe6-pubN65537" name="Battletome: Beasts of Chaos" publicationDate="2023"/>
     <publication id="6894-a70d-pubN65537" name="Chaos Battletome: Maggotkin of Nurgle"/>
@@ -12209,7 +12209,6 @@ If the target of an attack made with a Barbed Stinger has a Wounds characteristi
     </selectionEntryGroup>
     <selectionEntryGroup id="b2c6-bb69-8227-0445" name="Damned Legions" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="40c7-bea6-09b0-30be" type="min"/>
         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="358b-7f43-a31b-7d00" type="max"/>
       </constraints>
       <selectionEntries>
@@ -17107,26 +17106,6 @@ Before attempting to cast this spell, you can say that the caster will project t
               </conditionGroups>
             </modifier>
           </modifiers>
-          <profiles>
-            <profile id="6fa0-8cae-5e87-b39d" name="Slay Worthy Foes" publicationId="f3a5-ccd1-53af-9748" hidden="true" typeId="f71f-b0a4-730e-ced3" typeName="Command Abilities">
-              <modifiers>
-                <modifier type="set" field="hidden" value="false">
-                  <conditions>
-                    <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4e0e-664d-51ea-0929" type="instanceOf"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-              <characteristics>
-                <characteristic name="Command Ability Details" typeId="1b71-4c83-4e8c-093f">You can use this command ability at the start of the combat phase. A friendly UNDIVIDED SLAVES TO DARKNESS unit must receive this command. Until the end of that phase, add 1 to wound rolls for
-attacks made with melee weapons by that unit that target an enemy HERO or MONSTER.</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="89c2-2375-4c01-0b23" name="Mark of Chaos Undivided" hidden="false" typeId="c924-5a68-471a-2fd5" typeName="Unit Abilities">
-              <characteristics>
-                <characteristic name="Ability Details" typeId="d4dc-8e81-bc0e-b8f0">All MORTAL and OGROID SLAVES TO DARKNESS UNDIVIDED units that are not unique gain the EYE OF THE GODS keyword.  When a SLAVES TO DARKNESS UNDIVIDED HERO rolls on the Eye of the Gods table, you can re-roll any 1 of the dice.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
           </costs>
@@ -17139,6 +17118,21 @@ attacks made with melee weapons by that unit that target an enemy HERO or MONSTE
                   </conditions>
                 </modifier>
               </modifiers>
+              <profiles>
+                <profile id="6fa0-8cae-5e87-b39d" name="Slay Worthy Foes" publicationId="f3a5-ccd1-53af-9748" hidden="true" typeId="f71f-b0a4-730e-ced3" typeName="Command Abilities">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4e0e-664d-51ea-0929" type="instanceOf"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <characteristics>
+                    <characteristic name="Command Ability Details" typeId="1b71-4c83-4e8c-093f">You can use this command ability at the start of the combat phase. A friendly UNDIVIDED SLAVES TO DARKNESS unit must receive this command. Until the end of that phase, add 1 to wound rolls for
+attacks made with melee weapons by that unit that target an enemy HERO or MONSTER.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
             </infoGroup>
           </infoGroups>
         </selectionEntry>

--- a/Death - Data.cat
+++ b/Death - Data.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="e37a-2f18-f168-6ed3" name="Death - Data" revision="142" battleScribeVersion="2.03" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="true" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="161" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="e37a-2f18-f168-6ed3" name="Death - Data" revision="143" battleScribeVersion="2.03" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="true" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="161" type="catalogue">
   <publications>
     <publication id="e320-d5ec-pubN65537" name="Battletome: Legions of Nagash and Battletome: Nighthaunt"/>
     <publication id="e320-d5ec-pubN65555" name="Battletome: Nighthaunt"/>
@@ -726,7 +726,7 @@
             <profile id="6bef-2ece-58c5-df03" name="Templar Lance or Blade" hidden="false" typeId="96df-ab28-5d72-bbb3" typeName="Weapon">
               <characteristics>
                 <characteristic name="Type" typeId="655c-362e-a663-3e50">Melee</characteristic>
-                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">1&quot;</characteristic>
+                <characteristic name="Range" typeId="ee32-7f8e-ccd7-b7b0">2&quot;</characteristic>
                 <characteristic name="Attacks" typeId="0bd7-bded-a0e0-19a0">3</characteristic>
                 <characteristic name="To Hit" typeId="87f2-fb99-33f9-7269">3+</characteristic>
                 <characteristic name="To Wound" typeId="8842-17f1-9794-4efc">3+</characteristic>
@@ -5432,9 +5432,6 @@ end of that phase.</characteristic>
       </modifiers>
     </selectionEntry>
     <selectionEntry id="c724-23ef-e144-7933" name="Kosargi Nightguard" publicationId="7a08-6611-3750-6469" page="92" hidden="false" collective="false" import="true" type="unit">
-      <constraints>
-        <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6625-501d-5c55-8eba" type="max"/>
-      </constraints>
       <profiles>
         <profile id="a041-7295-edc9-a051" name="Kosargi Nightguard" hidden="false" typeId="1960-ca8e-67ce-2014" typeName="Unit">
           <characteristics>

--- a/Death - Soulblight Gravelords.cat
+++ b/Death - Soulblight Gravelords.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="0364-070f-023f-64d9" name="Death - Soulblight Gravelords" revision="34" battleScribeVersion="2.03" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="161" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="0364-070f-023f-64d9" name="Death - Soulblight Gravelords" revision="35" battleScribeVersion="2.03" library="false" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="161" type="catalogue">
   <categoryEntries>
     <categoryEntry id="d72b-b718-4010-345d" name="DEINTALOS THE EXILE" hidden="false"/>
     <categoryEntry id="68d2-327f-6699-51f3" name="THE EXILED DEAD" hidden="false"/>
@@ -68,7 +68,11 @@
     <entryLink id="1dc6-a8ab-53ee-0238" name="Soulblight Core Battalion: Radukar&apos;s Court" hidden="false" collective="false" import="true" targetId="f5d7-8594-2b91-7104" type="selectionEntry"/>
     <entryLink id="836c-dc0c-2d2e-2ba9" name="Deintalos the Exile" hidden="false" collective="false" import="true" targetId="98de-3585-725a-a25d" type="selectionEntry"/>
     <entryLink id="735c-9fc2-c05b-4b2d" name="The Exiled Dead" hidden="false" collective="false" import="true" targetId="7cec-ef8c-e266-e541" type="selectionEntry"/>
-    <entryLink id="28b9-86e1-8200-aba3" name="Battle Tactics: Terror of the Undead" hidden="false" collective="false" import="true" targetId="cdb4-1c8b-ee6d-55ab" type="selectionEntry"/>
+    <entryLink id="28b9-86e1-8200-aba3" name="Battle Tactics: Terror of the Undead" hidden="false" collective="false" import="true" targetId="cdb4-1c8b-ee6d-55ab" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink targetId="1974-3f49-7f0b-8422" id="1e7-852-92f5-e163" primary="true" name="Game Options"/>
+      </categoryLinks>
+    </entryLink>
     <entryLink id="150c-60af-8823-5dbb" name="Cado Ezechiar, the Hollow King" hidden="false" collective="false" import="true" targetId="364b-9f77-019a-1565" type="selectionEntry"/>
     <entryLink id="e239-13e7-b452-a3ad" name="The Sons of Velmorn" hidden="false" collective="false" import="true" targetId="55fe-7871-2714-4010" type="selectionEntry"/>
     <entryLink id="5ce9-ef70-b945-c33a" name="King Morlak Velmorn" hidden="false" collective="false" import="true" targetId="6b37-28df-c36d-2fbe" type="selectionEntry"/>
@@ -77,7 +81,11 @@
     <entryLink id="dde6-19a6-5b49-f001" name="Soulblight Warscroll Battalion: Deathmarch" hidden="false" collective="false" import="true" targetId="25ea-f40e-90d5-9b27" type="selectionEntry"/>
     <entryLink import="true" name="Regiment of Renown - Jerrion&apos;s Delegation" hidden="false" type="selectionEntry" id="a375-3dbb-ee29-6fcd" targetId="7836-fd33-36d8-9a7a"/>
     <entryLink import="true" name="Sekhar, Fang of Nulahmia" hidden="false" type="selectionEntry" id="e030-8e50-1bd1-4427" targetId="15bc-2892-693c-2c8g"/>
-    <entryLink import="true" name="Battle Tacics: Scions of Nulahmia" hidden="false" id="cfdb-946e-ce65-4c70" targetId="747e-22fd-6c6d-b84a" type="selectionEntry"/>
+    <entryLink import="true" name="Battle Tacics: Scions of Nulahmia" hidden="false" id="cfdb-946e-ce65-4c70" targetId="747e-22fd-6c6d-b84a" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink targetId="1974-3f49-7f0b-8422" id="d8b4-fc20-90cf-4c06" primary="true" name="Game Options"/>
+      </categoryLinks>
+    </entryLink>
     <entryLink import="true" name="Regiment of Renown - The Sorrowmourne Choir" hidden="false" type="selectionEntry" id="8dff-7932-2046-ec3a" targetId="48ca-d15d-4e8b-be5b"/>
     <entryLink import="true" name="Regiment of Renown - The Summerking&apos;s Entourage" hidden="false" type="selectionEntry" id="3d98-7fa-2755-c26a" targetId="2eda-9ef0-22d9-a4ba"/>
     <entryLink import="true" name="Regiment of Renown - Scions of the Necropolis" hidden="false" type="selectionEntry" id="7768-a8b7-a27d-f18a" targetId="8fe0-4d59-efcf-50e0"/>

--- a/Order - Idoneth Deepkin - Data.cat
+++ b/Order - Idoneth Deepkin - Data.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="b713-a274-2a46-fe02" name="Order - Idoneth Deepkin - Data" revision="106" battleScribeVersion="2.03" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="true" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="161" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="b713-a274-2a46-fe02" name="Order - Idoneth Deepkin - Data" revision="107" battleScribeVersion="2.03" authorContact="@BSData" authorUrl="https://github.com/BSData/warhammer-age-of-sigmar" library="true" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="161" type="catalogue">
   <publications>
     <publication id="0d25-2712-pubN65537" name="Order Battletome: Idoneth Deepkin"/>
     <publication id="5d07-d069-7e85-50e0" name="Battletome: Idoneth Deepkin Errata January 2023"/>
@@ -2914,7 +2914,7 @@ This faction terrain feature consists of 2 scenery pieces. When you set it up, y
         <cost name="pts" typeId="points" value="0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7fae-c1e4-166e-a9db" name="Bloodthirsty Shiver" hidden="true" collective="false" import="true" type="upgrade">
+    <selectionEntry id="7fae-c1e4-166e-a9db" name="Bloodthirsty Shiver" hidden="true" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>

--- a/Regiments of Renown.cat
+++ b/Regiments of Renown.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="33cf-d309-6df3-50d6" name="Regiments of Renown" revision="14" battleScribeVersion="2.03" library="true" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="157" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="33cf-d309-6df3-50d6" name="Regiments of Renown" revision="15" battleScribeVersion="2.03" library="true" gameSystemId="e51d-b1a3-75fc-dc33" gameSystemRevision="157" type="catalogue">
   <categoryEntries>
     <categoryEntry id="70bf-3963-c8b1-948f" name="ORRUK WARCLANS" hidden="false"/>
     <categoryEntry id="c391-fa3d-48c4-136f" name="ORRUK" hidden="false"/>
@@ -61,7 +61,7 @@
     <categoryEntry name="HAMMERS OF SIGMAR" hidden="false" id="678d-1e20-2e6a-c79c"/>
   </categoryEntries>
   <sharedSelectionEntries>
-    <selectionEntry id="fa3f-532f-9753-cd59" name="Regiment of Renown - Veremord&apos;s Shamblers" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="fa3f-532f-9753-cd59" name="Regiment of Renown - Veremord&apos;s Shamblers" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78fa-c9d5-ef50-57bc" type="max"/>
       </constraints>
@@ -92,7 +92,7 @@ The CORPSE CART in this regiment of renown has a ward of 5+ while it is wholly w
         <categoryLink targetId="1111-11dc-777-cf35" id="d0a3-129-de1e-b1b4" primary="false" name="Ally"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="20e6-655b-183a-5b56" name="1 Corpse Cart " hidden="false" collective="false" import="true" defaultSelectionEntryId="3d13-6856-579c-b262">
+        <selectionEntryGroup id="20e6-655b-183a-5b56" name="1 Corpse Cart" hidden="false" collective="false" import="true" defaultSelectionEntryId="3d13-6856-579c-b262">
           <constraints>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dad6-77d3-49ed-98e5" type="min"/>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d496-3e6d-03c8-42a3" type="max"/>
@@ -411,7 +411,7 @@ The CORPSE CART in this regiment of renown has a ward of 5+ while it is wholly w
         <cost name="pts" typeId="points" value="0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c9de-fb1a-e665-362f" name="Regiment of Renown - Big Grikk&apos;s Kruleshots" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="c9de-fb1a-e665-362f" name="Regiment of Renown - Big Grikk&apos;s Kruleshots" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4329-12da-4cda-0a86" type="max"/>
       </constraints>
@@ -465,7 +465,7 @@ The CORPSE CART in this regiment of renown has a ward of 5+ while it is wholly w
         </modifier>
       </modifiers>
     </selectionEntry>
-    <selectionEntry id="66f8-b848-40fa-a08d" name="Regiment of Renown - Elthwin&apos;s Thorns" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="66f8-b848-40fa-a08d" name="Regiment of Renown - Elthwin&apos;s Thorns" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fac3-ba11-c7dd-1ff0" type="max"/>
       </constraints>
@@ -529,7 +529,7 @@ The CORPSE CART in this regiment of renown has a ward of 5+ while it is wholly w
         </modifier>
       </modifiers>
     </selectionEntry>
-    <selectionEntry id="9553-8763-ddc2-a840" name="Regiment of Renown - Norgrimm&apos;s Rune Throng" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="9553-8763-ddc2-a840" name="Regiment of Renown - Norgrimm&apos;s Rune Throng" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b45-dc8e-9476-561c" type="max"/>
       </constraints>
@@ -588,7 +588,7 @@ The CORPSE CART in this regiment of renown has a ward of 5+ while it is wholly w
         </modifier>
       </modifiers>
     </selectionEntry>
-    <selectionEntry id="66b0-4847-a04e-0375" name="Regiment of Renown - The Coven of Thryx" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="66b0-4847-a04e-0375" name="Regiment of Renown - The Coven of Thryx" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c0d-e485-85ff-d367" type="max"/>
       </constraints>
@@ -702,7 +702,7 @@ The CORPSE CART in this regiment of renown has a ward of 5+ while it is wholly w
         </modifier>
       </modifiers>
     </selectionEntry>
-    <selectionEntry id="f5e6-6888-e003-118d" name="Regiment of Renown - Hargax&apos;s Pit-beats" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="f5e6-6888-e003-118d" name="Regiment of Renown - Hargax&apos;s Pit-beats" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f80-e4fa-fe7a-6f55" type="max"/>
       </constraints>
@@ -1386,7 +1386,7 @@ The CORPSE CART in this regiment of renown has a ward of 5+ while it is wholly w
         <cost name="pts" typeId="points" value="0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7836-fd33-36d8-9a7a" name="Regiment of Renown - Jerrion&apos;s Delegation" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="7836-fd33-36d8-9a7a" name="Regiment of Renown - Jerrion&apos;s Delegation" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78fa-c9d5-ef50-57bc" type="max"/>
       </constraints>
@@ -1785,7 +1785,7 @@ If it accepts, that enemy unit becomes infected. For the rest of the battle, rol
         <categoryLink targetId="222d-3eac-b8ff-970b" id="4e2a-ee9c-38a4-e4aa" primary="false" name="GRIMHOLD EXILE"/>
       </categoryLinks>
     </selectionEntry>
-    <selectionEntry id="679-2ac4-81f1-ac2" name="Regiment of Renown - Fjori&apos;s Flamebearers" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="679-2ac4-81f1-ac2" name="Regiment of Renown - Fjori&apos;s Flamebearers" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78fa-c9d5-ef50-57bc" type="max"/>
       </constraints>
@@ -2312,7 +2312,7 @@ If this unit has more than 1 model, roll to determine if mortal wounds are infli
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry id="10de-6e02-9446-6700" name="Regiment of Renown - Phulgoth&apos;s Shudderhood" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="10de-6e02-9446-6700" name="Regiment of Renown - Phulgoth&apos;s Shudderhood" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78fa-c9d5-ef50-57bc" type="max"/>
       </constraints>
@@ -2668,7 +2668,7 @@ Nasty Poisons: You can only pick this effect while this unit has a Spiker.  Pick
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry id="a8ad-bed9-8486-fc56" name="Regiment of Renown - Braggit&apos;s Bottle-Snatchaz" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="a8ad-bed9-8486-fc56" name="Regiment of Renown - Braggit&apos;s Bottle-Snatchaz" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4329-12da-4cda-0a86" type="max"/>
       </constraints>
@@ -3241,7 +3241,7 @@ Nasty Poisons: You can only pick this effect while this unit has a Spiker.  Pick
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="upgrade" import="true" name="Irondrakes" hidden="false" id="37b5-6b88-b50a-9f62">
+    <selectionEntry type="unit" import="true" name="Irondrakes" hidden="false" id="37b5-6b88-b50a-9f62">
       <categoryLinks>
         <categoryLink targetId="b970-b3bf-e1a4-a6fc" id="fa2d-5fae-a5f4-edb1" primary="false" name="ORDER"/>
         <categoryLink targetId="5f5a-43ec-c3f8-f174" id="5b72-efe0-7bc1-4b86" primary="false" name="CITIES OF SIGMAR"/>
@@ -3622,7 +3622,7 @@ Nasty Poisons: You can only pick this effect while this unit has a Spiker.  Pick
         </profile>
       </profiles>
     </selectionEntry>
-    <selectionEntry type="upgrade" import="true" name="Lorai, Child of the Abyss" hidden="false" id="4d66-2284-874e-c444">
+    <selectionEntry type="unit" import="true" name="Lorai, Child of the Abyss" hidden="false" id="4d66-2284-874e-c444">
       <categoryLinks>
         <categoryLink targetId="b970-b3bf-e1a4-a6fc" id="d5ed-d54c-1b1f-154f" primary="false" name="ORDER"/>
         <categoryLink targetId="6ec4-4931-4d7f-006b" id="c438-7171-b922-d93" primary="false" name="IDONETH DEEPKIN"/>
@@ -3681,7 +3681,7 @@ Nasty Poisons: You can only pick this effect while this unit has a Spiker.  Pick
         </profile>
       </profiles>
     </selectionEntry>
-    <selectionEntry type="upgrade" import="true" name="Regiment of Renown - The Blacktalons" hidden="false" id="41f8-64ce-7c63-f963">
+    <selectionEntry type="unit" import="true" name="Regiment of Renown - The Blacktalons" hidden="false" id="41f8-64ce-7c63-f963">
       <costs>
         <cost name="pts" typeId="points" value="340"/>
       </costs>
@@ -4161,7 +4161,7 @@ Nasty Poisons: You can only pick this effect while this unit has a Spiker.  Pick
         <cost name="pts" typeId="points" value="0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry type="upgrade" import="true" name="Regiment of Renown - Neferata&apos;s Royal Echelon" hidden="false" id="6a5b-f6a9-b445-7a2f">
+    <selectionEntry type="unit" import="true" name="Regiment of Renown - Neferata&apos;s Royal Echelon" hidden="false" id="6a5b-f6a9-b445-7a2f">
       <modifiers>
         <modifier type="set" value="true" field="hidden">
           <conditions>
@@ -4587,7 +4587,7 @@ renown.</characteristic>
         </selectionEntryGroup>
       </selectionEntryGroups>
     </selectionEntry>
-    <selectionEntry type="upgrade" import="true" name="Regiment of Renown - The Summerking&apos;s Entourage" hidden="false" id="2eda-9ef0-22d9-a4ba">
+    <selectionEntry type="unit" import="true" name="Regiment of Renown - The Summerking&apos;s Entourage" hidden="false" id="2eda-9ef0-22d9-a4ba">
       <modifiers>
         <modifier type="set" value="true" field="hidden">
           <conditions>
@@ -5057,7 +5057,7 @@ renown.</characteristic>
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="upgrade" import="true" name="Regiment of Renown - The Liche&apos;s Hand" hidden="false" id="b809-9d2-4993-b523">
+    <selectionEntry type="unit" import="true" name="Regiment of Renown - The Liche&apos;s Hand" hidden="false" id="b809-9d2-4993-b523">
       <modifiers>
         <modifier type="set" value="true" field="hidden">
           <conditions>
@@ -5802,7 +5802,7 @@ If that unit is an IMMORTIS GUARD or NECROPOLIS STALKERS unit, you can either he
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="upgrade" import="true" name="Regiment of Renown - Scions of the Necropolis" hidden="false" id="8fe0-4d59-efcf-50e0">
+    <selectionEntry type="unit" import="true" name="Regiment of Renown - Scions of the Necropolis" hidden="false" id="8fe0-4d59-efcf-50e0">
       <modifiers>
         <modifier type="set" value="true" field="hidden">
           <conditions>
@@ -5846,7 +5846,7 @@ If that unit is an IMMORTIS GUARD or NECROPOLIS STALKERS unit, you can either he
         <categoryLink targetId="6575-7d6c-ce4d-ada4" id="cc51-c55d-1c04-fbcd" primary="true" name="Core Battalion"/>
       </categoryLinks>
     </selectionEntry>
-    <selectionEntry type="upgrade" import="true" name="Regiment of Renown - The Sorrowmourne Choir" hidden="false" id="48ca-d15d-4e8b-be5b">
+    <selectionEntry type="unit" import="true" name="Regiment of Renown - The Sorrowmourne Choir" hidden="false" id="48ca-d15d-4e8b-be5b">
       <modifiers>
         <modifier type="set" value="true" field="hidden">
           <conditions>
@@ -5896,7 +5896,7 @@ If that unit is an IMMORTIS GUARD or NECROPOLIS STALKERS unit, you can either he
         <categoryLink targetId="6575-7d6c-ce4d-ada4" id="fe6a-8723-6b8d-132d" primary="true" name="Core Battalion"/>
       </categoryLinks>
     </selectionEntry>
-    <selectionEntry type="upgrade" import="true" name="Regiment of Renown - The Sternieste Garrison" hidden="false" id="1061-aedd-61af-3ef6">
+    <selectionEntry type="unit" import="true" name="Regiment of Renown - The Sternieste Garrison" hidden="false" id="1061-aedd-61af-3ef6">
       <modifiers>
         <modifier type="set" value="true" field="hidden">
           <conditions>

--- a/Regiments of Renown.cat
+++ b/Regiments of Renown.cat
@@ -105,7 +105,12 @@ The CORPSE CART in this regiment of renown has a ward of 5+ while it is wholly w
             <categoryLink id="36e9-5cea-b544-850a" name="HERO" hidden="false" targetId="4e0e-664d-51ea-0929" primary="false"/>
           </categoryLinks>
           <entryLinks>
-            <entryLink id="3d13-6856-579c-b262" name="Corpse Cart" hidden="false" collective="false" import="true" targetId="bb26-1d34-b140-7c2d" type="selectionEntry"/>
+            <entryLink id="3d13-6856-579c-b262" name="Corpse Cart" hidden="false" collective="false" import="true" targetId="bb26-1d34-b140-7c2d" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50d7-94f1-eae-300" type="min"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31aa-b9b9-a2c8-76f7" type="max"/>
+              </constraints>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="3047-b2f3-23df-3ee8" name="20 Deadwalker Zombies" hidden="false" collective="false" import="true" defaultSelectionEntryId="49c9-2ce0-9ea0-a0ea">
@@ -114,7 +119,12 @@ The CORPSE CART in this regiment of renown has a ward of 5+ while it is wholly w
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0eae-f686-9c8e-3e59" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="49c9-2ce0-9ea0-a0ea" name="Deadwalker Zombies" hidden="false" collective="false" import="true" targetId="ba7b-56a5-fe0e-5edd" type="selectionEntry"/>
+            <entryLink id="49c9-2ce0-9ea0-a0ea" name="Deadwalker Zombies" hidden="false" collective="false" import="true" targetId="ba7b-56a5-fe0e-5edd" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e3f-dd3e-c4d6-e104" type="min"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1cd9-1cc6-7dcf-2577" type="max"/>
+              </constraints>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -485,7 +495,12 @@ The CORPSE CART in this regiment of renown has a ward of 5+ while it is wholly w
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="611a-6a2e-2deb-82b6" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="97a3-a755-d9b7-0e27" name="Gossamid Archers" hidden="false" collective="false" import="true" targetId="08b4-dd47-ca09-12bf" type="selectionEntry"/>
+            <entryLink id="97a3-a755-d9b7-0e27" name="Gossamid Archers" hidden="false" collective="false" import="true" targetId="08b4-dd47-ca09-12bf" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d8f-f4a6-9c27-b54c" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e48f-6184-1caf-d679" type="min"/>
+              </constraints>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="0a13-f9c2-02d0-f309" name="1 Arch-Revenant" hidden="false" collective="false" import="true" defaultSelectionEntryId="503b-ab50-d885-d709">
@@ -494,7 +509,12 @@ The CORPSE CART in this regiment of renown has a ward of 5+ while it is wholly w
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eadc-a5a5-dc3c-5208" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="503b-ab50-d885-d709" name="Arch-Revenant" hidden="false" collective="false" import="true" targetId="5969-8b83-ce4c-91a7" type="selectionEntry"/>
+            <entryLink id="503b-ab50-d885-d709" name="Arch-Revenant" hidden="false" collective="false" import="true" targetId="5969-8b83-ce4c-91a7" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="591f-3c5d-56bf-e601" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a460-73c5-1908-d8ac" type="min"/>
+              </constraints>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -534,7 +554,12 @@ The CORPSE CART in this regiment of renown has a ward of 5+ while it is wholly w
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0504-8879-ec1d-b704" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="e443-20aa-f78a-fe92" name="Runelord" hidden="false" collective="false" import="true" targetId="7185-fd05-4aa5-6b2c" type="selectionEntry"/>
+            <entryLink id="e443-20aa-f78a-fe92" name="Runelord" hidden="false" collective="false" import="true" targetId="7185-fd05-4aa5-6b2c" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b39f-7b39-edd0-af8b" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="faad-d15a-2b51-fe43" type="min"/>
+              </constraints>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="8168-fde8-a43f-82e5" name="10 Irondrakes" hidden="false" collective="false" import="true" defaultSelectionEntryId="4521-5dd7-630a-c00e">
@@ -543,7 +568,12 @@ The CORPSE CART in this regiment of renown has a ward of 5+ while it is wholly w
             <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ddd8-ecc4-2bb2-924d" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="4521-5dd7-630a-c00e" name="Irondrakes" hidden="false" collective="false" import="true" targetId="37b5-6b88-b50a-9f62" type="selectionEntry"/>
+            <entryLink id="4521-5dd7-630a-c00e" name="Irondrakes" hidden="false" collective="false" import="true" targetId="37b5-6b88-b50a-9f62" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb28-b07c-5731-b58" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="756-c84f-bf8a-d4a7" type="min"/>
+              </constraints>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -702,7 +732,12 @@ The CORPSE CART in this regiment of renown has a ward of 5+ while it is wholly w
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2a1-324c-ed9e-e030" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="b820-2686-7547-800b" name="Ogroid Myrmidon" hidden="false" collective="false" import="true" targetId="7ad8-9f90-c8cc-318b" type="selectionEntry"/>
+            <entryLink id="b820-2686-7547-800b" name="Ogroid Myrmidon" hidden="false" collective="false" import="true" targetId="7ad8-9f90-c8cc-318b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a726-6283-e7d3-802" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ef3-6fad-62fb-5731" type="min"/>
+              </constraints>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="2ecb-3c13-7551-b957" name="1 Fomorid Crusher" hidden="false" collective="false" import="true" defaultSelectionEntryId="1598-23fd-1101-146f">
@@ -711,7 +746,12 @@ The CORPSE CART in this regiment of renown has a ward of 5+ while it is wholly w
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a97-abf6-0dff-d41f" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="1598-23fd-1101-146f" name="Fomoroid Crusher" hidden="false" collective="false" import="true" targetId="4188-7a04-67c8-c2de" type="selectionEntry"/>
+            <entryLink id="1598-23fd-1101-146f" name="Fomoroid Crusher" hidden="false" collective="false" import="true" targetId="4188-7a04-67c8-c2de" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97cd-acf5-e37d-4b59" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2fd-6b0-4ad6-dcbd" type="min"/>
+              </constraints>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="da8d-0c32-2c4f-2741" name="1 Mindstealer Sphiranx" hidden="false" collective="false" import="true" defaultSelectionEntryId="445b-75fd-5fdd-c772">
@@ -720,7 +760,12 @@ The CORPSE CART in this regiment of renown has a ward of 5+ while it is wholly w
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f31c-7fca-4891-9da2" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="445b-75fd-5fdd-c772" name="Mindstealer Sphiranx" hidden="false" collective="false" import="true" targetId="a7ea-37fa-041d-6508" type="selectionEntry"/>
+            <entryLink id="445b-75fd-5fdd-c772" name="Mindstealer Sphiranx" hidden="false" collective="false" import="true" targetId="a7ea-37fa-041d-6508" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a4a-b3ca-3037-3645" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5444-f20e-1f8b-9599" type="min"/>
+              </constraints>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -1766,7 +1811,12 @@ If it accepts, that enemy unit becomes infected. For the rest of the battle, rol
       <selectionEntryGroups>
         <selectionEntryGroup name="1 Grimhold Exile" hidden="false" id="5ce4-65a1-a826-45db">
           <entryLinks>
-            <entryLink import="true" name="Auric Hearthguard" hidden="false" type="selectionEntry" id="1272-1458-a922-94cc" targetId="fab9-a5ff-f601-b712"/>
+            <entryLink import="true" name="Auric Hearthguard" hidden="false" type="selectionEntry" id="1272-1458-a922-94cc" targetId="fab9-a5ff-f601-b712">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9518-e450-c78c-869b" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45b4-71d1-a9a5-c1df" type="min"/>
+              </constraints>
+            </entryLink>
           </entryLinks>
           <constraints>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12ba-8d22-8aad-e339" type="min"/>
@@ -1775,7 +1825,12 @@ If it accepts, that enemy unit becomes infected. For the rest of the battle, rol
         </selectionEntryGroup>
         <selectionEntryGroup name="1 Auric Hearthguard" hidden="false" id="321e-9fe4-ef43-3176">
           <entryLinks>
-            <entryLink import="true" name="Grimhold Exile" hidden="false" type="selectionEntry" id="35ae-6728-fca2-d304" targetId="2a0d-a294-3bc-d52b"/>
+            <entryLink import="true" name="Grimhold Exile" hidden="false" type="selectionEntry" id="35ae-6728-fca2-d304" targetId="2a0d-a294-3bc-d52b">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ebf-3ce0-1faf-753b" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5226-bd3-312b-ea45" type="min"/>
+              </constraints>
+            </entryLink>
           </entryLinks>
           <constraints>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12ba-8d22-8aad-e339" type="min"/>
@@ -1784,7 +1839,12 @@ If it accepts, that enemy unit becomes infected. For the rest of the battle, rol
         </selectionEntryGroup>
         <selectionEntryGroup name="1 Hearthguard Berserkers" hidden="false" id="d42c-3b6-946e-1034">
           <entryLinks>
-            <entryLink import="true" name="Hearthguard Berzerkers" hidden="false" type="selectionEntry" id="689e-6456-34d9-a7f" targetId="8206-9d33-98c6-66e5"/>
+            <entryLink import="true" name="Hearthguard Berzerkers" hidden="false" type="selectionEntry" id="689e-6456-34d9-a7f" targetId="8206-9d33-98c6-66e5">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29a0-4c69-ee41-4276" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ea6-e319-9b82-a784" type="min"/>
+              </constraints>
+            </entryLink>
           </entryLinks>
           <constraints>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12ba-8d22-8aad-e339" type="min"/>
@@ -1793,7 +1853,12 @@ If it accepts, that enemy unit becomes infected. For the rest of the battle, rol
         </selectionEntryGroup>
         <selectionEntryGroup name="1 Vulkite Berserkers with Fyresteel Handaxes" hidden="false" id="f6e9-4b0d-7ae5-5bdd">
           <entryLinks>
-            <entryLink import="true" name="Vulkite Berzerkers with Fyresteel Handaxes" hidden="false" type="selectionEntry" id="9512-f58c-9563-3815" targetId="2149-3c81-d730-421c"/>
+            <entryLink import="true" name="Vulkite Berzerkers with Fyresteel Handaxes" hidden="false" type="selectionEntry" id="9512-f58c-9563-3815" targetId="2149-3c81-d730-421c">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="513c-65a-c530-d858" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db76-78e5-552b-6f36" type="min"/>
+              </constraints>
+            </entryLink>
           </entryLinks>
           <constraints>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12ba-8d22-8aad-e339" type="min"/>
@@ -2273,7 +2338,12 @@ If this unit has more than 1 model, roll to determine if mortal wounds are infli
       <selectionEntryGroups>
         <selectionEntryGroup name="1 Putrid Blightkings" hidden="false" id="8ecf-b162-6f89-5f8">
           <entryLinks>
-            <entryLink import="true" name="Putrid Blightkings" hidden="false" type="selectionEntry" id="1449-281a-5194-2fbe" targetId="8086-f8d0-c56d-1a8e"/>
+            <entryLink import="true" name="Putrid Blightkings" hidden="false" type="selectionEntry" id="1449-281a-5194-2fbe" targetId="8086-f8d0-c56d-1a8e">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6754-f547-a499-d1fb" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="75bd-f584-d7d5-d8fc" type="min"/>
+              </constraints>
+            </entryLink>
           </entryLinks>
           <constraints>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12ba-8d22-8aad-e339" type="min"/>
@@ -2282,7 +2352,12 @@ If this unit has more than 1 model, roll to determine if mortal wounds are infli
         </selectionEntryGroup>
         <selectionEntryGroup name="1 Harbinger of Decay" hidden="false" id="8c2a-46a2-49f1-939f">
           <entryLinks>
-            <entryLink import="true" name="Harbinger of Decay" hidden="false" type="selectionEntry" id="fc7b-13dc-8ebf-2b" targetId="6b2d-58d8-7771-aa3"/>
+            <entryLink import="true" name="Harbinger of Decay" hidden="false" type="selectionEntry" id="fc7b-13dc-8ebf-2b" targetId="6b2d-58d8-7771-aa3">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35f8-75fe-6818-645c" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9946-7e85-f3-aafa" type="min"/>
+              </constraints>
+            </entryLink>
           </entryLinks>
           <constraints>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12ba-8d22-8aad-e339" type="min"/>
@@ -2291,7 +2366,14 @@ If this unit has more than 1 model, roll to determine if mortal wounds are infli
         </selectionEntryGroup>
         <selectionEntryGroup name="1 Pusgoyle Blightlords" hidden="false" id="f1f3-2fe7-3aad-943a">
           <entryLinks>
-            <entryLink import="true" name="Pusgoyle Blightlords" hidden="false" type="selectionEntry" id="76ad-d27a-4c86-bbf" targetId="1e4a-f23f-954e-1a52"/>
+            <entryLink import="true" name="Pusgoyle Blightlords" hidden="false" type="selectionEntry" id="76ad-d27a-4c86-bbf" targetId="1e4a-f23f-954e-1a52">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e79-a550-7db3-a771" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b389-d808-4088-a0d1" type="min"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e0cf-fbac-d7db-c925" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3bd3-82a7-e856-7633" type="min"/>
+              </constraints>
+            </entryLink>
           </entryLinks>
           <constraints>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12ba-8d22-8aad-e339" type="min"/>
@@ -2616,7 +2698,12 @@ Nasty Poisons: You can only pick this effect while this unit has a Spiker.  Pick
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e963-d8c1-43af-3ee2" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="e32-4e29-d906-e0d5" name="Squig Hoppers" hidden="false" collective="false" import="true" targetId="9dd2-4c65-bb9c-51c8" type="selectionEntry"/>
+            <entryLink id="e32-4e29-d906-e0d5" name="Squig Hoppers" hidden="false" collective="false" import="true" targetId="9dd2-4c65-bb9c-51c8" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9aa8-77df-4536-ee64" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9f4-71c5-b7f0-d47d" type="min"/>
+              </constraints>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="af00-35b2-7694-4559" name="1 Gobbapalooza" hidden="false" collective="false" import="true" defaultSelectionEntryId="a23e-381c-4a98-6697">
@@ -2625,7 +2712,12 @@ Nasty Poisons: You can only pick this effect while this unit has a Spiker.  Pick
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e963-d8c1-43af-3ee2" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="a461-76c4-8b68-35af" name="Gobbapalooza" hidden="false" collective="false" import="true" targetId="98fc-112f-db1e-6cda" type="selectionEntry"/>
+            <entryLink id="a461-76c4-8b68-35af" name="Gobbapalooza" hidden="false" collective="false" import="true" targetId="98fc-112f-db1e-6cda" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b00-962f-871b-99a8" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a51-ba02-ee8d-a866" type="min"/>
+              </constraints>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="c9af-daca-8d1a-9240" name="1 Rabble-Rowza" hidden="false" collective="false" import="true" defaultSelectionEntryId="a23e-381c-4a98-6697">
@@ -2634,7 +2726,12 @@ Nasty Poisons: You can only pick this effect while this unit has a Spiker.  Pick
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e963-d8c1-43af-3ee2" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="b73e-7d40-52c4-fb4e" name="Rabble-Rowza" hidden="false" collective="false" import="true" targetId="1a8a-f73-5699-295b" type="selectionEntry"/>
+            <entryLink id="b73e-7d40-52c4-fb4e" name="Rabble-Rowza" hidden="false" collective="false" import="true" targetId="1a8a-f73-5699-295b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e34-7260-4fe4-85fb" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3aa2-696b-b571-6546" type="min"/>
+              </constraints>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="de11-f55-c1aa-3fd2" name="1 Squig Herd" hidden="false" collective="false" import="true" defaultSelectionEntryId="a23e-381c-4a98-6697">
@@ -2643,7 +2740,12 @@ Nasty Poisons: You can only pick this effect while this unit has a Spiker.  Pick
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e963-d8c1-43af-3ee2" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="faa9-75f3-b47-cc96" name="Squig Herd" hidden="false" collective="false" import="true" targetId="106d-d2a5-e746-b58f" type="selectionEntry"/>
+            <entryLink id="faa9-75f3-b47-cc96" name="Squig Herd" hidden="false" collective="false" import="true" targetId="106d-d2a5-e746-b58f" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af7c-30a5-7da8-77d9" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d6f-bca5-62bb-948e" type="min"/>
+              </constraints>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -3597,9 +3699,24 @@ Nasty Poisons: You can only pick this effect while this unit has a Spiker.  Pick
         </profile>
       </profiles>
       <entryLinks>
-        <entryLink import="true" name="Neave Blacktalon" hidden="false" type="selectionEntry" id="6493-169e-47c4-12cd" targetId="43d3-fc45-1d43-5202"/>
-        <entryLink import="true" name="Neave&apos;s Companions" hidden="false" type="selectionEntry" id="b275-25f8-2e8-6c21" targetId="3369-32bc-62cf-58fc"/>
-        <entryLink import="true" name="Lorai, Child of the Abyss" hidden="false" type="selectionEntry" id="5cfb-e5d8-6a5f-c4f" targetId="4d66-2284-874e-c444"/>
+        <entryLink import="true" name="Neave Blacktalon" hidden="false" type="selectionEntry" id="6493-169e-47c4-12cd" targetId="43d3-fc45-1d43-5202">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85cb-a402-60ed-19c4" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d792-48a8-4dab-a5c7" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink import="true" name="Neave&apos;s Companions" hidden="false" type="selectionEntry" id="b275-25f8-2e8-6c21" targetId="3369-32bc-62cf-58fc">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aab6-47d8-68b4-73ea" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa0b-53e7-b64-d263" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink import="true" name="Lorai, Child of the Abyss" hidden="false" type="selectionEntry" id="5cfb-e5d8-6a5f-c4f" targetId="4d66-2284-874e-c444">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85f9-cd0b-65da-5fdd" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc9-ee9c-2578-c542" type="min"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <modifiers>
         <modifier type="set" value="true" field="hidden">
@@ -3613,22 +3730,6 @@ Nasty Poisons: You can only pick this effect while this unit has a Spiker.  Pick
       </categoryLinks>
     </selectionEntry>
     <selectionEntry id="7823-22d1-6e80-3dc3" name="Neferata, Mortarch of Blood" publicationId="7a08-6611-3750-6469" page="110" hidden="false" collective="false" import="true" type="unit">
-      <modifiers>
-        <modifier type="set" field="e725-7996-e2a1-6e80" value="1">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="75f5-9da1-acc8-eb33" type="greaterThan"/>
-                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf25-6b9f-6f44-5911" type="greaterThan"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90d4-efcc-c9d6-f365" type="max"/>
-        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e725-7996-e2a1-6e80" type="min"/>
-      </constraints>
       <profiles>
         <profile id="5ce3-f129-bc12-118b" name="Wizard" hidden="false" typeId="f55d-ee3a-1597-110f" typeName="Magic">
           <characteristics>


### PR DESCRIPTION
resolves #3323 

first attempt at fixing display issues with multi-unit selections such as Regiments of Renown in New Recruit